### PR TITLE
test: add integration tests for stacked PR rebase after squash merge

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3208,3 +3208,216 @@ path.write_text(text.replace("BAD", "GOOD"))
     let (_success, file2) = run_git(&repo_path, &["show", "HEAD:file2.txt"]);
     assert!(file2.contains("GOOD"));
 }
+
+// ============================================================
+// Tests for PR #106 - Rebase remaining branches after land
+// ============================================================
+
+#[test]
+fn test_stacked_branches_can_rebase_after_squash_merge() {
+    // This test verifies the mechanics that `gg land --all` relies on:
+    // After a squash merge, remaining stacked branches can be rebased
+    // onto the updated main to avoid merge conflicts.
+    //
+    // Scenario:
+    // - Stack: commit A -> commit B -> commit C
+    // - Each has a branch (simulating PR branches)
+    // - Squash merge commit A to main (creates new SHA)
+    // - Rebase branch B onto new main
+    // - Verify branch B now has only its own commit (not the old A)
+
+    let (_temp_dir, repo_path, _remote_path) = create_test_repo_with_remote();
+
+    // Set up gg config
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .expect("Failed to write config");
+
+    // Create stack with gg co
+    let (success, _, stderr) = run_gg(&repo_path, &["co", "stacked-test"]);
+    assert!(success, "Failed to create stack: {}", stderr);
+
+    // Create commit A
+    fs::write(repo_path.join("file_a.txt"), "content A").expect("Failed to write file A");
+    run_git(&repo_path, &["add", "."]);
+    run_git(
+        &repo_path,
+        &["commit", "-m", "feat: commit A\n\nGG-ID: c-aaa1111"],
+    );
+
+    // Create branch for commit A (simulating PR branch)
+    run_git(&repo_path, &["branch", "pr-branch-a"]);
+
+    // Create commit B
+    fs::write(repo_path.join("file_b.txt"), "content B").expect("Failed to write file B");
+    run_git(&repo_path, &["add", "."]);
+    run_git(
+        &repo_path,
+        &["commit", "-m", "feat: commit B\n\nGG-ID: c-bbb2222"],
+    );
+
+    // Create branch for commit B
+    run_git(&repo_path, &["branch", "pr-branch-b"]);
+
+    // Create commit C
+    fs::write(repo_path.join("file_c.txt"), "content C").expect("Failed to write file C");
+    run_git(&repo_path, &["add", "."]);
+    run_git(
+        &repo_path,
+        &["commit", "-m", "feat: commit C\n\nGG-ID: c-ccc3333"],
+    );
+
+    // Create branch for commit C
+    run_git(&repo_path, &["branch", "pr-branch-c"]);
+
+    // Get SHA of commit A on the stack branch
+    let (_, old_a_sha) = run_git(&repo_path, &["rev-parse", "pr-branch-a"]);
+    let old_a_sha = old_a_sha.trim();
+
+    // Now simulate a squash merge of commit A to main
+    // This creates a NEW commit with DIFFERENT SHA but same content
+    run_git(&repo_path, &["checkout", "main"]);
+
+    // Cherry-pick with squash (simulates GitHub squash merge)
+    fs::write(repo_path.join("file_a.txt"), "content A").expect("Failed to write file A");
+    run_git(&repo_path, &["add", "."]);
+    run_git(
+        &repo_path,
+        &["commit", "-m", "feat: commit A (#1)\n\nSquash merged"],
+    );
+
+    // Push the updated main
+    run_git(&repo_path, &["push", "origin", "main"]);
+
+    // Get the new SHA on main
+    let (_, new_main_sha) = run_git(&repo_path, &["rev-parse", "HEAD"]);
+    let new_main_sha = new_main_sha.trim();
+
+    // Verify the SHAs are different (squash creates new commit)
+    assert_ne!(
+        old_a_sha, new_main_sha,
+        "Squash merge should create different SHA"
+    );
+
+    // Now the critical part: rebase pr-branch-b onto the new main
+    // This is what gg land does after merging each PR
+    run_git(&repo_path, &["checkout", "pr-branch-b"]);
+
+    // Before rebase: branch B has commits A and B
+    let (_, log_before) = run_git(&repo_path, &["log", "--oneline", "main..HEAD"]);
+    let commits_before: Vec<&str> = log_before.trim().lines().collect();
+    assert_eq!(
+        commits_before.len(),
+        2,
+        "Before rebase: should have 2 commits (A and B)"
+    );
+
+    // Rebase onto the updated main
+    let (success, _) = run_git(&repo_path, &["rebase", "main"]);
+    assert!(success, "Rebase should succeed");
+
+    // After rebase: branch B should only have commit B
+    let (_, log_after) = run_git(&repo_path, &["log", "--oneline", "main..HEAD"]);
+    let commits_after: Vec<&str> = log_after.trim().lines().collect();
+    assert_eq!(
+        commits_after.len(),
+        1,
+        "After rebase: should have 1 commit (only B)"
+    );
+    assert!(
+        log_after.contains("commit B"),
+        "Should still have commit B: {}",
+        log_after
+    );
+
+    // Verify the rebased branch can be pushed (simulating force-push)
+    let (_success, _) = run_git(&repo_path, &["push", "-f", "origin", "pr-branch-b"]);
+    // Note: This might fail if branch doesn't exist on remote, which is fine for this test
+    // The important part is that the rebase succeeded
+}
+
+#[test]
+fn test_rebase_chain_after_multiple_squash_merges() {
+    // This test verifies that we can rebase a chain of branches
+    // after multiple squash merges (landing PR 1, then PR 2, etc.)
+
+    let (_temp_dir, repo_path, _remote_path) = create_test_repo_with_remote();
+
+    // Set up gg config
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .expect("Failed to write config");
+
+    // Create stack
+    let (success, _, stderr) = run_gg(&repo_path, &["co", "chain-test"]);
+    assert!(success, "Failed to create stack: {}", stderr);
+
+    // Create 3 commits with branches
+    for (letter, num) in [('a', 1), ('b', 2), ('c', 3)] {
+        let filename = format!("file_{}.txt", letter);
+        let content = format!("content {}", letter.to_uppercase());
+        fs::write(repo_path.join(&filename), &content).expect("Failed to write file");
+        run_git(&repo_path, &["add", "."]);
+        run_git(
+            &repo_path,
+            &[
+                "commit",
+                "-m",
+                &format!(
+                    "feat: commit {}\n\nGG-ID: c-{}{}{}",
+                    letter.to_uppercase(),
+                    letter,
+                    letter,
+                    num
+                ),
+            ],
+        );
+        run_git(&repo_path, &["branch", &format!("pr-branch-{}", letter)]);
+    }
+
+    // Simulate landing PR A (squash merge to main)
+    run_git(&repo_path, &["checkout", "main"]);
+    fs::write(repo_path.join("file_a.txt"), "content A").expect("Failed to write");
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "feat: commit A (#1)"]);
+    run_git(&repo_path, &["push", "origin", "main"]);
+
+    // Rebase remaining branches (B and C) onto new main
+    run_git(&repo_path, &["checkout", "pr-branch-b"]);
+    let (success, _) = run_git(&repo_path, &["rebase", "main"]);
+    assert!(success, "Rebase of B should succeed");
+
+    run_git(&repo_path, &["checkout", "pr-branch-c"]);
+    let (success, _) = run_git(&repo_path, &["rebase", "pr-branch-b"]);
+    assert!(success, "Rebase of C onto B should succeed");
+
+    // Simulate landing PR B (squash merge)
+    run_git(&repo_path, &["checkout", "main"]);
+    fs::write(repo_path.join("file_b.txt"), "content B").expect("Failed to write");
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "feat: commit B (#2)"]);
+    run_git(&repo_path, &["push", "origin", "main"]);
+
+    // Rebase C onto the new main
+    run_git(&repo_path, &["checkout", "pr-branch-c"]);
+    let (success, _) = run_git(&repo_path, &["rebase", "main"]);
+    assert!(success, "Rebase of C after B landed should succeed");
+
+    // Verify C only has one commit now
+    let (_, log) = run_git(&repo_path, &["log", "--oneline", "main..HEAD"]);
+    let commits: Vec<&str> = log.trim().lines().collect();
+    assert_eq!(
+        commits.len(),
+        1,
+        "C should only have 1 commit after all rebases"
+    );
+    assert!(log.contains("commit C"), "Should be commit C: {}", log);
+}


### PR DESCRIPTION
Follow-up to PR #106.

Adds integration tests that verify the mechanics behind `gg land --all`:

## Tests Added

### `test_stacked_branches_can_rebase_after_squash_merge`
- Creates a stack of 3 commits (A → B → C) with branches
- Simulates squash merge of commit A to main
- Verifies that branch B can be rebased onto the new main
- Confirms branch B only has its own commit after rebase

### `test_rebase_chain_after_multiple_squash_merges`
- Creates 3 commits with branches
- Simulates sequential landing: merge A, rebase B/C, merge B, rebase C
- Verifies the chain of rebases works correctly
- Confirms each branch ends up with only its own commit

These tests verify the core git mechanics that PR #106's `rebase_remaining_branches()` relies on.