### PR TITLE
fix: wait for approval before merge train + don't repeat idle message

### DIFF
--- a/docs/src/commands/land.md
+++ b/docs/src/commands/land.md
@@ -36,6 +36,14 @@ gg land --all --auto-merge
 gg land --all --json
 ```
 
+## Merge Trains (GitLab)
+
+When merge trains are enabled on the target branch, `gg land` automatically adds MRs to the merge train instead of merging directly.
+
+**Approval is always required** before an MR can enter the merge train queue — even with `--all`. If using `--wait`, the command will show "Waiting for approval..." until a reviewer approves the MR.
+
+## JSON Output
+
 Example JSON response:
 
 ```json

--- a/src/commands/land.rs
+++ b/src/commands/land.rs
@@ -2239,4 +2239,49 @@ mod tests {
         idle_count += 1;
         assert!(idle_count > IDLE_GRACE_POLLS);
     }
+
+    // ==========================================================================
+    // Tests for approval gate with merge trains
+    // ==========================================================================
+
+    #[test]
+    fn test_approval_not_skipped_when_merge_trains_enabled() {
+        // Simulates the condition in wait_for_pr_ready:
+        // `if skip_approval && !merge_trains_enabled`
+        let skip_approval = true; // --all flag
+        let merge_trains_enabled = true;
+
+        // With merge trains, approval should NOT be skipped
+        let actually_skip = skip_approval && !merge_trains_enabled;
+        assert!(
+            !actually_skip,
+            "Approval must not be skipped when merge trains are enabled"
+        );
+    }
+
+    #[test]
+    fn test_approval_skipped_without_merge_trains() {
+        // Without merge trains, --all should skip approval as before
+        let skip_approval = true;
+        let merge_trains_enabled = false;
+
+        let actually_skip = skip_approval && !merge_trains_enabled;
+        assert!(
+            actually_skip,
+            "Approval should be skipped with --all when merge trains are off"
+        );
+    }
+
+    #[test]
+    fn test_approval_not_skipped_without_all_flag() {
+        // Without --all, approval is always checked regardless of merge trains
+        let skip_approval = false;
+        let merge_trains_enabled = false;
+
+        let actually_skip = skip_approval && !merge_trains_enabled;
+        assert!(
+            !actually_skip,
+            "Approval should not be skipped without --all"
+        );
+    }
 }


### PR DESCRIPTION
## Problem 1: Skips approval check with merge trains

`gg land --wait --all` skips the approval check (by design for `--all`). But with GitLab merge trains, approval is required to enter the queue. The MR gets added to the train without approval, GitLab rejects it, and the command exits.

### Fix
When merge trains are enabled, always check for approval regardless of `--all`. The spinner shows "Waiting for approval..." until a reviewer approves.

## Problem 2: Repeated idle message

The "Waiting for merge train to pick up MR" message printed a new line every 10 seconds:
```
✓ 12s - Waiting for merge train to pick up MR (10s)...
✓ 12s - Waiting for merge train to pick up MR (20s)...
✓ 12s - Waiting for merge train to pick up MR (30s)...
```

### Fix
Use a static message so the spinner stays on one line, with the elapsed time updating in place:
```
⠏ 00:00:30 - Waiting for merge train to pick up MR...
```