### PR TITLE
feat(land): enable squash by default

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -117,9 +117,9 @@ enum Commands {
         #[arg(short, long)]
         all: bool,
 
-        /// Squash commits when merging
-        #[arg(short, long)]
-        squash: bool,
+        /// Disable squash when merging (default: squash enabled)
+        #[arg(long = "no-squash")]
+        no_squash: bool,
     },
 
     /// Clean up merged stacks
@@ -209,7 +209,7 @@ fn main() {
         Some(Commands::Reorder { order }) => {
             commands::reorder::run(commands::reorder::ReorderOptions { order })
         }
-        Some(Commands::Land { all, squash }) => commands::land::run(all, squash),
+        Some(Commands::Land { all, no_squash }) => commands::land::run(all, !no_squash),
         Some(Commands::Clean { all }) => commands::clean::run(all),
         Some(Commands::Rebase { target }) => commands::rebase::run(target),
         Some(Commands::Continue) => commands::rebase::continue_rebase(),


### PR DESCRIPTION
## Problem
`gg land` defaulted to merge commits, which caused issues with stack state after landing.

## Solution
- Enable squash by default (no flag needed)
- Add `--no-squash` flag for cases where merge commits are preferred

## Usage
```bash
gg land           # squashes by default
gg land --no-squash  # uses merge commit
```