### PR TITLE
feat: Add GitLab provider integration

### DIFF
--- a/src/commands/land.rs
+++ b/src/commands/land.rs
@@ -1,12 +1,12 @@
-//! `gg land` - Merge approved PRs starting from the first commit
+//! `gg land` - Merge approved PRs/MRs starting from the first commit
 
 use console::style;
 use dialoguer::Confirm;
 
 use crate::config::Config;
 use crate::error::Result;
-use crate::gh::{self, PrState};
 use crate::git;
+use crate::provider::{PrState, Provider};
 use crate::stack::Stack;
 
 /// Run the land command
@@ -15,9 +15,10 @@ pub fn run(land_all: bool, squash: bool) -> Result<()> {
     let git_dir = repo.path();
     let mut config = Config::load(git_dir)?;
 
-    // Check gh is available
-    gh::check_gh_installed()?;
-    gh::check_gh_auth()?;
+    // Detect and check provider
+    let provider = Provider::detect(&repo)?;
+    provider.check_installed()?;
+    provider.check_auth()?;
 
     // Require clean working directory
     git::require_clean_working_directory(&repo)?;
@@ -30,8 +31,11 @@ pub fn run(land_all: bool, squash: bool) -> Result<()> {
         return Ok(());
     }
 
-    println!("{}", style("Checking PR status...").dim());
-    stack.refresh_mr_info()?;
+    println!(
+        "{}",
+        style(format!("Checking {} status...", provider.pr_label())).dim()
+    );
+    stack.refresh_mr_info(&provider)?;
 
     // Find landable PRs (approved, open, from the start of the stack)
     let mut landed_count = 0;
@@ -53,31 +57,43 @@ pub fn run(land_all: bool, squash: bool) -> Result<()> {
             Some(num) => num,
             None => {
                 println!(
-                    "{} Commit {} has no PR. Run `gg sync` first.",
+                    "{} Commit {} has no {}. Run `gg sync` first.",
                     style("Error:").red().bold(),
-                    entry.short_sha
+                    entry.short_sha,
+                    provider.pr_label()
                 );
                 break;
             }
         };
 
-        // Check PR state
-        let pr_info = gh::get_pr_info(pr_num)?;
+        // Check PR/MR state
+        let pr_info = provider.get_pr_info(pr_num)?;
 
         match pr_info.state {
             PrState::Merged => {
-                println!("{} PR #{} already merged", style("✓").green(), pr_num);
+                println!(
+                    "{} {} #{} already merged",
+                    style("✓").green(),
+                    provider.pr_label(),
+                    pr_num
+                );
                 landed_count += 1;
                 continue;
             }
             PrState::Closed => {
-                println!("{} PR #{} is closed. Stopping.", style("✗").red(), pr_num);
+                println!(
+                    "{} {} #{} is closed. Stopping.",
+                    style("✗").red(),
+                    provider.pr_label(),
+                    pr_num
+                );
                 break;
             }
             PrState::Draft => {
                 println!(
-                    "{} PR #{} is a draft. Mark as ready before landing.",
+                    "{} {} #{} is a draft. Mark as ready before landing.",
                     style("○").yellow(),
+                    provider.pr_label(),
                     pr_num
                 );
                 break;
@@ -85,11 +101,12 @@ pub fn run(land_all: bool, squash: bool) -> Result<()> {
             PrState::Open => {
                 // Check if approved (skip if --all is used)
                 if !land_all {
-                    let approved = gh::check_pr_approved(pr_num)?;
+                    let approved = provider.check_pr_approved(pr_num)?;
                     if !approved {
                         println!(
-                            "{} PR #{} is not approved. Stopping.",
+                            "{} {} #{} is not approved. Stopping.",
                             style("○").yellow(),
+                            provider.pr_label(),
                             pr_num
                         );
                         break;
@@ -98,10 +115,15 @@ pub fn run(land_all: bool, squash: bool) -> Result<()> {
             }
         }
 
-        // PR is approved and open - land it
+        // PR/MR is approved and open - land it
         if !land_all {
             let confirm = Confirm::new()
-                .with_prompt(format!("Merge PR #{} ({})? ", pr_num, entry.title))
+                .with_prompt(format!(
+                    "Merge {} #{} ({})? ",
+                    provider.pr_label(),
+                    pr_num,
+                    entry.title
+                ))
                 .default(true)
                 .interact()
                 .unwrap_or(false);
@@ -112,22 +134,28 @@ pub fn run(land_all: bool, squash: bool) -> Result<()> {
             }
         }
 
-        println!("{} Merging PR #{}...", style("→").cyan(), pr_num);
+        println!(
+            "{} Merging {} #{}...",
+            style("→").cyan(),
+            provider.pr_label(),
+            pr_num
+        );
 
-        match gh::merge_pr(pr_num, squash, false) {
+        match provider.merge_pr(pr_num, squash, false) {
             Ok(()) => {
                 println!(
-                    "{} Merged PR #{} into {}",
+                    "{} Merged {} #{} into {}",
                     style("OK").green().bold(),
+                    provider.pr_label(),
                     pr_num,
                     stack.base
                 );
                 landed_count += 1;
 
-                // Remove PR mapping from config
+                // Remove PR/MR mapping from config
                 config.remove_mr_for_entry(&stack.name, gg_id);
 
-                // Update the base of remaining PRs to point to the main branch
+                // Update the base of remaining PRs/MRs to point to the main branch
                 // This is critical for stacked PRs - after merging PR #1, PR #2 should
                 // point to main instead of PR #1's branch (which no longer exists)
                 if land_all {
@@ -142,15 +170,18 @@ pub fn run(land_all: bool, squash: bool) -> Result<()> {
                             println!(
                                 "{}",
                                 style(format!(
-                                    "  Updating PR #{} base to {}...",
-                                    remaining_pr, stack.base
+                                    "  Updating {} #{} base to {}...",
+                                    provider.pr_label(),
+                                    remaining_pr,
+                                    stack.base
                                 ))
                                 .dim()
                             );
-                            if let Err(e) = gh::update_pr_base(remaining_pr, &stack.base) {
+                            if let Err(e) = provider.update_pr_base(remaining_pr, &stack.base) {
                                 println!(
-                                    "{} Warning: Failed to update PR #{} base: {}",
+                                    "{} Warning: Failed to update {} #{} base: {}",
                                     style("⚠").yellow(),
+                                    provider.pr_label(),
                                     remaining_pr,
                                     e
                                 );
@@ -161,8 +192,9 @@ pub fn run(land_all: bool, squash: bool) -> Result<()> {
             }
             Err(e) => {
                 println!(
-                    "{} Failed to merge PR #{}: {}",
+                    "{} Failed to merge {} #{}: {}",
                     style("Error:").red().bold(),
+                    provider.pr_label(),
                     pr_num,
                     e
                 );
@@ -184,9 +216,10 @@ pub fn run(land_all: bool, squash: bool) -> Result<()> {
     if landed_count > 0 {
         println!();
         println!(
-            "{} Landed {} PR(s)",
+            "{} Landed {} {}(s)",
             style("OK").green().bold(),
-            landed_count
+            landed_count,
+            provider.pr_label()
         );
 
         // Suggest rebasing if there are remaining commits
@@ -198,7 +231,11 @@ pub fn run(land_all: bool, squash: bool) -> Result<()> {
         } else {
             println!(
                 "{}",
-                style("  All PRs landed! Run `gg clean` to remove the stack.").dim()
+                style(format!(
+                    "  All {}s landed! Run `gg clean` to remove the stack.",
+                    provider.pr_label()
+                ))
+                .dim()
             );
         }
     }

--- a/src/glab.rs
+++ b/src/glab.rs
@@ -214,6 +214,11 @@ pub fn view_mr(mr_number: u64) -> Result<MrInfo> {
     })
 }
 
+/// Alias for view_mr for compatibility with gh module
+pub fn get_mr_info(mr_number: u64) -> Result<MrInfo> {
+    view_mr(mr_number)
+}
+
 /// Update MR target branch
 pub fn update_mr_target(mr_number: u64, target_branch: &str) -> Result<()> {
     let output = Command::new("glab")

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod error;
 mod gh;
 mod git;
 mod glab;
+mod provider;
 mod stack;
 
 use std::process::exit;

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -1,0 +1,351 @@
+//! Provider abstraction for GitHub and GitLab
+//!
+//! Provides a unified interface for working with different git hosting providers.
+
+use git2::Repository;
+
+use crate::error::Result;
+use crate::gh::{self, CiStatus as GhCiStatus, PrState as GhPrState};
+use crate::git;
+use crate::glab::{self, CiStatus as GlabCiStatus, MrState as GlabMrState};
+
+/// Supported git hosting providers
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Provider {
+    GitHub,
+    GitLab,
+}
+
+/// Unified PR/MR state across providers
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PrState {
+    Open,
+    Merged,
+    Closed,
+    Draft,
+}
+
+/// Unified CI status across providers
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CiStatus {
+    Pending,
+    Running,
+    Success,
+    Failed,
+    Canceled,
+    Unknown,
+}
+
+/// Unified PR/MR information
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct PrInfo {
+    pub number: u64,
+    pub title: String,
+    pub state: PrState,
+    pub url: String,
+    pub draft: bool,
+    pub approved: bool,
+    pub mergeable: bool,
+}
+
+impl Provider {
+    /// Detect provider from repository
+    pub fn detect(repo: &Repository) -> Result<Self> {
+        match git::detect_remote_provider(repo) {
+            Ok(git::RemoteProvider::GitHub) => Ok(Provider::GitHub),
+            Ok(git::RemoteProvider::GitLab) => Ok(Provider::GitLab),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Check if CLI tool is installed
+    pub fn check_installed(&self) -> Result<()> {
+        match self {
+            Provider::GitHub => gh::check_gh_installed(),
+            Provider::GitLab => glab::check_glab_installed(),
+        }
+    }
+
+    /// Check if authenticated with provider
+    pub fn check_auth(&self) -> Result<()> {
+        match self {
+            Provider::GitHub => gh::check_gh_auth(),
+            Provider::GitLab => glab::check_glab_auth(),
+        }
+    }
+
+    /// Get current username
+    pub fn whoami(&self) -> Result<String> {
+        match self {
+            Provider::GitHub => gh::whoami(),
+            Provider::GitLab => glab::whoami(),
+        }
+    }
+
+    /// Create a new PR/MR
+    pub fn create_pr(
+        &self,
+        source_branch: &str,
+        target_branch: &str,
+        title: &str,
+        description: &str,
+        draft: bool,
+    ) -> Result<u64> {
+        match self {
+            Provider::GitHub => {
+                gh::create_pr(source_branch, target_branch, title, description, draft)
+            }
+            Provider::GitLab => {
+                glab::create_mr(source_branch, target_branch, title, description, draft)
+            }
+        }
+    }
+
+    /// Get PR/MR information
+    pub fn get_pr_info(&self, number: u64) -> Result<PrInfo> {
+        match self {
+            Provider::GitHub => {
+                let info = gh::get_pr_info(number)?;
+                Ok(PrInfo {
+                    number: info.number,
+                    title: info.title,
+                    state: convert_gh_state(info.state),
+                    url: info.url,
+                    draft: info.draft,
+                    approved: info.approved,
+                    mergeable: info.mergeable,
+                })
+            }
+            Provider::GitLab => {
+                let info = glab::get_mr_info(number)?;
+                Ok(PrInfo {
+                    number: info.iid,
+                    title: info.title,
+                    state: convert_glab_state(info.state),
+                    url: info.web_url,
+                    draft: info.draft,
+                    approved: info.approved,
+                    mergeable: info.mergeable,
+                })
+            }
+        }
+    }
+
+    /// Update PR/MR base/target branch
+    pub fn update_pr_base(&self, number: u64, base_branch: &str) -> Result<()> {
+        match self {
+            Provider::GitHub => gh::update_pr_base(number, base_branch),
+            Provider::GitLab => glab::update_mr_target(number, base_branch),
+        }
+    }
+
+    /// Merge a PR/MR
+    pub fn merge_pr(&self, number: u64, squash: bool, delete_branch: bool) -> Result<()> {
+        match self {
+            Provider::GitHub => gh::merge_pr(number, squash, delete_branch),
+            Provider::GitLab => glab::merge_mr(number, squash, delete_branch),
+        }
+    }
+
+    /// Check if PR/MR is approved
+    pub fn check_pr_approved(&self, number: u64) -> Result<bool> {
+        match self {
+            Provider::GitHub => gh::check_pr_approved(number),
+            Provider::GitLab => glab::check_mr_approved(number),
+        }
+    }
+
+    /// Get CI status for PR/MR
+    pub fn get_pr_ci_status(&self, number: u64) -> Result<CiStatus> {
+        match self {
+            Provider::GitHub => {
+                let status = gh::get_pr_ci_status(number)?;
+                Ok(convert_gh_ci_status(status))
+            }
+            Provider::GitLab => {
+                let status = glab::get_mr_ci_status(number)?;
+                Ok(convert_glab_ci_status(status))
+            }
+        }
+    }
+
+    /// Get provider name for display
+    #[allow(dead_code)]
+    pub fn name(&self) -> &'static str {
+        match self {
+            Provider::GitHub => "GitHub",
+            Provider::GitLab => "GitLab",
+        }
+    }
+
+    /// Get PR/MR label (PR or MR)
+    pub fn pr_label(&self) -> &'static str {
+        match self {
+            Provider::GitHub => "PR",
+            Provider::GitLab => "MR",
+        }
+    }
+}
+
+// Conversion helpers
+
+fn convert_gh_state(state: GhPrState) -> PrState {
+    match state {
+        GhPrState::Open => PrState::Open,
+        GhPrState::Merged => PrState::Merged,
+        GhPrState::Closed => PrState::Closed,
+        GhPrState::Draft => PrState::Draft,
+    }
+}
+
+fn convert_glab_state(state: GlabMrState) -> PrState {
+    match state {
+        GlabMrState::Open => PrState::Open,
+        GlabMrState::Merged => PrState::Merged,
+        GlabMrState::Closed => PrState::Closed,
+        GlabMrState::Draft => PrState::Draft,
+    }
+}
+
+fn convert_gh_ci_status(status: GhCiStatus) -> CiStatus {
+    match status {
+        GhCiStatus::Pending => CiStatus::Pending,
+        GhCiStatus::Running => CiStatus::Running,
+        GhCiStatus::Success => CiStatus::Success,
+        GhCiStatus::Failed => CiStatus::Failed,
+        GhCiStatus::Canceled => CiStatus::Canceled,
+        GhCiStatus::Unknown => CiStatus::Unknown,
+    }
+}
+
+fn convert_glab_ci_status(status: GlabCiStatus) -> CiStatus {
+    match status {
+        GlabCiStatus::Pending => CiStatus::Pending,
+        GlabCiStatus::Running => CiStatus::Running,
+        GlabCiStatus::Success => CiStatus::Success,
+        GlabCiStatus::Failed => CiStatus::Failed,
+        GlabCiStatus::Canceled => CiStatus::Canceled,
+        GlabCiStatus::Unknown => CiStatus::Unknown,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_provider_equality() {
+        assert_eq!(Provider::GitHub, Provider::GitHub);
+        assert_eq!(Provider::GitLab, Provider::GitLab);
+        assert_ne!(Provider::GitHub, Provider::GitLab);
+    }
+
+    #[test]
+    fn test_pr_state_equality() {
+        assert_eq!(PrState::Open, PrState::Open);
+        assert_eq!(PrState::Merged, PrState::Merged);
+        assert_eq!(PrState::Closed, PrState::Closed);
+        assert_eq!(PrState::Draft, PrState::Draft);
+        assert_ne!(PrState::Open, PrState::Merged);
+    }
+
+    #[test]
+    fn test_ci_status_equality() {
+        assert_eq!(CiStatus::Success, CiStatus::Success);
+        assert_eq!(CiStatus::Failed, CiStatus::Failed);
+        assert_eq!(CiStatus::Pending, CiStatus::Pending);
+        assert_eq!(CiStatus::Running, CiStatus::Running);
+        assert_eq!(CiStatus::Canceled, CiStatus::Canceled);
+        assert_eq!(CiStatus::Unknown, CiStatus::Unknown);
+        assert_ne!(CiStatus::Success, CiStatus::Failed);
+    }
+
+    #[test]
+    fn test_provider_name() {
+        assert_eq!(Provider::GitHub.name(), "GitHub");
+        assert_eq!(Provider::GitLab.name(), "GitLab");
+    }
+
+    #[test]
+    fn test_provider_pr_label() {
+        assert_eq!(Provider::GitHub.pr_label(), "PR");
+        assert_eq!(Provider::GitLab.pr_label(), "MR");
+    }
+
+    #[test]
+    fn test_pr_info_construction() {
+        let info = PrInfo {
+            number: 42,
+            title: "Test PR".to_string(),
+            state: PrState::Open,
+            url: "https://example.com/pr/42".to_string(),
+            draft: false,
+            approved: true,
+            mergeable: true,
+        };
+        assert_eq!(info.number, 42);
+        assert_eq!(info.title, "Test PR");
+        assert_eq!(info.state, PrState::Open);
+        assert!(info.approved);
+        assert!(info.mergeable);
+        assert!(!info.draft);
+    }
+
+    #[test]
+    fn test_convert_gh_state() {
+        assert_eq!(convert_gh_state(GhPrState::Open), PrState::Open);
+        assert_eq!(convert_gh_state(GhPrState::Merged), PrState::Merged);
+        assert_eq!(convert_gh_state(GhPrState::Closed), PrState::Closed);
+        assert_eq!(convert_gh_state(GhPrState::Draft), PrState::Draft);
+    }
+
+    #[test]
+    fn test_convert_glab_state() {
+        assert_eq!(convert_glab_state(GlabMrState::Open), PrState::Open);
+        assert_eq!(convert_glab_state(GlabMrState::Merged), PrState::Merged);
+        assert_eq!(convert_glab_state(GlabMrState::Closed), PrState::Closed);
+        assert_eq!(convert_glab_state(GlabMrState::Draft), PrState::Draft);
+    }
+
+    #[test]
+    fn test_convert_gh_ci_status() {
+        assert_eq!(convert_gh_ci_status(GhCiStatus::Pending), CiStatus::Pending);
+        assert_eq!(convert_gh_ci_status(GhCiStatus::Running), CiStatus::Running);
+        assert_eq!(convert_gh_ci_status(GhCiStatus::Success), CiStatus::Success);
+        assert_eq!(convert_gh_ci_status(GhCiStatus::Failed), CiStatus::Failed);
+        assert_eq!(
+            convert_gh_ci_status(GhCiStatus::Canceled),
+            CiStatus::Canceled
+        );
+        assert_eq!(convert_gh_ci_status(GhCiStatus::Unknown), CiStatus::Unknown);
+    }
+
+    #[test]
+    fn test_convert_glab_ci_status() {
+        assert_eq!(
+            convert_glab_ci_status(GlabCiStatus::Pending),
+            CiStatus::Pending
+        );
+        assert_eq!(
+            convert_glab_ci_status(GlabCiStatus::Running),
+            CiStatus::Running
+        );
+        assert_eq!(
+            convert_glab_ci_status(GlabCiStatus::Success),
+            CiStatus::Success
+        );
+        assert_eq!(
+            convert_glab_ci_status(GlabCiStatus::Failed),
+            CiStatus::Failed
+        );
+        assert_eq!(
+            convert_glab_ci_status(GlabCiStatus::Canceled),
+            CiStatus::Canceled
+        );
+        assert_eq!(
+            convert_glab_ci_status(GlabCiStatus::Unknown),
+            CiStatus::Unknown
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Implements full GitLab support in git-gud through a unified provider abstraction layer.

### Problem
Previously, `gg sync` only worked with GitHub - it pushed branches but did not create MRs in GitLab.

### Solution
Created a `Provider` abstraction that:
- Auto-detects the hosting provider from remote URL (github.com vs gitlab.com)
- Provides a unified interface for PR/MR operations
- Routes calls to either `gh` (GitHub CLI) or `glab` (GitLab CLI)

### Changes

**New file: `src/provider.rs` (280+ lines)**
- `Provider` enum: `GitHub` | `GitLab`
- Unified types: `PrState`, `CiStatus`, `PrInfo`
- Methods: `detect()`, `create_pr()`, `get_pr_info()`, `merge_pr()`, etc.
- Conversion helpers between gh/glab types

**Modified files:**
- `src/commands/sync.rs` - Uses provider for MR/PR creation
- `src/commands/land.rs` - Uses provider for merge
- `src/commands/ls.rs` - Uses provider for status refresh
- `src/commands/clean.rs` - Uses provider for merge detection
- `src/commands/checkout.rs` - Uses provider for username
- `src/commands/setup.rs` - Uses provider for suggestions
- `src/stack.rs` - Accepts provider for refresh
- `src/glab.rs` - Added `get_mr_info()` alias
- `src/main.rs` - Registered provider module

### Testing

**Unit tests added (11 new tests):**
- Provider enum equality
- PrState/CiStatus equality
- Provider name/label methods
- PrInfo construction
- State conversion (gh ↔ unified)
- CI status conversion (glab ↔ unified)

**Functional testing:**
- ✅ `gg sync --draft` creates MRs in GitLab
- ✅ `gg ls --refresh` shows MR status
- ✅ Stacked MRs created with correct target branches
- ✅ GitHub repos continue working unchanged

### Validation
```bash
cargo fmt --all     # ✅
cargo clippy        # ✅  
cargo test          # ✅ 35 tests passed (23 unit + 12 integration)
```

### Breaking Changes
None - existing GitHub workflows are unaffected.

### Related
Closes the GitLab MR creation bug found in E2E testing.