### PR TITLE
fix: remove redundant Draft: prefix for GitLab MRs

### DIFF
--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -270,12 +270,7 @@ pub fn run(
         }
         let entry_draft = force_draft;
 
-        let mut title = clean_title(&raw_title);
-        // GitLab draft-ness is encoded in the title prefix. If we're forcing draft
-        // due to an earlier WIP/Draft commit, ensure the title carries the prefix.
-        if entry_draft && matches!(provider, Provider::GitLab) && !is_wip_or_draft_prefix(&title) {
-            title = format!("Draft: {}", title);
-        }
+        let title = clean_title(&raw_title);
 
         let (title, description) = build_pr_payload(
             &title,


### PR DESCRIPTION
## Problem

When using `gg sync --draft` with GitLab, MR titles end up with double prefix like:

```
Draft: Draft: Migrate publisher apps fetching from v2 to v3 paging API
```

## Cause

1. `sync.rs` was manually adding "Draft: " prefix to the title for GitLab
2. The `glab mr create --draft` command also adds "Draft: " when the flag is passed

## Solution

Remove the manual prefix addition in `sync.rs` since the `--draft` flag already handles it correctly through the GitLab API/CLI.

## Testing

- All 78 tests pass
- Manual testing recommended on GitLab