### PR TITLE
Add `wp` alias for `clean` command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -144,7 +144,7 @@ enum Commands {
     },
 
     /// Clean up merged stacks
-    #[command(name = "clean")]
+    #[command(name = "clean", alias = "wp")]
     Clean {
         /// Clean all merged stacks without prompting
         #[arg(short, long)]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -319,6 +319,24 @@ fn test_completions() {
     assert!(stdout.contains("complete") || stdout.contains("gg"));
 }
 
+#[test]
+fn test_wp_alias_for_clean() {
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    // Test that `gg wp --help` works and shows clean command help
+    let (success, stdout, _) = run_gg(&repo_path, &["wp", "--help"]);
+    assert!(success, "gg wp --help should succeed");
+    assert!(
+        stdout.contains("Clean up merged stacks"),
+        "wp should be an alias for clean: {}",
+        stdout
+    );
+
+    // Test that `gg wp` runs without error (same as `gg clean`)
+    let (success, _, _) = run_gg(&repo_path, &["wp"]);
+    assert!(success, "gg wp should succeed");
+}
+
 // ============================================================
 // Tests for bug fixes in PR #26
 // ============================================================


### PR DESCRIPTION
Adds `wp` as an alias for the `clean` command.

**Changes:**
- Added `alias = "wp"` to the `Clean` command in `src/main.rs`
- Added integration test `test_clean_wp_alias` to verify the alias works correctly

**Testing:**
- All existing tests pass
- New test verifies that `gg wp --help` works and shows the clean command help
- Manually tested: `gg wp` works the same as `gg clean`

Fixes the request to add a quick alias for the clean command.