### PR TITLE
fix: use hidden progress bar when stderr is not a TTY

### DIFF
--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -245,13 +245,18 @@ pub fn run(
     let pr_template = template::load_template(git_dir);
 
     // Sync progress
-    let pb = ProgressBar::new(entries_to_sync.len() as u64);
-    pb.set_style(
-        ProgressStyle::default_bar()
-            .template("{spinner:.green} [{bar:40.cyan/blue}] {pos}/{len} {msg}")
-            .unwrap()
-            .progress_chars("=>-"),
-    );
+    let pb = if atty::is(atty::Stream::Stderr) {
+        let pb = ProgressBar::new(entries_to_sync.len() as u64);
+        pb.set_style(
+            ProgressStyle::default_bar()
+                .template("{spinner:.green} [{bar:40.cyan/blue}] {pos}/{len} {msg}")
+                .unwrap()
+                .progress_chars("=>-"),
+        );
+        pb
+    } else {
+        ProgressBar::hidden()
+    };
 
     // Process each entry
     // If a commit title starts with "WIP:" or "Draft:" (case-insensitive),


### PR DESCRIPTION
## Summary
- fix `gg sync` progress handling when stderr is not an interactive terminal
- use `ProgressBar::hidden()` when `stderr` is piped/non-TTY
- keep the existing styled progress bar only for TTY stderr

## Why
`gg sync` can hang when output is piped, for example:

```bash
gg sync 2>&1 | tee log
```

This happens because indicatif's visible `ProgressBar` writes to non-TTY stderr and can block, especially when syncing multiple entries.

Using a hidden progress bar for non-TTY stderr avoids the hang and makes `gg sync` safe for CI, automation, and scripted usage.
