### PR TITLE
fix: gg land --wait should wait when CI status is unknown

### DIFF
--- a/src/commands/land.rs
+++ b/src/commands/land.rs
@@ -440,8 +440,11 @@ fn wait_for_pr_ready(
                 )));
             }
             CiStatus::Unknown => {
-                println!("  {} CI status unknown, proceeding...", style("⚠").yellow());
-                true
+                println!(
+                    "  {} CI status unknown, waiting for checks to start...",
+                    style("⏳").cyan()
+                );
+                false
             }
         };
 


### PR DESCRIPTION
## Problem
When running `gg land --wait` immediately after creating a PR (via `gg sync`), the CI status is "Unknown" because no checks have started yet. Currently, the code treats Unknown as "ready" and proceeds to merge, instead of waiting.

## Root Cause
In `src/commands/land.rs` around line 426-429, the Unknown case returned `true` (ready) instead of `false` (not ready).

## Solution
- Changed Unknown status handling to return `false` (not ready) to continue the wait loop
- Updated the message to "CI status unknown, waiting for checks to start..."
- Changed styling to use cyan color and hourglass emoji (⏳) to match other waiting messages

## Testing
- All existing tests pass (`cargo test`)
- No clippy warnings (`cargo clippy`)
- Code formatted (`cargo fmt`)

The wait loop will now continue polling until CI starts and completes (or until the configured timeout is reached).

## Testing Steps (Manual)
1. Run `gg sync` to create a PR
2. Immediately run `gg land --wait`
3. Verify it waits for CI to start and complete instead of proceeding immediately