### PR TITLE
feat: add agent skills plugin for GitHub and GitLab

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "git-gud",
   "description": "Stacked diffs CLI for GitHub and GitLab. Skills for creating, syncing, landing, and managing stacked PRs/MRs with gg.",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "author": {
     "name": "Nacho López",
     "url": "https://github.com/mrmans0n"

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -11,6 +11,7 @@
   - [Landing and Cleanup](./guides/landing-and-cleanup.md)
   - [Linting Your Stack](./guides/linting.md)
   - [Reconciling Out-of-Sync Stacks](./guides/reconciling.md)
+  - [Agent Skills Plugin](./guides/agent-skills.md)
 - [Command Reference](./commands/README.md)
   - [co (checkout)](./commands/co.md)
   - [ls](./commands/ls.md)

--- a/docs/src/guides/agent-skills.md
+++ b/docs/src/guides/agent-skills.md
@@ -1,0 +1,69 @@
+# Agent Skills Plugin
+
+git-gud ships as a [Claude Code plugin](https://code.claude.com/docs/en/plugins) and follows the open [Agent Skills](https://agentskills.io) standard. This means AI coding agents — Claude Code, Cursor, Gemini CLI, OpenAI Codex, and others — can learn to use `gg` for stacked-diff workflows.
+
+## What's included
+
+The plugin provides two skills:
+
+| Skill | Description |
+|-------|-------------|
+| `gg-github` | Use gg with GitHub PRs (`gh` CLI) |
+| `gg-gitlab` | Use gg with GitLab MRs (`glab` CLI, merge trains) |
+
+Each skill includes:
+
+- **SKILL.md** — concise instructions with agent operating rules
+- **reference.md** — full command reference with JSON output schemas
+- **examples/** — step-by-step workflow walkthroughs
+
+## Using with Claude Code
+
+Load the plugin from the git-gud repo:
+
+```bash
+claude --plugin-dir /path/to/git-gud
+```
+
+Then use the skills as slash commands:
+
+```
+/git-gud:gg-github
+/git-gud:gg-gitlab
+```
+
+Or let Claude pick them up automatically when you ask about stacked diffs or PRs.
+
+## Using with other tools
+
+Any tool supporting the Agent Skills standard can consume the skills from the `skills/` directory. The `SKILL.md` files use standard YAML frontmatter with `name` and `description` fields.
+
+## Agent operating rules
+
+The skills enforce several safety rules for AI agents:
+
+1. **Never land without user confirmation** — agents must always ask before merging
+2. **Always use `--json`** for parseable output
+3. **Prefer worktrees** (`gg co -w`) for isolation
+4. **Never `git add -A` blindly** — review and stage specific files only
+5. **Verify CI + approval** before suggesting to land
+
+## File structure
+
+```
+.claude-plugin/
+  plugin.json           # Plugin manifest
+skills/
+  gg-github/
+    SKILL.md            # GitHub skill
+    reference.md        # Command reference + JSON schemas
+    examples/
+      basic-flow.md     # Simple feature workflow
+      multi-commit.md   # Absorb, reorder, lint
+  gg-gitlab/
+    SKILL.md            # GitLab skill
+    reference.md        # Command reference + merge trains
+    examples/
+      basic-flow.md     # Simple feature workflow
+      merge-train.md    # Merge train workflow
+```

--- a/skills/gg-github/SKILL.md
+++ b/skills/gg-github/SKILL.md
@@ -51,7 +51,7 @@ gg co -w feature-auth
 2. Commit logical changes:
 
 ```bash
-git add -A
+git add <files>
 git commit -m "feat: add input validation"
 ```
 
@@ -76,11 +76,12 @@ gg land -a -c --json
 ## Agent operating rules (mandatory)
 
 1. **Never run `gg land` without explicit user confirmation.**
-2. **Always use `--json`** for `gg ls`, `gg sync`, `gg land`, `gg clean`, and `gg lint`.
+2. **Always use `--json`** for `gg ls`, `gg sync`, `gg land`, `gg clean -a`, and `gg lint`.
 3. **Prefer worktrees** for isolation (`gg co -w <stack>`).
 4. Verify `approved: true` and `ci_status` success before landing.
 5. If sync warns stack is behind base, run `gg rebase` first.
 6. Prefer `gg absorb -s` for multi-commit edits.
+7. **Never use `git add -A` blindly.** Review `git status` first and only stage intended files. Use `git add <specific-files>` to avoid leaking secrets, env files, or unrelated changes.
 
 ## Common operations
 
@@ -90,7 +91,7 @@ gg land -a -c --json
 - Reorder stack: `gg reorder -o "3,1,2"`
 - Sync subset: `gg sync -u <position|gg-id|sha> --json`
 - Lint stack: `gg lint --json`
-- Clean merged stacks: `gg clean --json`
+- Clean merged stacks: `gg clean -a --json`
 
 ## See also
 

--- a/skills/gg-github/examples/basic-flow.md
+++ b/skills/gg-github/examples/basic-flow.md
@@ -11,12 +11,12 @@ gg co -w add-user-validation
 ```bash
 # Commit 1
 $EDITOR src/validation/email.rs
-git add -A
+git add <files>
 git commit -m "feat: add email validation"
 
 # Commit 2
 $EDITOR src/validation/phone.rs
-git add -A
+git add <files>
 git commit -m "feat: add phone validation"
 ```
 
@@ -60,5 +60,5 @@ gg land -a -c --json
 ## 7) Optional cleanup check
 
 ```bash
-gg clean --json
+gg clean -a --json
 ```

--- a/skills/gg-github/examples/multi-commit.md
+++ b/skills/gg-github/examples/multi-commit.md
@@ -14,7 +14,7 @@ gg ls --json
 ```bash
 gg mv 1
 $EDITOR src/billing/parser.rs
-git add -A
+git add <files>
 gg sc
 ```
 
@@ -28,7 +28,7 @@ gg last
 
 ```bash
 $EDITOR src/billing/*.rs
-git add -A
+git add <files>
 gg absorb -s
 ```
 

--- a/skills/gg-github/reference.md
+++ b/skills/gg-github/reference.md
@@ -298,7 +298,7 @@ Field types:
 }
 ```
 
-### `gg clean --json`
+### `gg clean -a --json`
 
 ```json
 {

--- a/skills/gg-gitlab/SKILL.md
+++ b/skills/gg-gitlab/SKILL.md
@@ -54,7 +54,7 @@ gg co -w feature-payments
 2. Create commits and verify:
 
 ```bash
-git add -A
+git add <files>
 git commit -m "feat: add payment DTO"
 gg ls --json
 ```
@@ -78,11 +78,12 @@ gg land -a --auto-merge -w --json
 ## Agent operating rules (mandatory)
 
 1. **Never run `gg land` without explicit user confirmation.**
-2. **Always use `--json`** for `gg ls`, `gg sync`, `gg land`, `gg clean`, and `gg lint`.
+2. **Always use `--json`** for `gg ls`, `gg sync`, `gg land`, `gg clean -a`, and `gg lint`.
 3. **Prefer worktrees** with `gg co -w <stack>`.
 4. Check `approved: true` and CI success in `gg ls --json` before landing.
 5. For merge trains, monitor `in_merge_train` and `merge_train_position`.
 6. If stack is behind base, run `gg rebase` before syncing.
+7. **Never use `git add -A` blindly.** Review `git status` first and only stage intended files. Use `git add <specific-files>` to avoid leaking secrets, env files, or unrelated changes.
 
 ## GitLab notes
 

--- a/skills/gg-gitlab/examples/basic-flow.md
+++ b/skills/gg-gitlab/examples/basic-flow.md
@@ -10,11 +10,11 @@ gg co -w add-audit-events
 
 ```bash
 $EDITOR src/audit/model.rs
-git add -A
+git add <files>
 git commit -m "feat: add audit event model"
 
 $EDITOR src/audit/store.rs
-git add -A
+git add <files>
 git commit -m "feat: persist audit events"
 ```
 

--- a/skills/gg-gitlab/examples/merge-train.md
+++ b/skills/gg-gitlab/examples/merge-train.md
@@ -45,5 +45,5 @@ glab mr checks <iid>
 ## 5) Cleanup landed stacks
 
 ```bash
-gg clean --json
+gg clean -a --json
 ```

--- a/skills/gg-gitlab/reference.md
+++ b/skills/gg-gitlab/reference.md
@@ -284,7 +284,7 @@ All JSON payloads include `version` (`u32`, currently `1`).
 }
 ```
 
-### `gg clean --json`
+### `gg clean -a --json`
 
 ```json
 {


### PR DESCRIPTION
Adds Claude Code / Agent Skills plugin with two skills:

- **gg-github**: Teaches agents to use `gg` with GitHub PRs
- **gg-gitlab**: Teaches agents to use `gg` with GitLab MRs (includes merge trains)

Each skill includes:
- `SKILL.md` — main instructions with YAML frontmatter
- `reference.md` — full command reference with JSON output schemas
- `examples/` — step-by-step workflow examples

Follows the [Agent Skills](https://agentskills.io) open standard. Compatible with Claude Code, Cursor, Gemini CLI, Codex, and other tools.