### PR TITLE
Add configurable unstaged_action for gg amend

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,8 @@ Configuration is stored in `.git/gg/config.json`. Run `gg setup` to generate it 
     "lint": [
       "cargo fmt --check",
       "cargo clippy -- -D warnings"
-    ]
+    ],
+    "unstaged_action": "ask"
   },
   "stacks": {
     "my-feature": {
@@ -265,6 +266,7 @@ All configuration options are in the `defaults` section (with provider-specific 
 | `branch_username` | `string` | Username prefix for branch naming | Auto-detect via `gh whoami`/`glab whoami` |
 | `lint` | `array` | Lint commands to run on each commit with `gg lint` | `[]` |
 | `auto_add_gg_ids` | `boolean` | Automatically add GG-IDs to commits without prompting | `true` |
+| `unstaged_action` | `string` | Default behavior for `gg sc`/`gg amend` when unstaged changes exist: `"ask"` (prompt), `"stash"` (auto-stash), `"continue"` (ignore unstaged), `"abort"` (fail) | `"ask"` |
 | `land_wait_timeout_minutes` | `number` | Timeout in minutes for `gg land --wait` | `30` |
 | `land_auto_clean` | `boolean` | Automatically clean up stack after landing all PRs/MRs | `false` |
 | `sync_auto_lint` | `boolean` | Automatically run `gg lint` before `gg sync` | `false` |
@@ -285,6 +287,7 @@ Example configuration:
       "cargo clippy -- -D warnings"
     ],
     "auto_add_gg_ids": true,
+    "unstaged_action": "ask",
     "land_wait_timeout_minutes": 60,
     "land_auto_clean": true,
     "sync_auto_lint": true,

--- a/docs/src/commands/sc.md
+++ b/docs/src/commands/sc.md
@@ -10,6 +10,13 @@ gg sc [OPTIONS]
 
 - `-a, --all`: Include staged and unstaged changes
 
+When unstaged changes are present, behavior is controlled by `defaults.unstaged_action` in `.git/gg/config.json`:
+
+- `ask` (default): prompt to stash, continue, or abort
+- `stash`: auto-stash and continue
+- `continue`: continue without including unstaged changes
+- `abort`: fail immediately
+
 ## Examples
 
 ```bash

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -21,6 +21,7 @@ gg setup
       "cargo clippy -- -D warnings"
     ],
     "auto_add_gg_ids": true,
+    "unstaged_action": "ask",
     "land_wait_timeout_minutes": 30,
     "land_auto_clean": false,
     "sync_auto_lint": false,
@@ -43,6 +44,7 @@ gg setup
 | `branch_username` | `string` | Username prefix in stack/entry branch names | Auto-detected |
 | `lint` | `string[]` | Commands used by `gg lint` / `gg sync --lint` | `[]` |
 | `auto_add_gg_ids` | `boolean` | Auto-add GG-ID trailers when missing | `true` |
+| `unstaged_action` | `string` | Default behavior for `gg sc`/`gg amend` when unstaged changes exist: `ask`, `stash`, `continue`, or `abort` | `ask` |
 | `land_wait_timeout_minutes` | `number` | Timeout for `gg land --wait` polling | `30` |
 | `land_auto_clean` | `boolean` | Auto-run cleanup after full landing | `false` |
 | `sync_auto_lint` | `boolean` | Automatically run `gg lint` before `gg sync` | `false` |


### PR DESCRIPTION
Adds `defaults.unstaged_action` config option with values: `ask` (default, prompt), `stash` (auto-stash), `continue` (ignore), `abort` (always fail). Written explicitly by `gg setup`. Documented in README and docs.