### PR TITLE
feat(absorb): integrate git-absorb as library dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,6 +186,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -195,6 +196,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "430b4dc2b5e3861848de79627b2bedc9f3342c7da5173a14eaa5d0f8dc18ae5d"
 dependencies = [
  "clap",
+]
+
+[[package]]
+name = "clap_complete_nushell"
+version = "4.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685bc86fd34b7467e0532a4f8435ab107960d69a243785ef0275e571b35b641a"
+dependencies = [
+ "clap",
+ "clap_complete",
 ]
 
 [[package]]
@@ -476,6 +487,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "erased-serde"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,6 +565,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "git-absorb"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d1f3af8e8072014ad172abc9775bdd6c793378005eb2c6fe3e4ef939da1aea8"
+dependencies = [
+ "anyhow",
+ "clap",
+ "clap_complete",
+ "clap_complete_nushell",
+ "git2",
+ "memchr",
+ "slog",
+ "slog-term",
+]
+
+[[package]]
 name = "git-gud"
 version = "0.1.0"
 dependencies = [
@@ -553,12 +589,16 @@ dependencies = [
  "clap_complete",
  "console",
  "dialoguer",
+ "git-absorb",
  "git2",
  "indicatif",
  "regex",
  "serde",
  "serde_json",
  "skim",
+ "slog",
+ "slog-async",
+ "slog-term",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -591,6 +631,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "iana-time-zone"
@@ -745,6 +791,17 @@ dependencies = [
  "unicode-width",
  "unit-prefix",
  "web-time",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1328,8 +1385,46 @@ dependencies = [
  "log",
  "nix",
  "skim-common",
- "term",
+ "term 0.7.0",
  "unicode-width",
+]
+
+[[package]]
+name = "slog"
+version = "2.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b3b8565691b22d2bdfc066426ed48f837fc0c5f2c8cad8d9718f7f99d6995c1"
+dependencies = [
+ "anyhow",
+ "erased-serde",
+ "rustversion",
+ "serde_core",
+]
+
+[[package]]
+name = "slog-async"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c8038f898a2c79507940990f05386455b3a317d8f18d4caea7cbc3d5096b84"
+dependencies = [
+ "crossbeam-channel",
+ "slog",
+ "take_mut",
+ "thread_local",
+]
+
+[[package]]
+name = "slog-term"
+version = "2.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cb1fc680b38eed6fad4c02b3871c09d2c81db8c96aa4e9c0a34904c830f09b5"
+dependencies = [
+ "chrono",
+ "is-terminal",
+ "slog",
+ "term 1.2.1",
+ "thread_local",
+ "time",
 ]
 
 [[package]]
@@ -1383,6 +1478,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "take_mut"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
+
+[[package]]
 name = "tempfile"
 version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1404,6 +1505,25 @@ dependencies = [
  "dirs-next",
  "rustversion",
  "winapi",
+]
+
+[[package]]
+name = "term"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
+dependencies = [
+ "rustix",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1462,10 +1582,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -1473,6 +1595,16 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78cc610bac2dcee56805c99642447d4c5dbde4d01f752ffea0199aee1f601dc4"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "timer"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,5 +38,11 @@ thiserror = "2"
 uuid = { version = "1", features = ["v4"] }
 regex = "1"
 
+# Absorb (library integration)
+git-absorb = "0.8"
+slog = "2"
+slog-term = "2"
+slog-async = "2"
+
 [dev-dependencies]
 tempfile = "3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,7 +150,23 @@ enum Commands {
 
     /// Absorb staged changes into the appropriate commits
     #[command(name = "absorb")]
-    Absorb,
+    Absorb {
+        /// Show what would be done without making changes
+        #[arg(short = 'n', long)]
+        dry_run: bool,
+
+        /// Automatically rebase after creating fixup commits
+        #[arg(short, long)]
+        and_rebase: bool,
+
+        /// Absorb whole files rather than individual hunks
+        #[arg(short, long)]
+        whole_file: bool,
+
+        /// Create at most one fixup per commit
+        #[arg(long)]
+        one_fixup_per_commit: bool,
+    },
 
     /// Generate shell completions
     #[command(name = "completions")]
@@ -185,7 +201,17 @@ fn main() {
         Some(Commands::Abort) => commands::rebase::abort_rebase(),
         Some(Commands::Lint { until }) => commands::lint::run(until),
         Some(Commands::Setup) => commands::setup::run(),
-        Some(Commands::Absorb) => commands::absorb::run(),
+        Some(Commands::Absorb {
+            dry_run,
+            and_rebase,
+            whole_file,
+            one_fixup_per_commit,
+        }) => commands::absorb::run(commands::absorb::AbsorbOptions {
+            dry_run,
+            and_rebase,
+            whole_file,
+            one_fixup_per_commit,
+        }),
         Some(Commands::Completions { shell }) => commands::completions::run(shell),
     };
 


### PR DESCRIPTION
## Summary

Replace the external CLI wrapper with direct library integration, eliminating the need for users to install `git-absorb` separately.

## Changes

- Add `git-absorb`, `slog`, `slog-term`, `slog-async` dependencies
- Rewrite `absorb.rs` to use `git_absorb::run()` directly
- Add `AbsorbOptions` struct with CLI-configurable options

## New CLI Options

```
gg absorb [OPTIONS]

Options:
  -n, --dry-run               Show what would be done without making changes
  -a, --and-rebase            Automatically rebase after creating fixup commits
  -w, --whole-file            Absorb whole files rather than individual hunks
      --one-fixup-per-commit  Create at most one fixup per commit
```

## Benefits

- ✅ No external dependency required (`git-absorb` CLI no longer needed)
- ✅ Consistent behavior across platforms
- ✅ Better error messages integrated with gg workflow
- ✅ More options exposed (dry-run, whole-file, etc.)

## Testing

- [x] All 47 tests pass (35 unit + 12 integration)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy` passes
- [ ] Manual testing in playground (pending)