### PR TITLE
fix: add gg-mcp to dist-workspace members

### DIFF
--- a/crates/gg-mcp/Cargo.toml
+++ b/crates/gg-mcp/Cargo.toml
@@ -6,7 +6,7 @@ description = "MCP server for git-gud (gg) stacked-diffs tool"
 authors = ["Nacho Lopez"]
 license = "MIT"
 repository = "https://github.com/mrmans0n/git-gud"
-homepage = "https://github.com/mrmans0n/git-gud"
+homepage = "https://mrmans0n.github.io/git-gud/"
 
 [[bin]]
 name = "gg-mcp"


### PR DESCRIPTION
The change from PR #175 was lost when #176 replaced it with only README changes.

### Changes
- Re-add `gg-mcp` to `dist-workspace.toml` members so cargo-dist builds both binaries
- Add `homepage` to `gg-mcp/Cargo.toml` (fixes Homebrew formula warning)