### PR TITLE
fix: show message when PR/MR is already merged or closed during land

### DIFF
--- a/src/commands/land.rs
+++ b/src/commands/land.rs
@@ -384,6 +384,16 @@ pub fn run(
                     } else if info.state == PrState::Merged {
                         if let Some(gg_id) = &entry.gg_id {
                             if seen_already_merged.insert(gg_id.clone()) {
+                                if !json {
+                                    println!(
+                                        "{} {} {}{} ({}) — already merged",
+                                        style("→").cyan(),
+                                        provider.pr_label(),
+                                        provider.pr_number_prefix(),
+                                        num,
+                                        entry.title
+                                    );
+                                }
                                 landed_entries.push(LandedEntryJson {
                                     position: entry.position,
                                     sha: entry.short_sha.clone(),
@@ -400,6 +410,16 @@ pub fn run(
                     } else if info.state == PrState::Closed {
                         if let Some(gg_id) = &entry.gg_id {
                             if seen_closed.insert(gg_id.clone()) {
+                                if !json {
+                                    println!(
+                                        "{} {} {}{} ({}) — closed, skipping",
+                                        style("⚠").yellow(),
+                                        provider.pr_label(),
+                                        provider.pr_number_prefix(),
+                                        num,
+                                        entry.title
+                                    );
+                                }
                                 landed_entries.push(LandedEntryJson {
                                     position: entry.position,
                                     sha: entry.short_sha.clone(),
@@ -457,6 +477,16 @@ pub fn run(
         match pr_info.state {
             PrState::Merged => {
                 if seen_already_merged.insert(gg_id.clone()) {
+                    if !json {
+                        println!(
+                            "{} {} {}{} ({}) — already merged",
+                            style("→").cyan(),
+                            provider.pr_label(),
+                            provider.pr_number_prefix(),
+                            pr_num,
+                            entry.title
+                        );
+                    }
                     landed_entries.push(LandedEntryJson {
                         position: entry.position,
                         sha: entry.short_sha.clone(),
@@ -472,6 +502,16 @@ pub fn run(
             }
             PrState::Closed => {
                 if seen_closed.insert(gg_id.clone()) {
+                    if !json {
+                        println!(
+                            "{} {} {}{} ({}) — closed, skipping",
+                            style("⚠").yellow(),
+                            provider.pr_label(),
+                            provider.pr_number_prefix(),
+                            pr_num,
+                            entry.title
+                        );
+                    }
                     landed_entries.push(LandedEntryJson {
                         position: entry.position,
                         sha: entry.short_sha.clone(),


### PR DESCRIPTION
## Problem

When running `gg land` and the PR/MR was already merged, the command only showed `Checking PR status...` and then silently exited (or showed a generic `Landed X PR(s)` without explaining they were already merged). Same for closed PRs — no output at all.

## Solution

Added user-visible messages when encountering already-merged or closed PRs/MRs:

```
Checking PR status...
→ PR #42 (Fix error handling) — already merged
→ PR #43 (Add logging) — already merged

OK Landed 2 PR(s)
```

For closed PRs:
```
⚠ PR #44 (Refactor module) — closed, skipping
```

Works for both GitHub PRs and GitLab MRs. JSON output (`--json`) is unchanged.