### PR TITLE
feat(sync): auto-add GG-IDs without prompting by default

### DIFF
--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -39,20 +39,25 @@ pub fn run(draft: bool, force: bool) -> Result<()> {
     if !missing_ids.is_empty() {
         println!(
             "{} {} commits are missing GG-IDs:",
-            style("Warning:").yellow().bold(),
+            style("→").cyan(),
             missing_ids.len()
         );
         for entry in &missing_ids {
             println!("  [{}] {} {}", entry.position, entry.short_sha, entry.title);
         }
 
-        let confirm = Confirm::new()
-            .with_prompt("Add GG-IDs to these commits? (requires rebase)")
-            .default(true)
-            .interact()
-            .unwrap_or(true); // Default to yes if not interactive
+        // Check config for auto_add_gg_ids (default: true)
+        let should_add = if config.defaults.auto_add_gg_ids {
+            true
+        } else {
+            Confirm::new()
+                .with_prompt("Add GG-IDs to these commits? (requires rebase)")
+                .default(true)
+                .interact()
+                .unwrap_or(true)
+        };
 
-        if confirm {
+        if should_add {
             add_gg_ids_to_commits(&repo, &stack)?;
             // Reload stack after rebase
             return run(draft, force);

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,18 @@ pub struct Defaults {
     /// Lint commands to run per commit
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub lint: Vec<String>,
+
+    /// Automatically add GG-IDs to commits without prompting (default: true)
+    #[serde(default = "default_true", skip_serializing_if = "is_true")]
+    pub auto_add_gg_ids: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn is_true(b: &bool) -> bool {
+    *b
 }
 
 /// Per-stack configuration


### PR DESCRIPTION
## Summary
- Add `auto_add_gg_ids` config option (defaults to `true`)
- When `true`: automatically adds GG-IDs without confirmation
- When `false`: prompts for confirmation (previous behavior)

## Rationale
Declining to add GG-IDs aborts sync anyway, so the prompt was unnecessary friction. Users who want the old behavior can set `auto_add_gg_ids: false` in their config.