### PR TITLE
fix: always use --force-with-lease when pushing entry branches

### DIFF
--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -78,8 +78,10 @@ pub fn run(draft: bool, force: bool) -> Result<()> {
         // Create/update the remote branch for this commit
         create_entry_branch(&repo, &stack, entry, &entry_branch)?;
 
-        // Push the branch
-        let push_result = git::push_branch(&entry_branch, force);
+        // Push the branch (always force-push with lease because rebases change commit SHAs)
+        // This is safe because each entry branch is owned by this stack
+        // If --force is passed, use hard force as an escape hatch
+        let push_result = git::push_branch(&entry_branch, true, force);
         if let Err(e) = push_result {
             pb.abandon_with_message(format!("Failed to push {}: {}", entry_branch, e));
             return Err(e);

--- a/src/git.rs
+++ b/src/git.rs
@@ -250,9 +250,14 @@ pub fn run_git_command(args: &[&str]) -> Result<String> {
 }
 
 /// Push a branch to origin
-pub fn push_branch(branch_name: &str, force: bool) -> Result<()> {
+///
+/// - `force_with_lease`: Use --force-with-lease (safe force, recommended for stacked diffs)
+/// - `hard_force`: Use --force (overrides force_with_lease, use only as escape hatch)
+pub fn push_branch(branch_name: &str, force_with_lease: bool, hard_force: bool) -> Result<()> {
     let mut args = vec!["push", "origin", branch_name];
-    if force {
+    if hard_force {
+        args.insert(1, "--force");
+    } else if force_with_lease {
         args.insert(1, "--force-with-lease");
     }
     run_git_command(&args)?;


### PR DESCRIPTION
## Problem
When adding new commits to a stack and syncing, the rebase to add GG-IDs changes all commit SHAs. This causes push to fail with 'non-fast-forward' error because the remote branch has the old SHA.

## Reproduction steps
```bash
gg co mystack
# make commit
gg sync  # works
# make another commit  
gg sync  # FAILS with non-fast-forward error
```

## Solution
Always use `--force-with-lease` when pushing entry branches since they are owned by the stack and rebases are expected. This is consistent with how other stacked-diff tools like Graphite handle this.

The `--force` CLI flag now enables hard force (`--force` instead of `--force-with-lease`) as an escape hatch if needed.

## Changes
- `git.rs`: Updated `push_branch` to take `force_with_lease` and `hard_force` params
- `sync.rs`: Always use force-with-lease, use hard force if `--force` flag is passed

## Testing
- Verified fix works in git-gud-playground
- All tests pass