### PR TITLE
chore: configure crates.io releases as gg-stack

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-action@stable
+
+      - name: Verify version matches tag
+        run: |
+          CARGO_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [ "$CARGO_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::Cargo.toml version ($CARGO_VERSION) does not match tag ($TAG_VERSION)"
+            exit 1
+          fi
+          echo "Version verified: $CARGO_VERSION"
+
+      - name: Publish to crates.io
+        run: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "git-gud"
+name = "gg-stack"
 version = "0.1.0"
 edition = "2021"
 description = "A stacked-diffs CLI tool for GitLab"

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ Stacked diffs allow you to break large changes into small, reviewable commits th
 cargo install --path .
 ```
 
-### From crates.io (coming soon)
+### From crates.io
 
 ```bash
-cargo install git-gud
+cargo install gg-stack
 ```
 
 ## Prerequisites


### PR DESCRIPTION
## Changes

- **Rename crate**: `git-gud` → `gg-stack` in Cargo.toml
  - Binary stays as `gg` (existing `[[bin]]` section)
- **Add release workflow**: `.github/workflows/release.yml`
  - Triggers on GitHub releases (tags `v*`)
  - Publishes to crates.io using `CRATES_IO_TOKEN` secret
  - Verifies Cargo.toml version matches tag
- **Update README**: Installation instructions now show `cargo install gg-stack`

## To Release

1. Update version in `Cargo.toml`
2. Create GitHub release with tag `vX.Y.Z`
3. Workflow publishes to crates.io automatically

## Required Secret

Add `CRATES_IO_TOKEN` to repository secrets before first release.