### PR TITLE
fix(gh): remove invalid --yes flag from gh pr merge

### DIFF
--- a/src/gh.rs
+++ b/src/gh.rs
@@ -239,9 +239,6 @@ pub fn merge_pr(pr_number: u64, squash: bool, delete_branch: bool) -> Result<()>
         args.push("--delete-branch");
     }
 
-    // Skip confirmation prompt in non-interactive environments
-    args.push("--yes");
-
     let output = Command::new("gh").args(&args).output()?;
 
     if !output.status.success() {


### PR DESCRIPTION
## Problem
`gg land` fails with GitHub because it passes `--yes` to `gh pr merge`, but that flag doesn't exist.

## Solution
Remove the `--yes` flag. `gh pr merge` proceeds without confirmation when run non-interactively (which is our case since we use `.output()`).