### PR TITLE
fix: skip closed/merged PRs in sync and fix approval check

### DIFF
--- a/src/gh.rs
+++ b/src/gh.rs
@@ -310,7 +310,10 @@ pub fn check_pr_approved(pr_number: u64) -> Result<bool> {
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    Ok(stdout == "APPROVED")
+    // APPROVED = explicitly approved
+    // Empty = no review required (e.g., no branch protection rules requiring review)
+    // "" = same as empty
+    Ok(stdout == "APPROVED" || stdout.is_empty() || stdout == "null")
 }
 
 /// Get CI status for a PR


### PR DESCRIPTION
Two fixes:

## 1. Sync skips closed/merged PRs
When running `gg sync`, it was trying to update PRs that were already merged/closed, causing:
```
Warning: Cannot change the base branch of a closed pull request
```

Now checks PR state before updating and skips closed/merged PRs.

## 2. Land allows merging when no review required (GitHub)
On GitHub, if branch protection doesn't require reviews, `reviewDecision` is empty/null. Previously this was treated as "not approved" and blocked merging.

Now treats empty `reviewDecision` as "no review required" = allowed to merge.