### PR TITLE
fix: use dynamic PR/MR label in user-facing messages

### DIFF
--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -172,14 +172,21 @@ pub fn run(stack_name: Option<String>, base: Option<String>, use_worktree: bool)
                 import_pr_mappings_for_remote_stack(&repo, &mut config, &username, &stack_name)
             {
                 println!(
-                    "{} Could not import PR mappings: {}",
+                    "{} Could not import PR/MR mappings: {}",
                     style("Warning:").yellow(),
                     e
                 );
+                let prs_label = Provider::detect(&repo)
+                    .ok()
+                    .map(|provider| format!("{}s", provider.pr_label()))
+                    .unwrap_or_else(|| "PRs/MRs".to_string());
                 println!(
                     "{}",
-                    style("Continuing without PR mappings. Run `gg sync` to create/update PRs.")
-                        .dim()
+                    style(format!(
+                        "Continuing without PR/MR mappings. Run `gg sync` to create/update {}.",
+                        prs_label
+                    ))
+                    .dim()
                 );
             }
 
@@ -477,9 +484,10 @@ fn import_pr_mappings_for_remote_stack(
         // Save config with new mappings
         config.save(git_dir)?;
         println!(
-            "{} Imported {} PR mapping(s) for stack {}",
+            "{} Imported {} {} mapping(s) for stack {}",
             style("→").cyan(),
             imported_count,
+            provider.pr_label(),
             style(stack_name).cyan()
         );
     }

--- a/src/commands/land.rs
+++ b/src/commands/land.rs
@@ -287,7 +287,11 @@ pub fn run(
     if merge_trains_enabled {
         println!(
             "{}",
-            style("Merge trains enabled - MRs will be added to the merge train").dim()
+            style(format!(
+                "Merge trains enabled - {}s will be added to the merge train",
+                provider.pr_label()
+            ))
+            .dim()
         );
     }
 
@@ -574,8 +578,11 @@ pub fn run(
                                 );
                                 println!(
                                     "{}",
-                                    style("  You may need to rebase the remaining PRs manually.")
-                                        .dim()
+                                    style(format!(
+                                        "  You may need to rebase the remaining {}s manually.",
+                                        provider.pr_label()
+                                    ))
+                                    .dim()
                                 );
                                 break 'landing_loop;
                             }
@@ -604,7 +611,10 @@ pub fn run(
                         // Without --wait, stop after queuing
                         println!(
                             "{}",
-                            style("  Note: MR is queued but not yet merged. Run `gg land --wait` to wait for merge completion.")
+                            style(format!(
+                                "  Note: {} is queued but not yet merged. Run `gg land --wait` to wait for merge completion.",
+                                provider.pr_label()
+                            ))
                                 .dim()
                         );
                         // Note: We intentionally do NOT clean up config mappings or increment
@@ -673,8 +683,11 @@ pub fn run(
                                 );
                                 println!(
                                     "{}",
-                                    style("  You may need to rebase the remaining PRs manually.")
-                                        .dim()
+                                    style(format!(
+                                        "  You may need to rebase the remaining {}s manually.",
+                                        provider.pr_label()
+                                    ))
+                                    .dim()
                                 );
                                 break 'landing_loop;
                             }
