### PR TITLE
feat: add --wait flag to gg land command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +319,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "ctrlc"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73736a89c4aff73035ba2ed2e565061954da00d4970fc9ac25dcc85a2a20d790"
+dependencies = [
+ "dispatch2",
+ "nix 0.30.1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,6 +446,18 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2",
+ "libc",
+ "objc2",
 ]
 
 [[package]]
@@ -588,6 +620,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "console",
+ "ctrlc",
  "dialoguer",
  "git-absorb",
  "git2",
@@ -979,6 +1012,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -992,6 +1037,21 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "objc2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"
@@ -1353,7 +1413,7 @@ dependencies = [
  "fuzzy-matcher",
  "indexmap",
  "log",
- "nix",
+ "nix 0.29.0",
  "rand",
  "rayon",
  "regex",
@@ -1383,7 +1443,7 @@ dependencies = [
  "bitflags 1.3.2",
  "lazy_static",
  "log",
- "nix",
+ "nix 0.29.0",
  "skim-common",
  "term 0.7.0",
  "unicode-width",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ thiserror = "2"
 # Utilities
 uuid = { version = "1", features = ["v4"] }
 regex = "1"
+ctrlc = "3"
 
 # Absorb (library integration)
 git-absorb = "0.8"

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,6 +120,10 @@ enum Commands {
         /// Disable squash when merging (default: squash enabled)
         #[arg(long = "no-squash")]
         no_squash: bool,
+
+        /// Wait for CI to pass and approvals before merging
+        #[arg(short, long)]
+        wait: bool,
     },
 
     /// Clean up merged stacks
@@ -209,7 +213,11 @@ fn main() {
         Some(Commands::Reorder { order }) => {
             commands::reorder::run(commands::reorder::ReorderOptions { order })
         }
-        Some(Commands::Land { all, no_squash }) => commands::land::run(all, !no_squash),
+        Some(Commands::Land {
+            all,
+            no_squash,
+            wait,
+        }) => commands::land::run(all, !no_squash, wait),
         Some(Commands::Clean { all }) => commands::clean::run(all),
         Some(Commands::Rebase { target }) => commands::rebase::run(target),
         Some(Commands::Continue) => commands::rebase::continue_rebase(),


### PR DESCRIPTION
## Summary

Implements the `--wait` flag for the `gg land` command as requested.

## Features

- **Blocking wait**: The command blocks the terminal until all PRs/MRs in the stack are ready to merge
- **CI polling**: Continuously checks CI status (success/failure/running/pending)
- **Approval checking**: Waits for required approvals (unless `--all` is used)
- **Interrupt handling**: Gracefully handles Ctrl+C interrupts
- **Timeout protection**: Defaults to 30-minute timeout to prevent infinite waiting
- **Progress feedback**: Provides clear status updates while waiting
- **Cross-platform**: Works with both GitHub and GitLab

## Behavior

When `gg land --wait` is invoked:
1. Checks the first PR/MR in the stack
2. Polls CI status every 10 seconds
3. Checks for required approvals
4. Waits until both CI passes and approvals are met
5. Merges the PR/MR
6. Continues to next PR/MR if `--all` flag is present
7. Reports errors for failed CI, timeouts, or conflicts

## Error Handling

- **CI fails**: Stops immediately with clear error message
- **CI canceled**: Stops immediately with error message
- **Timeout**: Stops after 30 minutes with timeout error
- **Ctrl+C**: Gracefully exits on user interrupt
- **Closed/Draft PRs**: Stops with appropriate message

## Testing

- ✅ Unit tests added for timeout constants
- ✅ All existing tests pass
- ✅ Code formatted with `cargo fmt`
- ✅ No clippy warnings

## Usage Examples

```bash
# Wait for first PR to be ready, then merge it
gg land --wait

# Wait for all PRs in stack, merge them sequentially
gg land --all --wait

# Wait and merge without squashing
gg land --wait --no-squash
```

## Implementation Notes

- Uses `ctrlc` crate for interrupt handling
- Polling interval: 10 seconds
- Default timeout: 30 minutes
- Leverages existing `provider.get_pr_ci_status()` and `provider.check_pr_approved()` APIs