### PR TITLE
fix: remove unnecessary clean working directory check from land

### DIFF
--- a/src/commands/land.rs
+++ b/src/commands/land.rs
@@ -20,8 +20,9 @@ pub fn run(land_all: bool, squash: bool) -> Result<()> {
     provider.check_installed()?;
     provider.check_auth()?;
 
-    // Require clean working directory
-    git::require_clean_working_directory(&repo)?;
+    // Note: We don't require a clean working directory here because land
+    // only performs remote operations (merging PRs via the API). It doesn't
+    // modify local files.
 
     // Load stack and refresh PR info
     let mut stack = Stack::load(&repo, &config)?;


### PR DESCRIPTION
## Problem
`gg land` fails with 'Dirty working directory' error even after committing and syncing all changes.

Workflow that triggers the issue:
```bash
gg co mystack
# commit
gg sync
# commit  
gg sync
gg land  # ERROR: Dirty working directory
```

## Root cause
The `land` command was requiring a clean working directory, but this check was overly strict and could trigger false positives.

## Solution
Remove the clean working directory check from `land` because:
- `land` only performs **remote operations** (merging PRs via the API)
- It doesn't modify any local files
- The check was unnecessary and caused friction

## Testing
- All tests pass
- Verified the fix addresses the reported issue