### PR TITLE
Add unstaged_action=add option to stage all and continue

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ All configuration options are in the `defaults` section (with provider-specific 
 | `branch_username` | `string` | Username prefix for branch naming | Auto-detect via `gh whoami`/`glab whoami` |
 | `lint` | `array` | Lint commands to run on each commit with `gg lint` | `[]` |
 | `auto_add_gg_ids` | `boolean` | Automatically add GG-IDs to commits without prompting | `true` |
-| `unstaged_action` | `string` | Default behavior for `gg sc`/`gg amend` when unstaged changes exist: `"ask"` (prompt), `"stash"` (auto-stash), `"continue"` (ignore unstaged), `"abort"` (fail) | `"ask"` |
+| `unstaged_action` | `string` | Default behavior for `gg sc`/`gg amend` when unstaged changes exist: `"ask"` (prompt), `"add"` (stage all changes), `"stash"` (auto-stash), `"continue"` (ignore unstaged), `"abort"` (fail) | `"ask"` |
 | `land_wait_timeout_minutes` | `number` | Timeout in minutes for `gg land --wait` | `30` |
 | `land_auto_clean` | `boolean` | Automatically clean up stack after landing all PRs/MRs | `false` |
 | `sync_auto_lint` | `boolean` | Automatically run `gg lint` before `gg sync` | `false` |

--- a/docs/src/commands/sc.md
+++ b/docs/src/commands/sc.md
@@ -12,7 +12,8 @@ gg sc [OPTIONS]
 
 When unstaged changes are present, behavior is controlled by `defaults.unstaged_action` in `.git/gg/config.json`:
 
-- `ask` (default): prompt to stash, continue, or abort
+- `ask` (default): prompt to stage all, stash, continue, or abort
+- `add`: auto-stage all changes (`git add -A`) and continue
 - `stash`: auto-stash and continue
 - `continue`: continue without including unstaged changes
 - `abort`: fail immediately

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -44,7 +44,7 @@ gg setup
 | `branch_username` | `string` | Username prefix in stack/entry branch names | Auto-detected |
 | `lint` | `string[]` | Commands used by `gg lint` / `gg sync --lint` | `[]` |
 | `auto_add_gg_ids` | `boolean` | Auto-add GG-ID trailers when missing | `true` |
-| `unstaged_action` | `string` | Default behavior for `gg sc`/`gg amend` when unstaged changes exist: `ask`, `stash`, `continue`, or `abort` | `ask` |
+| `unstaged_action` | `string` | Default behavior for `gg sc`/`gg amend` when unstaged changes exist: `ask`, `add`, `stash`, `continue`, or `abort` | `ask` |
 | `land_wait_timeout_minutes` | `number` | Timeout for `gg land --wait` polling | `30` |
 | `land_auto_clean` | `boolean` | Auto-run cleanup after full landing | `false` |
 | `sync_auto_lint` | `boolean` | Automatically run `gg lint` before `gg sync` | `false` |

--- a/src/config.rs
+++ b/src/config.rs
@@ -97,6 +97,8 @@ pub enum UnstagedAction {
     /// Prompt the user to choose what to do.
     #[default]
     Ask,
+    /// Stage all changes (including untracked files) and continue automatically.
+    Add,
     /// Stash unstaged changes and continue automatically.
     Stash,
     /// Continue without including unstaged changes.
@@ -639,5 +641,12 @@ mod tests {
         let config: Config =
             serde_json::from_str(r#"{"defaults":{"unstaged_action":"stash"}}"#).unwrap();
         assert_eq!(config.get_unstaged_action(), UnstagedAction::Stash);
+    }
+
+    #[test]
+    fn test_unstaged_action_deserializes_add_when_present() {
+        let config: Config =
+            serde_json::from_str(r#"{"defaults":{"unstaged_action":"add"}}"#).unwrap();
+        assert_eq!(config.get_unstaged_action(), UnstagedAction::Add);
     }
 }


### PR DESCRIPTION
Adds a new unstaged_action option (add) for gg amend/gg sc that stages all changes via git add -A and proceeds. Also available in the interactive prompt as 'Stage all and continue'. Docs and tests updated.