### PR TITLE
fix: handle 'stale info' error when syncing after manual merge

### DIFF
--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -22,6 +22,10 @@ pub fn run(draft: bool, force: bool) -> Result<()> {
     provider.check_installed()?;
     provider.check_auth()?;
 
+    // Fetch from remote to ensure we have up-to-date refs
+    // This prevents "stale info" errors when remote branches were deleted (e.g., after merge)
+    let _ = git::fetch_and_prune();
+
     // Load current stack
     let stack = Stack::load(&repo, &config)?;
 


### PR DESCRIPTION
Fixes error when running `gg sync` after manually merging a PR on GitHub/GitLab (with 'delete branch').

## Problem
When a PR is merged manually (not via `gg land`) with the 'delete branch' option, the remote entry branch is deleted. Subsequently running `gg sync` fails with:
```
! [rejected] branch-name -> branch-name (stale info)
```

This happens because `--force-with-lease` checks against outdated local tracking refs.

## Solution
1. **Fetch before sync**: Added `git fetch origin --prune` at the start of sync to update local refs and remove deleted remote branches
2. **Retry on stale info**: If `--force-with-lease` still fails with 'stale info', retry with regular `--force` since the branch either doesn't exist anymore or was updated externally

## Testing
- All 20 tests pass
- Manual testing: After merging PR #1 on GitHub with delete branch, `gg sync` now succeeds