### PR TITLE
feat: add --until flag to land command

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ gg clean
 | `gg land --all --wait` | Wait and merge all PRs/MRs in sequence |
 | `gg land --no-squash` | Merge using merge commit instead of squash |
 | `gg land --auto-merge` | *(GitLab only)* Queue MR auto-merge ("merge when pipeline succeeds") instead of merging immediately |
+| `gg land --until <target>` | Land only up to a specific commit (by position, GG-ID, or SHA) |
 | `gg land --clean` | Automatically clean up stack after landing all PRs/MRs |
 | `gg land --no-clean` | Disable automatic cleanup (overrides config default) |
 | `gg rebase` | Rebase stack onto updated base branch |

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -12,7 +12,7 @@ use crate::git::{
     strip_gg_id_from_message,
 };
 use crate::provider::Provider;
-use crate::stack::Stack;
+use crate::stack::{resolve_target, Stack};
 use crate::template::{self, TemplateContext};
 
 /// Format and display a push error with helpful context
@@ -459,38 +459,6 @@ pub fn run(
     );
 
     Ok(())
-}
-
-/// Resolve a target string (position, GG-ID, or SHA) to a position in the stack
-fn resolve_target(stack: &Stack, target: &str) -> Result<usize> {
-    // Try to parse target as position (1-indexed number)
-    if let Ok(pos) = target.parse::<usize>() {
-        if pos == 0 || pos > stack.len() {
-            return Err(GgError::Other(format!(
-                "Position {} is out of range (1-{})",
-                pos,
-                stack.len()
-            )));
-        }
-        return Ok(pos);
-    }
-
-    // Try to find by GG-ID
-    if let Some(entry) = stack.get_entry_by_gg_id(target) {
-        return Ok(entry.position);
-    }
-
-    // Try to find by SHA prefix
-    for entry in &stack.entries {
-        if entry.short_sha.starts_with(target) || entry.oid.to_string().starts_with(target) {
-            return Ok(entry.position);
-        }
-    }
-
-    Err(GgError::Other(format!(
-        "Could not find commit matching '{}' in stack",
-        target
-    )))
 }
 
 fn build_pr_payload(

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,6 +146,10 @@ enum Commands {
         #[arg(short, long)]
         wait: bool,
 
+        /// Land commits only up to this target (position, GG-ID, or SHA)
+        #[arg(short, long)]
+        until: Option<String>,
+
         /// Automatically clean up stack after landing all PRs/MRs
         #[arg(short, long, conflicts_with = "no_clean")]
         clean: bool,
@@ -279,6 +283,7 @@ fn main() {
             auto_merge,
             no_squash,
             wait,
+            until,
             clean,
             no_clean,
         }) => {
@@ -297,7 +302,7 @@ fn main() {
                 }
             };
 
-            commands::land::run(all, !no_squash, wait, auto_clean, auto_merge)
+            commands::land::run(all, !no_squash, wait, auto_clean, auto_merge, until)
         }
         Some(Commands::Clean { all }) => commands::clean::run(all),
         Some(Commands::Rebase { target }) => commands::rebase::run(target),

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -295,6 +295,38 @@ impl Stack {
     }
 }
 
+/// Resolve a target string (position, GG-ID, or SHA) to a position in the stack
+pub fn resolve_target(stack: &Stack, target: &str) -> Result<usize> {
+    // Try to parse target as position (1-indexed number)
+    if let Ok(pos) = target.parse::<usize>() {
+        if pos == 0 || pos > stack.len() {
+            return Err(GgError::Other(format!(
+                "Position {} is out of range (1-{})",
+                pos,
+                stack.len()
+            )));
+        }
+        return Ok(pos);
+    }
+
+    // Try to find by GG-ID
+    if let Some(entry) = stack.get_entry_by_gg_id(target) {
+        return Ok(entry.position);
+    }
+
+    // Try to find by SHA prefix
+    for entry in &stack.entries {
+        if entry.short_sha.starts_with(target) || entry.oid.to_string().starts_with(target) {
+            return Ok(entry.position);
+        }
+    }
+
+    Err(GgError::Other(format!(
+        "Could not find commit matching '{}' in stack",
+        target
+    )))
+}
+
 /// Store the current stack branch for use in detached HEAD mode
 #[allow(dead_code)]
 pub fn save_current_stack(git_dir: &Path, branch_name: &str) -> Result<()> {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -101,6 +101,15 @@ fn test_gg_sync_help_has_update_descriptions() {
 }
 
 #[test]
+fn test_gg_land_help_has_until() {
+    let (_temp_dir, repo_path) = create_test_repo();
+    let (success, stdout, _stderr) = run_gg(&repo_path, &["land", "--help"]);
+
+    assert!(success);
+    assert!(stdout.contains("--until"));
+}
+
+#[test]
 fn test_gg_version() {
     let (_temp_dir, repo_path) = create_test_repo();
     let (success, stdout, _stderr) = run_gg(&repo_path, &["--version"]);


### PR DESCRIPTION
## Problem
When landing a stack, you might want to land only the first N commits instead of all approved PRs.

## Solution
Add `--until <target>` flag to `gg land` that lands PRs only up to a specific commit.

**Target can be:**
- Position in stack (1-indexed): `gg land --until 2`
- GG-ID: `gg land --until c-abc1234`
- Commit SHA (partial): `gg land --until abc123`

## Changes
- Added `--until` flag to land command in `main.rs`
- Moved `resolve_target()` helper to `stack.rs` for reuse between sync and land
- Updated `land.rs` to respect the `--until` parameter
- Updated README with documentation
- Added test for `--help` output

## Testing
- `cargo fmt --all` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo test --all-features` ✅