### PR TITLE
feat: display PR/MR URL when creating new PRs/MRs during sync

### DIFF
--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -128,17 +128,21 @@ pub fn run(draft: bool, force: bool) -> Result<()> {
 
                 match provider.create_pr(&entry_branch, &target_branch, &title, &description, draft)
                 {
-                    Ok(pr_num) => {
-                        config.set_mr_for_entry(&stack.name, gg_id, pr_num);
+                    Ok(result) => {
+                        config.set_mr_for_entry(&stack.name, gg_id, result.number);
                         let draft_label = if draft { " (draft)" } else { "" };
                         pb.println(format!(
                             "{} Pushed {} -> {} #{}{}",
                             style("OK").green().bold(),
                             style(&entry_branch).cyan(),
                             provider.pr_label(),
-                            pr_num,
+                            result.number,
                             draft_label
                         ));
+                        // Show clickable URL for new PRs/MRs
+                        if !result.url.is_empty() {
+                            pb.println(format!("   {}", style(&result.url).underlined().blue()));
+                        }
                     }
                     Err(e) => {
                         pb.println(format!(

--- a/src/glab.rs
+++ b/src/glab.rs
@@ -111,6 +111,13 @@ pub fn whoami() -> Result<String> {
     ))
 }
 
+/// Result of creating an MR
+#[derive(Debug, Clone)]
+pub struct MrCreationResult {
+    pub number: u64,
+    pub url: String,
+}
+
 /// Create a new MR
 pub fn create_mr(
     source_branch: &str,
@@ -118,7 +125,7 @@ pub fn create_mr(
     title: &str,
     description: &str,
     draft: bool,
-) -> Result<u64> {
+) -> Result<MrCreationResult> {
     let mut args = vec![
         "mr",
         "create",
@@ -147,11 +154,67 @@ pub fn create_mr(
         )));
     }
 
-    // Parse the output to get the MR number
+    // Parse the output to get the MR number and URL
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
 
-    parse_mr_number_from_output(&stdout, &stderr)
+    parse_mr_creation_result(&stdout, &stderr)
+}
+
+/// Parse MR creation result (number and URL) from glab command output.
+///
+/// Tries multiple strategies to extract the MR number and URL:
+/// 1. Look for URL containing `/merge_requests/N`
+/// 2. Look for `!N` pattern (e.g., "Created merge request !123")
+/// 3. Look for "MR N" or "merge request N" patterns
+/// 4. Last resort: find any number > 0 in the output
+fn parse_mr_creation_result(stdout: &str, stderr: &str) -> Result<MrCreationResult> {
+    let combined = format!("{} {}", stdout, stderr);
+
+    // First, try to extract URL - it's more reliable and gives us both URL and number
+    let url = extract_mr_url(&combined);
+
+    // Try to get number from URL first
+    if let Some(ref url_str) = url {
+        if let Some(idx) = url_str.find("/merge_requests/") {
+            let after = &url_str[idx + "/merge_requests/".len()..];
+            let num_str: String = after.chars().take_while(|c| c.is_ascii_digit()).collect();
+            if let Ok(num) = num_str.parse::<u64>() {
+                if num > 0 {
+                    return Ok(MrCreationResult {
+                        number: num,
+                        url: url_str.clone(),
+                    });
+                }
+            }
+        }
+    }
+
+    // Fallback: parse number using various strategies
+    let number = parse_mr_number_from_output(stdout, stderr)?;
+
+    // If we have a URL, use it; otherwise construct a placeholder
+    let final_url = url.unwrap_or_default();
+
+    Ok(MrCreationResult {
+        number,
+        url: final_url,
+    })
+}
+
+/// Extract MR URL from glab output
+fn extract_mr_url(text: &str) -> Option<String> {
+    // Look for URLs containing /merge_requests/
+    for word in text.split_whitespace() {
+        if word.contains("/merge_requests/")
+            && (word.starts_with("http://") || word.starts_with("https://"))
+        {
+            // Clean up the URL (remove trailing punctuation)
+            let url = word.trim_end_matches(|c: char| !c.is_alphanumeric() && c != '/');
+            return Some(url.to_string());
+        }
+    }
+    None
 }
 
 /// Parse MR number from glab command output.
@@ -493,6 +556,95 @@ mod tests {
                 ""
             ).unwrap(),
             42
+        );
+    }
+
+    #[test]
+    fn test_extract_mr_url_basic() {
+        let url = extract_mr_url("https://gitlab.com/user/repo/-/merge_requests/123");
+        assert_eq!(
+            url,
+            Some("https://gitlab.com/user/repo/-/merge_requests/123".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_mr_url_with_surrounding_text() {
+        let url = extract_mr_url(
+            "Created MR at https://gitlab.com/user/repo/-/merge_requests/456 successfully",
+        );
+        assert_eq!(
+            url,
+            Some("https://gitlab.com/user/repo/-/merge_requests/456".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_mr_url_with_trailing_punctuation() {
+        let url = extract_mr_url("See https://gitlab.com/user/repo/-/merge_requests/789.");
+        assert_eq!(
+            url,
+            Some("https://gitlab.com/user/repo/-/merge_requests/789".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_mr_url_no_url() {
+        let url = extract_mr_url("Created MR !123");
+        assert_eq!(url, None);
+    }
+
+    #[test]
+    fn test_extract_mr_url_http() {
+        let url = extract_mr_url("http://gitlab.internal/group/project/-/merge_requests/42");
+        assert_eq!(
+            url,
+            Some("http://gitlab.internal/group/project/-/merge_requests/42".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_mr_creation_result_with_url() {
+        let result = parse_mr_creation_result(
+            "Creating merge request\n\n!42 Feature\nhttps://gitlab.com/user/repo/-/merge_requests/42",
+            ""
+        ).unwrap();
+        assert_eq!(result.number, 42);
+        assert_eq!(
+            result.url,
+            "https://gitlab.com/user/repo/-/merge_requests/42"
+        );
+    }
+
+    #[test]
+    fn test_parse_mr_creation_result_url_only() {
+        let result =
+            parse_mr_creation_result("https://gitlab.com/user/repo/-/merge_requests/123", "")
+                .unwrap();
+        assert_eq!(result.number, 123);
+        assert_eq!(
+            result.url,
+            "https://gitlab.com/user/repo/-/merge_requests/123"
+        );
+    }
+
+    #[test]
+    fn test_parse_mr_creation_result_no_url() {
+        let result = parse_mr_creation_result("Created MR !789", "").unwrap();
+        assert_eq!(result.number, 789);
+        assert!(result.url.is_empty());
+    }
+
+    #[test]
+    fn test_mr_creation_result_construction() {
+        let result = MrCreationResult {
+            number: 42,
+            url: "https://gitlab.com/test/repo/-/merge_requests/42".to_string(),
+        };
+        assert_eq!(result.number, 42);
+        assert_eq!(
+            result.url,
+            "https://gitlab.com/test/repo/-/merge_requests/42"
         );
     }
 }


### PR DESCRIPTION
## Summary
When running `gg sync` or `gg diff`, the URL of newly created PRs/MRs is now displayed in the output, making it easy to click and open in the browser.

## Changes
- Added `PrCreationResult` struct to `gh.rs` and `glab.rs` to return both number and URL from `create_pr`/`create_mr`
- Added `parse_mr_creation_result` and `extract_mr_url` helpers in `glab.rs`
- Updated `Provider.create_pr` to return unified `PrCreationResult`
- Modified `sync.rs` to display the clickable URL (styled with underline and blue) for new PRs/MRs
- Added comprehensive tests for new functionality (13 new tests)

## Example output
```
OK Pushed nacho/feature/c-abc1234 -> PR #42
   https://github.com/user/repo/pull/42
```

## Tests
All tests pass:
- `cargo fmt --all` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo test --all-features` ✅ (67 tests)