### PR TITLE
fix: prevent double-lock in land command

### DIFF
--- a/src/commands/land.rs
+++ b/src/commands/land.rs
@@ -485,7 +485,8 @@ pub fn run(
                 println!("{}", style("Cleaning up stack...").dim());
 
                 // First, rebase to update main and detect merged commits
-                let rebase_result = crate::commands::rebase::run(Some(stack.base.clone()));
+                let rebase_result =
+                    crate::commands::rebase::run_with_repo(&repo, Some(stack.base.clone()));
                 if let Err(e) = rebase_result {
                     println!("{} Failed to rebase: {}", style("Warning:").yellow(), e);
                     println!(
@@ -496,7 +497,8 @@ pub fn run(
                 }
 
                 // Then, clean the stack
-                let clean_result = crate::commands::clean::run_for_stack(&stack.name, true);
+                let clean_result =
+                    crate::commands::clean::run_for_stack_with_repo(&repo, &stack.name, true);
                 match clean_result {
                     Ok(()) => {
                         println!("{} Stack cleaned successfully", style("OK").green().bold());


### PR DESCRIPTION
## Summary
Fixes a potential double-lock issue in the `land` command found during lock audit.

## Problem
`land::run()` acquires the operation lock, then internally calls:
- `rebase::run()` which also acquires the lock
- `clean::run_for_stack()` which also acquires the lock

This would cause a deadlock or lock error since the lock is non-reentrant.

## Solution
Added lock-free helper functions:
- `rebase::run_with_repo(&Repository, Option<String>)` - does rebase without acquiring lock
- `clean::run_for_stack_with_repo(&Repository, &str, bool)` - does clean without acquiring lock

The original `run()` functions now acquire the lock and delegate to these helpers.
`land.rs` now calls the `*_with_repo()` helpers directly since it already holds the lock.

## Testing
- All 66 tests pass
- `cargo clippy` clean
- `cargo fmt` applied