### PR TITLE
Fix crates.io release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ jobs:
     name: Publish to crates.io
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Verify version matches tag
         run: |


### PR DESCRIPTION
Fix GitHub Release → crates.io publishing workflow.

- Switch to actions/checkout@v4
- Switch to dtolnay/rust-toolchain@stable (dtolnay/rust-action is not a real repo)

After merging, create a new release tag (e.g. v0.1.1) to re-trigger publishing with the fixed workflow.