### PR TITLE
fix: restore branch after lint --until makes changes

### DIFF
--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -177,15 +177,23 @@ fn run_lint_on_commits(
     println!();
     if let Some(branch) = original_branch {
         if had_changes {
-            if end_pos == stack.len() {
-                git::move_branch_to_head(repo, &branch)?;
-                git::checkout_branch(repo, &branch)?;
-            }
+            // Move the stack branch to the current HEAD (last linted commit)
+            // and checkout the branch to avoid leaving user in detached HEAD
+            git::move_branch_to_head(repo, &branch)?;
+            git::checkout_branch(repo, &branch)?;
 
-            println!(
-                "{}",
-                style("Lint made changes. Review with `gg ls` and sync with `gg sync`.").dim()
-            );
+            if end_pos < stack.len() {
+                // Partial lint: remaining commits need rebasing
+                println!(
+                    "{}",
+                    style("Lint made changes. Run `gg rebase` to update remaining commits, then `gg sync`.").dim()
+                );
+            } else {
+                println!(
+                    "{}",
+                    style("Lint made changes. Review with `gg ls` and sync with `gg sync`.").dim()
+                );
+            }
         } else {
             git::checkout_branch(repo, &branch)?;
         }


### PR DESCRIPTION
## Problem
When using `gg lint --until N` where N is less than the total stack size, if lint made changes, the user was left in detached HEAD state.

## Solution
- Always move the stack branch to HEAD and check it out when lint makes changes
- Show appropriate message based on whether full or partial lint was done
- For partial lint, suggest running `gg rebase` to update remaining commits

## Example
Before:
```
gg lint --until 2
...
OK Linted 2 commits
$ git status
HEAD detached at 14415a4  # ❌ Bad UX
```

After:
```
gg lint --until 2
...
Lint made changes. Run `gg rebase` to update remaining commits, then `gg sync`.
OK Linted 2 commits
$ git status
On branch nacho/my-stack  # ✅ Back on branch
```

## Testing
- `cargo fmt --all` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo test --all-features` ✅ (74 tests)