### PR TITLE
fix: don't show 'not pushed' for commits with MR numbers

### DIFF
--- a/src/stack.rs
+++ b/src/stack.rs
@@ -73,6 +73,9 @@ impl StackEntry {
             (Some(PrState::Draft), _) => "draft".to_string(),
             (Some(PrState::Open), true) => "approved".to_string(),
             (Some(PrState::Open), false) => "open".to_string(),
+            // If we have an MR number but no state, it's pushed but status not fetched
+            // Use --refresh to fetch current state
+            (None, _) if self.mr_number.is_some() => String::new(),
             (None, _) => "not pushed".to_string(),
         }
     }


### PR DESCRIPTION
Fixes incorrect 'not pushed' status in `gg ls` for synced commits.

## Problem
Commits that have MR numbers (e.g., `!194`) were showing 'not pushed':
```
[1] abc123 My commit not pushed (id: c-xxx) !194
```

This was confusing since the MR number proves it was pushed.

## Cause
The `status_display()` function showed 'not pushed' when `mr_state` was `None`. But `mr_state` is only populated when using `--refresh` flag.

## Solution
Now checks if `mr_number` exists before showing 'not pushed'. If there's an MR number, show empty string (cleaner display):
```
[1] abc123 My commit (id: c-xxx) !194
```

Use `gg ls --refresh` to fetch actual state (open/draft/merged).