### PR TITLE
fix: remove --jq dependency for glab compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "gg-stack"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "atty",


### PR DESCRIPTION
## Problem
The `--jq` flag is not available in all glab versions. For example, glab 1.82.0 (latest via Homebrew) returns:
```
ERROR Unknown flag: --jq. Try --help for usage.
```

This caused `check_mr_approved()` to silently fail and always return `false`, making `gg land` report "waiting for approval" even when MRs were fully approved.

## Solution
Parse JSON responses directly in Rust using `serde_json` instead of relying on glab's `--jq` flag.

## Affected functions
- `get_username()`: fallback glab api user call
- `check_mr_approved()`: approvals endpoint  
- `check_merge_trains_enabled()`: project settings endpoint