### PR TITLE
Add GitHub support with provider abstraction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "git-gud"
 version = "0.1.0"
 edition = "2021"
-description = "A stacked-diffs CLI tool for GitLab"
+description = "A stacked-diffs CLI tool for GitHub and GitLab"
 authors = ["Nacho Lopez"]
 
 [[bin]]

--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 A stacked-diffs CLI tool for GitLab, inspired by Gerrit, Phabricator/Arcanist, and Graphite.
 
-> [!CAUTION]
-> This tool has been vibe coded for myself and hasn't been battle tested yet. Do not use! You might bork your git repository!
-
 ## What are Stacked Diffs?
 
 Stacked diffs allow you to break large changes into small, reviewable commits that build on each other. Each commit becomes its own Merge Request, with proper dependency chains. This enables:

--- a/src/commands/clean.rs
+++ b/src/commands/clean.rs
@@ -7,7 +7,7 @@ use git2::BranchType;
 use crate::config::Config;
 use crate::error::{GgError, Result};
 use crate::git;
-use crate::glab::{self, MrState};
+use crate::provider::{self, PrState, Provider};
 use crate::stack;
 
 /// Run the clean command
@@ -16,12 +16,15 @@ pub fn run(clean_all: bool) -> Result<()> {
     let git_dir = repo.path();
     let mut config = Config::load(git_dir)?;
 
+    // Get provider if available
+    let provider = provider::get_provider(&config, &repo).ok();
+
     // Get username
     let username = config
         .defaults
         .branch_username
         .clone()
-        .or_else(|| glab::whoami().ok())
+        .or_else(|| provider.as_ref().and_then(|p| p.whoami().ok()))
         .unwrap_or_else(|| "unknown".to_string());
 
     // Get all stacks
@@ -47,7 +50,8 @@ pub fn run(clean_all: bool) -> Result<()> {
         }
 
         // Load the stack to check MR status
-        let is_merged = check_stack_merged(&repo, &config, stack_name, &username)?;
+        let is_merged =
+            check_stack_merged(&repo, &config, stack_name, &username, provider.as_deref())?;
 
         if is_merged {
             if !clean_all {
@@ -130,6 +134,7 @@ fn check_stack_merged(
     config: &Config,
     stack_name: &str,
     username: &str,
+    provider: Option<&dyn Provider>,
 ) -> Result<bool> {
     let branch_name = git::format_stack_branch(username, stack_name);
 
@@ -154,24 +159,24 @@ fn check_stack_merged(
         return Ok(true);
     }
 
-    // Alternative: check if all MRs are merged
-    if let Some(stack_config) = config.get_stack(stack_name) {
+    // Alternative: check if all PRs/MRs are merged (requires provider)
+    if let (Some(stack_config), Some(p)) = (config.get_stack(stack_name), provider) {
         if stack_config.mrs.is_empty() {
-            // No MRs tracked, can't determine merge status
+            // No PRs/MRs tracked, can't determine merge status
             return Ok(false);
         }
 
         let mut all_merged = true;
         for mr_num in stack_config.mrs.values() {
-            match glab::view_mr(*mr_num) {
+            match p.view_pr(*mr_num) {
                 Ok(info) => {
-                    if info.state != MrState::Merged {
+                    if info.state != PrState::Merged {
                         all_merged = false;
                         break;
                     }
                 }
                 Err(_) => {
-                    // MR might be deleted, assume not merged
+                    // PR/MR might be deleted, assume not merged
                     all_merged = false;
                     break;
                 }

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -7,7 +7,7 @@ use dialoguer::{Confirm, Input};
 use crate::config::{Config, Defaults};
 use crate::error::{GgError, Result};
 use crate::git;
-use crate::glab;
+use crate::provider::{self, ProviderType};
 
 /// Run the setup command
 pub fn run() -> Result<()> {
@@ -59,7 +59,19 @@ fn prompt_defaults(
     let mut defaults = existing.clone();
 
     defaults.base = prompt_base_branch(repo, existing.base.as_deref(), theme)?;
-    defaults.branch_username = prompt_branch_username(existing.branch_username.as_deref(), theme)?;
+    defaults.provider = prompt_provider(repo, existing.provider.as_ref(), theme)?;
+
+    // Get provider for whoami fallback - use configured provider or detect from remote
+    let provider_for_whoami = defaults
+        .provider
+        .clone()
+        .or_else(|| provider::detect_provider(repo));
+
+    defaults.branch_username = prompt_branch_username(
+        existing.branch_username.as_deref(),
+        provider_for_whoami.as_ref(),
+        theme,
+    )?;
     defaults.lint = prompt_lint_commands(repo, &existing.lint, theme)?;
 
     Ok(defaults)
@@ -137,10 +149,57 @@ fn prompt_base_branch(
     })
 }
 
-fn prompt_branch_username(existing: Option<&str>, theme: &ColorfulTheme) -> Result<Option<String>> {
-    let suggested = existing
-        .map(|s| s.to_string())
-        .or_else(|| glab::whoami().ok());
+fn prompt_provider(
+    repo: &git2::Repository,
+    existing: Option<&ProviderType>,
+    theme: &ColorfulTheme,
+) -> Result<Option<ProviderType>> {
+    let detected = provider::detect_provider(repo);
+
+    // Build options
+    let options = ["Auto-detect", "GitHub", "GitLab"];
+    let default_idx = match existing.or(detected.as_ref()) {
+        Some(ProviderType::GitHub) => 1,
+        Some(ProviderType::GitLab) => 2,
+        None => 0,
+    };
+
+    let detection_hint = match &detected {
+        Some(ProviderType::GitHub) => " (detected: GitHub)",
+        Some(ProviderType::GitLab) => " (detected: GitLab)",
+        None => " (could not detect from remote)",
+    };
+
+    let selection = dialoguer::Select::with_theme(theme)
+        .with_prompt(format!("Git hosting provider{}", detection_hint))
+        .items(options)
+        .default(default_idx)
+        .interact()
+        .map_err(|e| GgError::Other(format!("Prompt failed: {}", e)))?;
+
+    Ok(match selection {
+        0 => None, // Auto-detect
+        1 => Some(ProviderType::GitHub),
+        2 => Some(ProviderType::GitLab),
+        _ => None,
+    })
+}
+
+fn prompt_branch_username(
+    existing: Option<&str>,
+    provider_type: Option<&ProviderType>,
+    theme: &ColorfulTheme,
+) -> Result<Option<String>> {
+    // Try to get username from provider
+    let whoami_result = provider_type.and_then(|pt| {
+        let provider: Box<dyn provider::Provider> = match pt {
+            ProviderType::GitHub => Box::new(provider::github::GitHubProvider),
+            ProviderType::GitLab => Box::new(provider::gitlab::GitLabProvider),
+        };
+        provider.whoami().ok()
+    });
+
+    let suggested = existing.map(|s| s.to_string()).or(whoami_result);
 
     let input: String = if let Some(suggested) = suggested {
         Input::with_theme(theme)

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,13 +19,21 @@ pub struct Defaults {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub base: Option<String>,
 
-    /// Username for branch naming (default: glab whoami)
+    /// Username for branch naming (default: provider whoami)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub branch_username: Option<String>,
 
     /// Lint commands to run per commit
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub lint: Vec<String>,
+
+    /// Git hosting provider (auto-detected if not set)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<crate::provider::ProviderType>,
+
+    /// Currently selected stack (for operations when not on a stack branch)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_stack: Option<String>,
 }
 
 /// Per-stack configuration

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,6 +35,18 @@ pub enum GgError {
     #[error("glab command failed: {0}")]
     GlabError(String),
 
+    #[error("Could not detect git provider. Run `gg setup` to configure.")]
+    ProviderNotConfigured,
+
+    #[error("gh is not installed. Install from https://cli.github.com")]
+    GhNotInstalled,
+
+    #[error("Not authenticated with GitHub. Run `gh auth login` first.")]
+    GhNotAuthenticated,
+
+    #[error("gh command failed: {0}")]
+    GhError(String),
+
     #[error("Rebase conflict. Resolve conflicts and run `gg continue`, or `gg abort` to cancel.")]
     RebaseConflict,
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -89,13 +89,11 @@ pub fn find_entry_branch_for_stack(
     stack_name: &str,
 ) -> Option<String> {
     let branches = repo.branches(Some(BranchType::Local)).ok()?;
-    for branch_result in branches {
-        if let Ok((branch, _)) = branch_result {
-            if let Ok(Some(name)) = branch.name() {
-                if let Some((branch_user, branch_stack, _entry_id)) = parse_entry_branch(name) {
-                    if branch_user == username && branch_stack == stack_name {
-                        return Some(name.to_string());
-                    }
+    for (branch, _) in branches.flatten() {
+        if let Ok(Some(name)) = branch.name() {
+            if let Some((branch_user, branch_stack, _entry_id)) = parse_entry_branch(name) {
+                if branch_user == username && branch_stack == stack_name {
+                    return Some(name.to_string());
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-//! git-gud (gg) - A stacked-diffs CLI tool for GitLab
+//! git-gud (gg) - A stacked-diffs CLI tool for GitHub and GitLab
 //!
 //! Entry point for the CLI application.
 
@@ -7,6 +7,7 @@ mod config;
 mod error;
 mod git;
 mod glab;
+mod provider;
 mod stack;
 
 use std::process::exit;
@@ -19,7 +20,7 @@ use console::style;
     name = "gg",
     author = "Nacho Lopez",
     version,
-    about = "A stacked-diffs CLI tool for GitLab",
+    about = "A stacked-diffs CLI tool for GitHub and GitLab",
     long_about = None
 )]
 struct Cli {

--- a/src/provider/github.rs
+++ b/src/provider/github.rs
@@ -1,0 +1,322 @@
+//! GitHub provider implementation
+//!
+//! Uses the gh CLI for GitHub operations.
+
+use std::process::Command;
+
+use serde::Deserialize;
+
+use crate::error::{GgError, Result};
+use crate::provider::{CiStatus, PrInfo, PrState, Provider};
+
+/// GitHub provider using the gh CLI
+pub struct GitHubProvider;
+
+/// JSON response from `gh pr view --json`
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GhPrJson {
+    number: u64,
+    title: String,
+    state: String,
+    url: String,
+    is_draft: Option<bool>,
+    review_decision: Option<String>,
+    mergeable: Option<String>,
+}
+
+/// JSON response from `gh pr checks --json`
+#[derive(Debug, Deserialize)]
+struct GhCheckJson {
+    state: Option<String>,
+    conclusion: Option<String>,
+}
+
+impl Provider for GitHubProvider {
+    fn name(&self) -> &'static str {
+        "GitHub"
+    }
+
+    fn pr_prefix(&self) -> &'static str {
+        "#"
+    }
+
+    fn check_installed(&self) -> Result<()> {
+        let output = Command::new("gh").arg("--version").output();
+
+        match output {
+            Ok(o) if o.status.success() => Ok(()),
+            _ => Err(GgError::GhNotInstalled),
+        }
+    }
+
+    fn check_auth(&self) -> Result<()> {
+        let output = Command::new("gh").args(["auth", "status"]).output()?;
+
+        if output.status.success() {
+            Ok(())
+        } else {
+            Err(GgError::GhNotAuthenticated)
+        }
+    }
+
+    fn whoami(&self) -> Result<String> {
+        let output = Command::new("gh")
+            .args(["api", "user", "--jq", ".login"])
+            .output()?;
+
+        if !output.status.success() {
+            return Err(GgError::GhNotAuthenticated);
+        }
+
+        let username = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if username.is_empty() {
+            return Err(GgError::GhError(
+                "Could not determine GitHub username".to_string(),
+            ));
+        }
+
+        Ok(username)
+    }
+
+    fn create_pr(
+        &self,
+        source_branch: &str,
+        target_branch: &str,
+        title: &str,
+        description: &str,
+        draft: bool,
+    ) -> Result<u64> {
+        let mut args = vec![
+            "pr",
+            "create",
+            "--head",
+            source_branch,
+            "--base",
+            target_branch,
+            "--title",
+            title,
+            "--body",
+            description,
+        ];
+
+        if draft {
+            args.push("--draft");
+        }
+
+        let output = Command::new("gh").args(&args).output()?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(GgError::GhError(format!("Failed to create PR: {}", stderr)));
+        }
+
+        // Parse the output to get the PR number
+        // gh outputs a URL like https://github.com/owner/repo/pull/123
+        let stdout = String::from_utf8_lossy(&output.stdout);
+
+        // Try to extract PR number from URL
+        for word in stdout.split_whitespace() {
+            if word.contains("/pull/") {
+                if let Some(num_str) = word.split("/pull/").nth(1) {
+                    let num_str = num_str.trim_end_matches(|c: char| !c.is_ascii_digit());
+                    if let Ok(num) = num_str.parse::<u64>() {
+                        return Ok(num);
+                    }
+                }
+            }
+        }
+
+        Err(GgError::GhError(
+            "Could not parse PR number from gh output".to_string(),
+        ))
+    }
+
+    fn view_pr(&self, number: u64) -> Result<PrInfo> {
+        let output = Command::new("gh")
+            .args([
+                "pr",
+                "view",
+                &number.to_string(),
+                "--json",
+                "number,title,state,url,isDraft,reviewDecision,mergeable",
+            ])
+            .output()?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(GgError::GhError(format!(
+                "Failed to view PR #{}: {}",
+                number, stderr
+            )));
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let pr_json: GhPrJson = serde_json::from_str(&stdout)
+            .map_err(|e| GgError::GhError(format!("Failed to parse PR JSON: {}", e)))?;
+
+        let draft = pr_json.is_draft.unwrap_or(false);
+
+        let state = match pr_json.state.as_str() {
+            "MERGED" => PrState::Merged,
+            "CLOSED" => PrState::Closed,
+            _ if draft => PrState::Draft,
+            _ => PrState::Open,
+        };
+
+        // reviewDecision: APPROVED, CHANGES_REQUESTED, REVIEW_REQUIRED, or null
+        let approved = pr_json.review_decision.as_deref() == Some("APPROVED");
+
+        // mergeable: MERGEABLE, CONFLICTING, UNKNOWN
+        let mergeable =
+            pr_json.mergeable.as_deref() == Some("MERGEABLE") && state == PrState::Open && !draft;
+
+        Ok(PrInfo {
+            number: pr_json.number,
+            title: pr_json.title,
+            state,
+            web_url: pr_json.url,
+            draft,
+            approved,
+            mergeable,
+        })
+    }
+
+    fn update_pr_target(&self, number: u64, target_branch: &str) -> Result<()> {
+        let output = Command::new("gh")
+            .args(["pr", "edit", &number.to_string(), "--base", target_branch])
+            .output()?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(GgError::GhError(format!(
+                "Failed to update PR #{}: {}",
+                number, stderr
+            )));
+        }
+
+        Ok(())
+    }
+
+    fn merge_pr(&self, number: u64, squash: bool, delete_branch: bool) -> Result<()> {
+        let pr_num_str = number.to_string();
+        let mut args = vec!["pr", "merge", &pr_num_str];
+
+        if squash {
+            args.push("--squash");
+        } else {
+            args.push("--merge");
+        }
+
+        if delete_branch {
+            args.push("--delete-branch");
+        }
+
+        let output = Command::new("gh").args(&args).output()?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(GgError::GhError(format!(
+                "Failed to merge PR #{}: {}",
+                number, stderr
+            )));
+        }
+
+        Ok(())
+    }
+
+    fn check_approved(&self, number: u64) -> Result<bool> {
+        let output = Command::new("gh")
+            .args([
+                "pr",
+                "view",
+                &number.to_string(),
+                "--json",
+                "reviewDecision",
+            ])
+            .output()?;
+
+        if !output.status.success() {
+            // If the call fails, assume not approved
+            return Ok(false);
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+
+        // Parse JSON to check reviewDecision
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct ReviewResponse {
+            review_decision: Option<String>,
+        }
+
+        if let Ok(response) = serde_json::from_str::<ReviewResponse>(&stdout) {
+            Ok(response.review_decision.as_deref() == Some("APPROVED"))
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn get_ci_status(&self, number: u64) -> Result<CiStatus> {
+        let output = Command::new("gh")
+            .args([
+                "pr",
+                "checks",
+                &number.to_string(),
+                "--json",
+                "state,conclusion",
+            ])
+            .output()?;
+
+        if !output.status.success() {
+            return Ok(CiStatus::Unknown);
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+
+        // Parse JSON array of checks
+        let checks: Vec<GhCheckJson> = match serde_json::from_str(&stdout) {
+            Ok(c) => c,
+            Err(_) => return Ok(CiStatus::Unknown),
+        };
+
+        if checks.is_empty() {
+            return Ok(CiStatus::Unknown);
+        }
+
+        // Aggregate check states
+        let mut has_failure = false;
+        let mut has_pending = false;
+        let mut has_running = false;
+        let mut has_canceled = false;
+
+        for check in &checks {
+            match check.state.as_deref() {
+                Some("PENDING") | Some("QUEUED") => has_pending = true,
+                Some("IN_PROGRESS") => has_running = true,
+                Some("COMPLETED") => match check.conclusion.as_deref() {
+                    Some("FAILURE") | Some("TIMED_OUT") | Some("STARTUP_FAILURE") => {
+                        has_failure = true
+                    }
+                    Some("CANCELLED") => has_canceled = true,
+                    Some("SUCCESS") | Some("NEUTRAL") | Some("SKIPPED") => {}
+                    _ => {}
+                },
+                _ => {}
+            }
+        }
+
+        // Determine overall status (failure > running > pending > canceled > success)
+        if has_failure {
+            Ok(CiStatus::Failed)
+        } else if has_running {
+            Ok(CiStatus::Running)
+        } else if has_pending {
+            Ok(CiStatus::Pending)
+        } else if has_canceled {
+            Ok(CiStatus::Canceled)
+        } else {
+            Ok(CiStatus::Success)
+        }
+    }
+}

--- a/src/provider/gitlab.rs
+++ b/src/provider/gitlab.rs
@@ -1,0 +1,95 @@
+//! GitLab provider implementation
+//!
+//! Wraps the existing glab module to implement the Provider trait.
+
+use crate::error::Result;
+use crate::glab;
+use crate::provider::{CiStatus, PrInfo, PrState, Provider};
+
+/// GitLab provider using the glab CLI
+pub struct GitLabProvider;
+
+impl Provider for GitLabProvider {
+    fn name(&self) -> &'static str {
+        "GitLab"
+    }
+
+    fn pr_prefix(&self) -> &'static str {
+        "!"
+    }
+
+    fn check_installed(&self) -> Result<()> {
+        glab::check_glab_installed()
+    }
+
+    fn check_auth(&self) -> Result<()> {
+        glab::check_glab_auth()
+    }
+
+    fn whoami(&self) -> Result<String> {
+        glab::whoami()
+    }
+
+    fn create_pr(
+        &self,
+        source_branch: &str,
+        target_branch: &str,
+        title: &str,
+        description: &str,
+        draft: bool,
+    ) -> Result<u64> {
+        glab::create_mr(source_branch, target_branch, title, description, draft)
+    }
+
+    fn view_pr(&self, number: u64) -> Result<PrInfo> {
+        let mr_info = glab::view_mr(number)?;
+        Ok(PrInfo {
+            number: mr_info.iid,
+            title: mr_info.title,
+            state: convert_mr_state(mr_info.state),
+            web_url: mr_info.web_url,
+            draft: mr_info.draft,
+            approved: mr_info.approved,
+            mergeable: mr_info.mergeable,
+        })
+    }
+
+    fn update_pr_target(&self, number: u64, target_branch: &str) -> Result<()> {
+        glab::update_mr_target(number, target_branch)
+    }
+
+    fn merge_pr(&self, number: u64, squash: bool, delete_branch: bool) -> Result<()> {
+        glab::merge_mr(number, squash, delete_branch)
+    }
+
+    fn check_approved(&self, number: u64) -> Result<bool> {
+        glab::check_mr_approved(number)
+    }
+
+    fn get_ci_status(&self, number: u64) -> Result<CiStatus> {
+        let status = glab::get_mr_ci_status(number)?;
+        Ok(convert_ci_status(status))
+    }
+}
+
+/// Convert glab::MrState to provider::PrState
+fn convert_mr_state(state: glab::MrState) -> PrState {
+    match state {
+        glab::MrState::Open => PrState::Open,
+        glab::MrState::Merged => PrState::Merged,
+        glab::MrState::Closed => PrState::Closed,
+        glab::MrState::Draft => PrState::Draft,
+    }
+}
+
+/// Convert glab::CiStatus to provider::CiStatus
+fn convert_ci_status(status: glab::CiStatus) -> CiStatus {
+    match status {
+        glab::CiStatus::Pending => CiStatus::Pending,
+        glab::CiStatus::Running => CiStatus::Running,
+        glab::CiStatus::Success => CiStatus::Success,
+        glab::CiStatus::Failed => CiStatus::Failed,
+        glab::CiStatus::Canceled => CiStatus::Canceled,
+        glab::CiStatus::Unknown => CiStatus::Unknown,
+    }
+}

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -1,0 +1,126 @@
+//! Provider abstraction for Git hosting platforms (GitHub, GitLab)
+//!
+//! This module provides a unified interface for interacting with different
+//! Git hosting platforms, enabling git-gud to work with both GitHub and GitLab.
+
+pub mod github;
+pub mod gitlab;
+
+use git2::Repository;
+
+use crate::config::Config;
+use crate::error::{GgError, Result};
+
+/// Pull/Merge Request state
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PrState {
+    Open,
+    Merged,
+    Closed,
+    Draft,
+}
+
+/// CI/Check status
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CiStatus {
+    Pending,
+    Running,
+    Success,
+    Failed,
+    Canceled,
+    Unknown,
+}
+
+/// Pull/Merge Request information
+#[derive(Debug, Clone)]
+#[allow(dead_code)] // Fields used for display/future features
+pub struct PrInfo {
+    pub number: u64,
+    pub title: String,
+    pub state: PrState,
+    pub web_url: String,
+    pub draft: bool,
+    pub approved: bool,
+    pub mergeable: bool,
+}
+
+/// Provider type enum for configuration
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ProviderType {
+    GitHub,
+    GitLab,
+}
+
+/// Provider trait for Git hosting platforms
+#[allow(dead_code)] // name() reserved for future use in UI
+pub trait Provider: Send + Sync {
+    /// Provider name for display
+    fn name(&self) -> &'static str;
+
+    /// PR/MR notation prefix (# for GitHub, ! for GitLab)
+    fn pr_prefix(&self) -> &'static str;
+
+    /// Check if CLI tool is installed
+    fn check_installed(&self) -> Result<()>;
+
+    /// Check if authenticated
+    fn check_auth(&self) -> Result<()>;
+
+    /// Get current username
+    fn whoami(&self) -> Result<String>;
+
+    /// Create a pull/merge request
+    fn create_pr(
+        &self,
+        source_branch: &str,
+        target_branch: &str,
+        title: &str,
+        description: &str,
+        draft: bool,
+    ) -> Result<u64>;
+
+    /// View PR/MR information
+    fn view_pr(&self, number: u64) -> Result<PrInfo>;
+
+    /// Update PR/MR target branch
+    fn update_pr_target(&self, number: u64, target_branch: &str) -> Result<()>;
+
+    /// Merge PR/MR
+    fn merge_pr(&self, number: u64, squash: bool, delete_branch: bool) -> Result<()>;
+
+    /// Check if PR/MR is approved
+    fn check_approved(&self, number: u64) -> Result<bool>;
+
+    /// Get CI status for PR/MR
+    fn get_ci_status(&self, number: u64) -> Result<CiStatus>;
+}
+
+/// Detect provider from git remote URL
+pub fn detect_provider(repo: &Repository) -> Option<ProviderType> {
+    let remote = repo.find_remote("origin").ok()?;
+    let url = remote.url()?;
+
+    if url.contains("github.com") {
+        Some(ProviderType::GitHub)
+    } else if url.contains("gitlab.com") || url.contains("gitlab.") {
+        Some(ProviderType::GitLab)
+    } else {
+        None
+    }
+}
+
+/// Get provider instance based on config (with auto-detection fallback)
+pub fn get_provider(config: &Config, repo: &Repository) -> Result<Box<dyn Provider>> {
+    let provider_type = config
+        .defaults
+        .provider
+        .clone()
+        .or_else(|| detect_provider(repo))
+        .ok_or(GgError::ProviderNotConfigured)?;
+
+    match provider_type {
+        ProviderType::GitHub => Ok(Box::new(github::GitHubProvider)),
+        ProviderType::GitLab => Ok(Box::new(gitlab::GitLabProvider)),
+    }
+}

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -11,7 +11,7 @@ use git2::{Commit, Repository};
 use crate::config::Config;
 use crate::error::{GgError, Result};
 use crate::git::{self, get_gg_id, short_sha};
-use crate::glab::{self, CiStatus, MrState};
+use crate::provider::{CiStatus, PrState, Provider};
 
 /// File to store the current stack when in detached HEAD mode
 const CURRENT_STACK_FILE: &str = "gg/current_stack";
@@ -27,10 +27,10 @@ pub struct StackEntry {
     pub title: String,
     /// GG-ID (stable identifier)
     pub gg_id: Option<String>,
-    /// MR number if synced
+    /// PR/MR number if synced
     pub mr_number: Option<u64>,
-    /// MR state if synced
-    pub mr_state: Option<MrState>,
+    /// PR/MR state if synced
+    pub mr_state: Option<PrState>,
     /// Whether the MR is approved
     pub approved: bool,
     /// CI status
@@ -68,11 +68,11 @@ impl StackEntry {
     /// Get status display string
     pub fn status_display(&self) -> String {
         match (&self.mr_state, self.approved) {
-            (Some(MrState::Merged), _) => "merged".to_string(),
-            (Some(MrState::Closed), _) => "closed".to_string(),
-            (Some(MrState::Draft), _) => "draft".to_string(),
-            (Some(MrState::Open), true) => "approved".to_string(),
-            (Some(MrState::Open), false) => "open".to_string(),
+            (Some(PrState::Merged), _) => "merged".to_string(),
+            (Some(PrState::Closed), _) => "closed".to_string(),
+            (Some(PrState::Draft), _) => "draft".to_string(),
+            (Some(PrState::Open), true) => "approved".to_string(),
+            (Some(PrState::Open), false) => "open".to_string(),
             (None, _) => "not pushed".to_string(),
         }
     }
@@ -104,6 +104,20 @@ impl Stack {
             .or_else(|| {
                 // If in detached HEAD, try to read stored stack
                 read_current_stack(git_dir)
+            })
+            .or_else(|| {
+                // If not on a stack branch, use the configured current stack
+                config
+                    .defaults
+                    .current_stack
+                    .as_ref()
+                    .and_then(|stack_name| {
+                        config
+                            .defaults
+                            .branch_username
+                            .as_ref()
+                            .map(|username| git::format_stack_branch(username, stack_name))
+                    })
             })
             .ok_or(GgError::NotOnStack)?;
 
@@ -248,28 +262,28 @@ impl Stack {
             .map(|gg_id| git::format_entry_branch(&self.username, &self.name, gg_id))
     }
 
-    /// Refresh MR info for all entries from GitLab
-    pub fn refresh_mr_info(&mut self) -> Result<()> {
+    /// Refresh PR/MR info for all entries from the provider
+    pub fn refresh_mr_info(&mut self, provider: &dyn Provider) -> Result<()> {
         for entry in &mut self.entries {
             if let Some(mr_num) = entry.mr_number {
-                match glab::view_mr(mr_num) {
+                match provider.view_pr(mr_num) {
                     Ok(info) => {
                         entry.mr_state = Some(info.state);
                         entry.approved = info.approved;
                     }
                     Err(_) => {
-                        // MR might have been deleted
+                        // PR/MR might have been deleted
                         entry.mr_state = None;
                     }
                 }
 
                 // Get CI status
-                if let Ok(ci) = glab::get_mr_ci_status(mr_num) {
+                if let Ok(ci) = provider.get_ci_status(mr_num) {
                     entry.ci_status = Some(ci);
                 }
 
                 // Check approval status
-                if let Ok(approved) = glab::check_mr_approved(mr_num) {
+                if let Ok(approved) = provider.check_approved(mr_num) {
                     entry.approved = approved;
                 }
             }
@@ -326,8 +340,7 @@ pub fn list_all_stacks(repo: &Repository, config: &Config, username: &str) -> Re
                 }
             }
             // Also check for 3-part entry branch (username/stack-name/entry-id)
-            else if let Some((branch_user, stack_name, _entry_id)) =
-                git::parse_entry_branch(name)
+            else if let Some((branch_user, stack_name, _entry_id)) = git::parse_entry_branch(name)
             {
                 if branch_user == username && !stacks.contains(&stack_name) {
                     stacks.push(stack_name);


### PR DESCRIPTION
Implement GitHub support alongside GitLab by introducing a Provider trait abstraction. The implementation uses native CLI tools (gh for GitHub, glab for GitLab) and maintains platform-specific conventions (# for GitHub PRs, ! for GitLab MRs).

Key changes:
- Add Provider trait in src/provider/mod.rs with unified interface
- Implement GitHubProvider using gh CLI commands
- Implement GitLabProvider wrapping existing glab functions
- Add provider auto-detection from git remote URLs
- Update all commands (sync, land, ls, setup, clean) to use provider
- Add provider configuration option with auto-detect fallback
- Maintain full backward compatibility with GitLab-only usage
- Fix git ref conflicts when creating entry branches

The provider is auto-detected from the remote URL (github.com or gitlab.com) but can be manually configured via 'gg setup'.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

GG-ID: c-4555562