### PR TITLE
fix: improve working directory clean check to match git status

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -113,8 +113,18 @@ pub fn find_entry_branch_for_stack(
 }
 
 /// Check if the working directory is clean
+/// Only checks for actual changes (modified, staged, deleted, etc.)
+/// Ignores untracked files and submodules to match `git status` behavior
 pub fn is_working_directory_clean(repo: &Repository) -> Result<bool> {
-    let statuses = repo.statuses(None)?;
+    use git2::StatusOptions;
+
+    let mut opts = StatusOptions::new();
+    opts.include_untracked(false)
+        .include_ignored(false)
+        .include_unmodified(false)
+        .exclude_submodules(true);
+
+    let statuses = repo.statuses(Some(&mut opts))?;
     Ok(statuses.is_empty())
 }
 


### PR DESCRIPTION
Fixes false positives in `gg lint` (and any other command using `require_clean_working_directory`).

## Problem
The `is_working_directory_clean` function was using default git2 status options which could report the directory as dirty even when `git status` shows it as clean.

## Solution
Now explicitly configures StatusOptions to:
- Exclude untracked files
- Exclude ignored files
- Exclude submodules

This matches the behavior of `git status` CLI.