@@ -703,7 +716,10 @@ pub fn run(
                         // Without --wait, stop after noting it's queued
                         println!(
                             "{}",
-                            style("  Note: MR is queued but not yet merged. Run `gg land --wait` to wait for merge completion.")
+                            style(format!(
+                                "  Note: {} is queued but not yet merged. Run `gg land --wait` to wait for merge completion.",
+                                provider.pr_label()
+                            ))
                                 .dim()
                         );
                         // Note: We intentionally do NOT clean up here - MR is not merged yet.
@@ -743,7 +759,10 @@ pub fn run(
                     );
                     println!(
                         "{}",
-                        style("  Note: MR is queued but not yet merged. Run `gg land` again after it merges to clean up.")
+                        style(format!(
+                            "  Note: {} is queued but not yet merged. Run `gg land` again after it merges to clean up.",
+                            provider.pr_label()
+                        ))
                             .dim()
                     );
                     // Note: We intentionally do NOT increment landed_count or clean up
@@ -760,7 +779,10 @@ pub fn run(
                     );
                     println!(
                         "{}",
-                        style("  Note: MR is queued but not yet merged. Run `gg land` again after it merges to clean up.")
+                        style(format!(
+                            "  Note: {} is queued but not yet merged. Run `gg land` again after it merges to clean up.",
+                            provider.pr_label()
+                        ))
                             .dim()
                     );
                     // Note: We intentionally do NOT increment landed_count or clean up here.
@@ -827,7 +849,11 @@ pub fn run(
                             );
                             println!(
                                 "{}",
-                                style("  You may need to rebase the remaining PRs manually.").dim()
+                                style(format!(
+                                    "  You may need to rebase the remaining {}s manually.",
+                                    provider.pr_label()
+                                ))
+                                .dim()
                             );
                             break 'landing_loop;
                         }
@@ -896,7 +922,10 @@ pub fn run(
                 // Interactive prompt (only if stdout is a TTY)
                 println!();
                 Confirm::new()
-                    .with_prompt("All PRs merged successfully. Clean up this stack?")
+                    .with_prompt(format!(
+                        "All {}s merged successfully. Clean up this stack?",
+                        provider.pr_label()
+                    ))
                     .default(false)
                     .interact()
                     .unwrap_or(false)

--- a/src/commands/ls.rs
+++ b/src/commands/ls.rs
@@ -34,7 +34,7 @@ pub fn run(all: bool, refresh: bool, remote: bool, json: bool) -> Result<()> {
             if refresh {
                 let provider = Provider::detect(&repo)?;
                 if !json {
-                    print!("Refreshing MR status... ");
+                    print!("Refreshing {} status... ", provider.pr_label());
                 }
                 stack.refresh_mr_info(&provider)?;
                 if !json {

--- a/src/commands/reconcile.rs
+++ b/src/commands/reconcile.rs
@@ -96,7 +96,7 @@ pub fn run(dry_run: bool) -> Result<()> {
         } else {
             println!(
                 "{}",
-                style("  (Skipping PR discovery - provider not authenticated)").dim()
+                style("  (Skipping PR/MR discovery - provider not authenticated)").dim()
             );
             Vec::new()
         }
@@ -201,8 +201,9 @@ fn find_unmapped_prs(
             Err(e) => {
                 // Log warning but continue
                 eprintln!(
-                    "{} Could not search PRs for {}: {}",
+                    "{} Could not search {}s for {}: {}",
                     style("Warning:").yellow(),
+                    provider.pr_label(),
                     entry_branch,
                     e
                 );

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -35,11 +35,17 @@ fn maybe_rebase_if_base_is_behind(
         return Ok(());
     }
 
+    let prs_label = Provider::detect(repo)
+        .ok()
+        .map(|provider| format!("{}s", provider.pr_label()))
+        .unwrap_or_else(|| "PRs/MRs".to_string());
+
     println!(
-        "{} Your stack is {} commits behind origin/{}. PRs may show unrelated changes. Run 'gg rebase' first to update.",
+        "{} Your stack is {} commits behind origin/{}. {} may show unrelated changes. Run 'gg rebase' first to update.",
         style("⚠").yellow().bold(),
         behind,
-        base_branch
+        base_branch,
+        prs_label
     );
 
     if config.get_sync_auto_rebase() {


### PR DESCRIPTION
## Summary
- replace hardcoded PR/MR user-facing labels with provider-aware labels via provider.pr_label() where provider is available
- use fallback PRs/MRs in early sync/checkout paths when provider may be unavailable
- update related user-facing messages in sync, checkout, reconcile, land, and ls

## Validation
- cargo fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-features
