### PR TITLE
feat: add gg-mcp to cargo-dist distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,6 +568,23 @@ Stacks must have linear history. Rebase your branch to remove merge commits:
 git rebase main
 ```
 
+## MCP Server
+
+git-gud includes an MCP (Model Context Protocol) server that lets AI assistants interact with your stacked-diffs workflows.
+
+```json
+{
+  "mcpServers": {
+    "git-gud": {
+      "command": "gg-mcp",
+      "env": { "GG_REPO_PATH": "/path/to/your/repo" }
+    }
+  }
+}
+```
+
+**16 tools** available: stack inspection, PR status, sync, land, rebase, navigation, and more. See the [MCP Server docs](https://mrmans0n.github.io/git-gud/mcp-server.html) for details.
+
 ## License
 
 MIT License - see [LICENSE](LICENSE) for details.

--- a/crates/gg-mcp/Cargo.toml
+++ b/crates/gg-mcp/Cargo.toml
@@ -6,6 +6,7 @@ description = "MCP server for git-gud (gg) stacked-diffs tool"
 authors = ["Nacho Lopez"]
 license = "MIT"
 repository = "https://github.com/mrmans0n/git-gud"
+homepage = "https://github.com/mrmans0n/git-gud"
 
 [[bin]]
 name = "gg-mcp"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["cargo:crates/gg-cli"]
+members = ["cargo:crates/gg-cli", "cargo:crates/gg-mcp"]
 
 # Config for 'dist'
 [dist]


### PR DESCRIPTION
## Summary

Phase 4 of MCP implementation: distribution and polish.

## Changes

- **dist-workspace.toml**: Added `cargo:crates/gg-mcp` to members — both `gg` and `gg-mcp` will be built on release
- **README.md**: Added MCP Server section with Claude Desktop config example
- **gg-mcp Cargo.toml**: Added homepage (fixes Homebrew publish warning)

## Verified

`dist plan` confirms both binaries produce:
- Archives for all 4 targets (aarch64/x86_64 × macOS/Linux)
- Separate Homebrew formulas (`gg-cli.rb` + `gg-mcp.rb`)

## Testing

- All 312 tests pass
- clippy clean, fmt clean