### PR TITLE
feat: Add GitLab merge trains support

### DIFF
--- a/src/commands/ls.rs
+++ b/src/commands/ls.rs
@@ -369,6 +369,9 @@ fn show_stack(stack: &Stack) -> Result<()> {
             _ => String::new(),
         };
 
+        // Merge train indicator
+        let train = if entry.in_merge_train { " 🚂" } else { "" };
+
         // GG-ID display
         let gg_id = entry.gg_id.as_deref().unwrap_or("-");
 
@@ -383,30 +386,43 @@ fn show_stack(stack: &Stack) -> Result<()> {
 
         if is_current {
             println!(
-                "  {} {} {} {} {} (id: {}){}",
+                "  {} {} {} {} {}{} (id: {}){}",
                 style(&position).bold(),
                 style(sha).yellow().bold(),
                 style(title).bold(),
                 status_styled,
                 ci,
+                train,
                 style(gg_id).dim(),
                 style(head_marker).cyan().bold()
             );
         } else {
             println!(
-                "  {} {} {} {} {} (id: {})",
+                "  {} {} {} {} {}{} (id: {})",
                 style(&position).dim(),
                 style(sha).yellow(),
                 title,
                 status_styled,
                 ci,
+                train,
                 style(gg_id).dim()
             );
         }
 
-        // Show MR link if available
+        // Show MR link and merge train info if available
         if !mr_display.is_empty() {
-            println!("      {}", style(&mr_display).blue());
+            let mut mr_line = mr_display.clone();
+
+            // Add merge train indicator if in train
+            if entry.in_merge_train {
+                if let Some(pos) = entry.merge_train_position {
+                    mr_line.push_str(&format!(" [train pos {}]", pos));
+                } else {
+                    mr_line.push_str(" [train]");
+                }
+            }
+
+            println!("      {}", style(&mr_line).blue());
         }
     }
 

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -271,6 +271,42 @@ impl Provider {
             Provider::GitLab => "!",
         }
     }
+
+    /// Check if merge trains are enabled (GitLab only)
+    /// Returns false for GitHub (not supported)
+    pub fn check_merge_trains_enabled(&self) -> Result<bool> {
+        match self {
+            Provider::GitHub => Ok(false),
+            Provider::GitLab => glab::check_merge_trains_enabled(),
+        }
+    }
+
+    /// Add PR/MR to merge train (GitLab only)
+    /// Falls back to regular merge for GitHub
+    pub fn add_to_merge_train(&self, number: u64) -> Result<()> {
+        match self {
+            Provider::GitHub => {
+                // GitHub doesn't support merge trains, fallback to regular merge
+                Err(GgError::Other(
+                    "Merge trains are not supported on GitHub".to_string(),
+                ))
+            }
+            Provider::GitLab => glab::add_to_merge_train(number),
+        }
+    }
+
+    /// Get merge train status (GitLab only)
+    /// Returns None for GitHub (not supported)
+    pub fn get_merge_train_status(
+        &self,
+        number: u64,
+        target_branch: &str,
+    ) -> Result<Option<glab::MergeTrainInfo>> {
+        match self {
+            Provider::GitHub => Ok(None),
+            Provider::GitLab => Ok(Some(glab::get_merge_train_status(number, target_branch)?)),
+        }
+    }
 }
 
 // Conversion helpers


### PR DESCRIPTION
## Summary

This PR adds comprehensive support for GitLab merge trains to git-gud.

## Changes

### 🚂 Merge Train Detection
- Automatically detect if merge trains are enabled via GitLab API
- Cache detection per session to avoid repeated API calls

### 🔀 Add to Merge Train
- Use merge train API when enabled instead of direct merge
- Graceful fallback to direct merge if train fails

### 📊 Monitor Merge Train Status
- Show position in merge train during `gg land --wait`
- Display status: idle, stale, fresh, merging, merged, skip_merged
- Show pipeline running indicator

### 📝 Show in `gg ls`
- Display train emoji (🚂) for MRs in merge train
- Show position in train alongside MR number

## Implementation

### New API Functions (`src/glab.rs`)
- `check_merge_trains_enabled()` - queries project settings
- `add_to_merge_train()` - adds MR to train via API
- `get_merge_train_status()` - retrieves train position and status
- New types: `MergeTrainStatus`, `MergeTrainInfo`

### Provider Interface (`src/provider.rs`)
- Extended with merge train methods
- GitHub: Returns false/None (not supported)
- GitLab: Full merge train support

### Commands
- **land**: Detects merge trains, uses train API, shows status during wait
- **ls**: Shows train indicator and position

### Data Model (`src/stack.rs`)
- Added `in_merge_train` and `merge_train_position` to `StackEntry`
- Refresh logic queries train status

## Testing
✅ All existing tests pass
✅ New unit tests for merge train types
✅ Formatted with `cargo fmt`
✅ Passed `cargo clippy` with `-D warnings`

## Graceful Degradation
- GitHub: Returns false for merge trains (not supported)
- API failures: Fallback to direct merge with warning
- Missing data: Safe defaults (Idle status, no position)

## Screenshots/Examples

```
$ gg land
Merge trains enabled - MRs will be added to the merge train
→ Adding MR !123 to merge train...
OK Added MR !123 to merge train
```

```
$ gg ls
[1] abc1234 Fix bug (open) ✓ 🚂 (id: c-abc1234)
    !123 [train pos 2]
```

## Related Issues
Implements merge trains support as requested.

## Checklist
- [x] Code formatted with `cargo fmt`
- [x] No clippy warnings
- [x] All tests pass
- [x] New functionality has tests
- [x] Graceful fallback for unsupported platforms