### PR TITLE
fix(land): handle Ctrl+C promptly during --wait

### DIFF
--- a/crates/gg-core/src/commands/land.rs
+++ b/crates/gg-core/src/commands/land.rs
@@ -380,7 +380,10 @@ pub fn run(
         let json_mode = json;
         ctrlc::set_handler(move || {
             if flag_clone.load(Ordering::SeqCst) {
-                std::process::exit(130);
+                // Use abort() instead of process::exit(130) to avoid potential
+                // deadlock: process::exit calls fflush which needs the stdout
+                // lock, but the spinner thread (indicatif) may be holding it.
+                std::process::abort();
             }
 
             flag_clone.store(true, Ordering::SeqCst);


### PR DESCRIPTION
## Summary
- add an interruptible_sleep helper that sleeps in 250ms steps and checks the shared interrupt flag between steps
- use interruptible sleep in both wait loops used by gg land --wait (wait_for_pr_ready and wait_for_merge_train_completion)
- update the Ctrl+C handler so a second Ctrl+C force-exits with code 130
- add unit tests for the new interruptible sleep behavior

## Verification
- cargo fmt --all
- cargo check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test