### PR TITLE
fix(lint): improve error handling and always restore original position

### DIFF
--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -3,6 +3,7 @@
 use std::process::Command;
 
 use console::style;
+use git2::Oid;
 
 use crate::config::Config;
 use crate::error::{GgError, Result};
@@ -69,6 +70,26 @@ pub fn run(until: Option<usize>) -> Result<()> {
     let original_branch = git::current_branch_name(&repo);
     let original_head = repo.head()?.peel_to_commit()?.id();
 
+    // Run lint with cleanup on error
+    let result = run_lint_on_commits(&repo, &stack, lint_commands, end_pos);
+
+    // Always try to restore original position on error
+    if result.is_err() {
+        restore_original_position(&repo, original_branch.as_deref(), original_head);
+    }
+
+    result
+}
+
+/// Run lint commands on commits, returning the result
+fn run_lint_on_commits(
+    repo: &git2::Repository,
+    stack: &Stack,
+    lint_commands: &[String],
+    end_pos: usize,
+) -> Result<()> {
+    let original_branch = git::current_branch_name(repo);
+    let original_head = repo.head()?.peel_to_commit()?.id();
     let mut had_changes = false;
 
     // Process each commit from first to end_pos
@@ -86,7 +107,7 @@ pub fn run(until: Option<usize>) -> Result<()> {
 
         // Checkout this commit
         let commit = repo.find_commit(entry.oid)?;
-        git::checkout_commit(&repo, &commit)?;
+        git::checkout_commit(repo, &commit)?;
 
         // Run lint commands
         for cmd in lint_commands {
@@ -97,7 +118,22 @@ pub fn run(until: Option<usize>) -> Result<()> {
                 continue;
             }
 
-            let output = Command::new(parts[0]).args(&parts[1..]).output()?;
+            let output = match Command::new(parts[0]).args(&parts[1..]).output() {
+                Ok(output) => output,
+                Err(e) => {
+                    println!("{}", style("ERROR").red().bold());
+                    let error_msg = if e.kind() == std::io::ErrorKind::NotFound {
+                        format!(
+                            "Command '{}' not found. Make sure it's installed and in your PATH.\n\
+                             Note: Shell aliases don't work here. Use the full command (e.g., './gradlew' instead of 'gw').",
+                            parts[0]
+                        )
+                    } else {
+                        format!("Failed to run '{}': {}", parts[0], e)
+                    };
+                    return Err(GgError::Other(error_msg));
+                }
+            };
 
             if output.status.success() {
                 println!("{}", style("OK").green());
@@ -113,7 +149,7 @@ pub fn run(until: Option<usize>) -> Result<()> {
         }
 
         // Check if lint made changes
-        if !git::is_working_directory_clean(&repo)? {
+        if !git::is_working_directory_clean(repo)? {
             println!("  {} Lint made changes, squashing...", style("!").yellow());
 
             // Stage all changes
@@ -148,17 +184,44 @@ pub fn run(until: Option<usize>) -> Result<()> {
                 style("Lint made changes. Review with `gg ls` and sync with `gg sync`.").dim()
             );
         } else {
-            git::checkout_branch(&repo, &branch)?;
+            git::checkout_branch(repo, &branch)?;
         }
     } else {
         // Return to original detached HEAD if no changes
         if !had_changes {
             let commit = repo.find_commit(original_head)?;
-            git::checkout_commit(&repo, &commit)?;
+            git::checkout_commit(repo, &commit)?;
         }
     }
 
     println!("{} Linted {} commits", style("OK").green().bold(), end_pos);
 
     Ok(())
+}
+
+/// Restore the original branch/HEAD position
+fn restore_original_position(
+    repo: &git2::Repository,
+    original_branch: Option<&str>,
+    original_head: Oid,
+) {
+    println!();
+    println!("{} Restoring original position...", style("→").cyan());
+
+    let restored = if let Some(branch) = original_branch {
+        git::checkout_branch(repo, branch).is_ok()
+    } else if let Ok(commit) = repo.find_commit(original_head) {
+        git::checkout_commit(repo, &commit).is_ok()
+    } else {
+        false
+    };
+
+    if restored {
+        println!("{} Restored to original position", style("OK").green());
+    } else {
+        println!(
+            "{} Could not restore original position. You may be in detached HEAD.",
+            style("Warning:").yellow()
+        );
+    }
 }


### PR DESCRIPTION
## Problem
When `gg lint` fails (e.g., command not found because it's a shell alias), it:
1. Leaves you in detached HEAD instead of your original branch
2. Shows a cryptic error message

## Solution
- Always restore to original branch/HEAD when an error occurs
- Show clear error message when command is not found:
  ```
  Command 'gw' not found. Make sure it's installed and in your PATH.
  Note: Shell aliases don't work here. Use the full command (e.g., './gradlew' instead of 'gw').
  ```
- Refactored to ensure cleanup happens even on early errors