### PR TITLE
fix: sort merge train results ascending to fix position calculation

### DIFF
--- a/src/glab.rs
+++ b/src/glab.rs
@@ -678,7 +678,7 @@ pub fn get_merge_train_status(mr_number: u64, target_branch: &str) -> Result<Mer
     let output = Command::new("glab")
         .args([
             "api",
-            &format!("projects/:id/merge_trains/{}", target_branch),
+            &format!("projects/:id/merge_trains/{}?sort=asc", target_branch),
         ])
         .output()?;
 


### PR DESCRIPTION
## Problem

In `gg land --wait`, the merge train position was being reported incorrectly.

## Root Cause

The function `get_merge_train_status()` in `src/glab.rs` calls the GitLab API:
```
GET /projects/:id/merge_trains/:target_branch
```

Without an explicit `sort` parameter, the API defaults to `sort=desc`, which means:
- The first element in the returned array is the **last** MR added to the merge train
- The last element is the **first** MR in the queue (next to be merged)

The code then uses `idx + 1` to calculate position, which gives the wrong result.

## Fix

Added `?sort=asc` to the API call:
```rust
&format!("projects/:id/merge_trains/{}?sort=asc", target_branch)
```

Now the array is sorted by merge order (first to merge = index 0), making `idx + 1` give the correct position.

## Testing

- ✅ All existing tests pass (`cargo test`)
- ✅ No clippy warnings (`cargo clippy --all-targets --all-features -- -D warnings`)
- ✅ Code formatted (`cargo fmt --all`)