### PR TITLE
fix(ci): grant write permissions for claude-code-review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,8 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:


### PR DESCRIPTION
## Problem
Claude Code Review runs and generates feedback (visible in logs), but never posts it to the PR.

## Cause
The workflow had `pull-requests: read` and `issues: read` permissions, which are insufficient for posting comments.

## Solution
Changed to `pull-requests: write` and `issues: write` so Claude can post review feedback directly to PRs.