### PR TITLE
fix(land): show CI failure details when landing stops

### DIFF
--- a/crates/gg-core/src/commands/land.rs
+++ b/crates/gg-core/src/commands/land.rs
@@ -867,14 +867,27 @@ pub fn run(
                 error: land_error,
             },
         });
-    } else if landed_count > 0 {
-        println!();
-        println!(
-            "{} Landed {} {}(s)",
-            style("OK").green().bold(),
-            landed_count,
-            provider.pr_label()
-        );
+    } else {
+        if landed_count > 0 {
+            println!();
+            println!(
+                "{} Landed {} {}(s)",
+                style("OK").green().bold(),
+                landed_count,
+                provider.pr_label()
+            );
+        }
+        if let Some(ref err) = land_error {
+            println!();
+            if landed_count > 0 {
+                println!("{} Stopped: {}", style("⚠").yellow(), err);
+            } else {
+                println!("{} {}", style("✗").red().bold(), err);
+            }
+        }
+        for warning in &warnings {
+            println!("{} {}", style("⚠").yellow(), warning);
+        }
     }
 
     Ok(())
@@ -1007,12 +1020,21 @@ fn wait_for_pr_ready(
                 if let Some(ref spinner) = current_spinner {
                     spinner.finish_and_clear();
                 }
-                return Err(GgError::Other(format!(
+                let mut msg = format!(
                     "{} {}{} CI failed",
                     provider.pr_label(),
                     provider.pr_number_prefix(),
                     pr_num
-                )));
+                );
+                if let Ok(failed_jobs) = provider.get_failed_ci_jobs(pr_num) {
+                    if !failed_jobs.is_empty() {
+                        msg.push_str(&format!(
+                            "\n  Failed jobs: {}",
+                            crate::glab::format_failed_jobs(&failed_jobs)
+                        ));
+                    }
+                }
+                return Err(GgError::Other(msg));
             }
             CiStatus::Canceled => {
                 if let Some(ref spinner) = current_spinner {

--- a/crates/gg-core/src/glab.rs
+++ b/crates/gg-core/src/glab.rs
@@ -671,6 +671,101 @@ pub fn add_to_merge_train(mr_number: u64) -> Result<AutoMergeResult> {
     Ok(AutoMergeResult::Queued)
 }
 
+/// A failed CI job with its name, stage, and optional URL
+#[derive(Debug, Clone)]
+pub struct FailedJob {
+    pub name: String,
+    pub stage: String,
+    pub web_url: Option<String>,
+}
+
+/// Get failed CI jobs for an MR's head pipeline.
+///
+/// Steps:
+/// 1. `glab mr view <mr_number> --output json` → extract `head_pipeline.id`
+/// 2. `glab api "projects/:id/pipelines/<id>/jobs"` → find jobs with status "failed"
+pub fn get_mr_failed_ci_jobs(mr_number: u64) -> Result<Vec<FailedJob>> {
+    // Step 1: Get MR details to find the head pipeline ID
+    let output = Command::new("glab")
+        .args(["mr", "view", &mr_number.to_string(), "--output", "json"])
+        .output()?;
+
+    if !output.status.success() {
+        return Ok(vec![]);
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mr_json: serde_json::Value = match serde_json::from_str(&stdout) {
+        Ok(v) => v,
+        Err(_) => return Ok(vec![]),
+    };
+
+    let pipeline_id = mr_json
+        .get("head_pipeline")
+        .and_then(|p| p.get("id"))
+        .and_then(|id| id.as_u64());
+
+    let pipeline_id = match pipeline_id {
+        Some(id) => id,
+        None => return Ok(vec![]),
+    };
+
+    // Step 2: Get jobs for this pipeline
+    let jobs_output = Command::new("glab")
+        .args([
+            "api",
+            &format!("projects/:id/pipelines/{}/jobs", pipeline_id),
+        ])
+        .output()?;
+
+    if !jobs_output.status.success() {
+        return Ok(vec![]);
+    }
+
+    let jobs_stdout = String::from_utf8_lossy(&jobs_output.stdout);
+
+    #[derive(Deserialize)]
+    struct JobJson {
+        name: String,
+        #[serde(default)]
+        stage: String,
+        status: String,
+        #[serde(default)]
+        web_url: Option<String>,
+    }
+
+    let jobs: Vec<JobJson> = match serde_json::from_str(&jobs_stdout) {
+        Ok(v) => v,
+        Err(_) => return Ok(vec![]),
+    };
+
+    let failed_jobs = jobs
+        .into_iter()
+        .filter(|j| j.status == "failed")
+        .map(|j| FailedJob {
+            name: j.name,
+            stage: j.stage,
+            web_url: j.web_url,
+        })
+        .collect();
+
+    Ok(failed_jobs)
+}
+
+/// Format failed jobs as a compact string for error messages
+pub fn format_failed_jobs(jobs: &[FailedJob]) -> String {
+    jobs.iter()
+        .map(|j| {
+            if j.stage.is_empty() {
+                j.name.clone()
+            } else {
+                format!("{} (stage: {})", j.name, j.stage)
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
 /// Get merge train status for an MR
 /// Returns information about the MR's position and status in the merge train
 pub fn get_merge_train_status(mr_number: u64, target_branch: &str) -> Result<MergeTrainInfo> {
@@ -1106,4 +1201,89 @@ mod tests {
     // 2. Return Ok(AutoMergeResult::AlreadyQueued) in that case
     // 3. Return Ok(AutoMergeResult::Queued) on success
     // 4. Return Err(...) for other errors
+
+    #[test]
+    fn test_failed_job_construction() {
+        let job = FailedJob {
+            name: "lint".to_string(),
+            stage: "test".to_string(),
+            web_url: Some("https://gitlab.com/job/1".to_string()),
+        };
+        assert_eq!(job.name, "lint");
+        assert_eq!(job.stage, "test");
+        assert_eq!(job.web_url, Some("https://gitlab.com/job/1".to_string()));
+    }
+
+    #[test]
+    fn test_failed_job_no_url() {
+        let job = FailedJob {
+            name: "build".to_string(),
+            stage: "build".to_string(),
+            web_url: None,
+        };
+        assert_eq!(job.name, "build");
+        assert!(job.web_url.is_none());
+    }
+
+    #[test]
+    fn test_format_failed_jobs_with_stages() {
+        let jobs = vec![
+            FailedJob {
+                name: "lint".to_string(),
+                stage: "test".to_string(),
+                web_url: None,
+            },
+            FailedJob {
+                name: "build-android".to_string(),
+                stage: "build".to_string(),
+                web_url: None,
+            },
+        ];
+        let formatted = format_failed_jobs(&jobs);
+        assert_eq!(
+            formatted,
+            "lint (stage: test), build-android (stage: build)"
+        );
+    }
+
+    #[test]
+    fn test_format_failed_jobs_without_stage() {
+        let jobs = vec![FailedJob {
+            name: "unit-tests".to_string(),
+            stage: String::new(),
+            web_url: None,
+        }];
+        let formatted = format_failed_jobs(&jobs);
+        assert_eq!(formatted, "unit-tests");
+    }
+
+    #[test]
+    fn test_format_failed_jobs_empty() {
+        let jobs: Vec<FailedJob> = vec![];
+        let formatted = format_failed_jobs(&jobs);
+        assert_eq!(formatted, "");
+    }
+
+    #[test]
+    fn test_format_failed_jobs_single() {
+        let jobs = vec![FailedJob {
+            name: "security-scan".to_string(),
+            stage: "security".to_string(),
+            web_url: Some("https://gitlab.com/job/99".to_string()),
+        }];
+        let formatted = format_failed_jobs(&jobs);
+        assert_eq!(formatted, "security-scan (stage: security)");
+    }
+
+    #[test]
+    fn test_failed_job_clone() {
+        let job = FailedJob {
+            name: "test".to_string(),
+            stage: "test".to_string(),
+            web_url: None,
+        };
+        let cloned = job.clone();
+        assert_eq!(cloned.name, job.name);
+        assert_eq!(cloned.stage, job.stage);
+    }
 }

--- a/crates/gg-core/src/provider.rs
+++ b/crates/gg-core/src/provider.rs
@@ -10,6 +10,8 @@ use crate::gh::{self, CiStatus as GhCiStatus, PrState as GhPrState};
 use crate::git;
 use crate::glab::{self, AutoMergeResult, CiStatus as GlabCiStatus, MrState as GlabMrState};
 
+pub use crate::glab::FailedJob;
+
 /// Supported git hosting providers
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Provider {
@@ -334,6 +336,16 @@ impl Provider {
         match self {
             Provider::GitHub => Ok(None),
             Provider::GitLab => Ok(Some(glab::get_merge_train_status(number, target_branch)?)),
+        }
+    }
+
+    /// Get failed CI jobs for a PR/MR's head pipeline.
+    ///
+    /// GitLab only — returns empty vec for GitHub (not yet implemented).
+    pub fn get_failed_ci_jobs(&self, number: u64) -> Result<Vec<FailedJob>> {
+        match self {
+            Provider::GitHub => Ok(vec![]),
+            Provider::GitLab => glab::get_mr_failed_ci_jobs(number),
         }
     }
 }


### PR DESCRIPTION
## Problem

When running `gg land --wait --all` with GitLab merge trains, if MR #1 merges successfully but MR #2's CI fails, the output only shows:

```
OK Landed 1 MR(s)
```

Users have no idea why it stopped or what went wrong.

## Solution

Enhanced the output to show:
1. The partial success count
2. A warning explaining why it stopped  
3. Details of which CI jobs failed (name + stage)

### New output example:
```
OK Landed 1 MR(s)

⚠ Stopped: MR !7621 CI failed
  Failed jobs: lint (stage: test), build-android (stage: build)
```

### When no MRs land (error only):
```
✗ MR !7621 CI failed
  Failed jobs: lint (stage: test)
```

## Changes

- **land.rs**: Enhanced output section to show `land_error` and warnings when `landed_count > 0`
- **land.rs**: `wait_for_pr_ready` now fetches failed job details on CI failure
- **glab.rs**: Added `get_mr_failed_ci_jobs()` to fetch pipeline job statuses via GitLab API
- **glab.rs**: Added `format_failed_jobs()` helper for error messages
- **provider.rs**: Added `get_failed_ci_jobs()` wrapper (GitLab only for now, returns empty for GitHub)

## Testing

- All existing tests pass
- Added unit tests for `FailedJob` struct and `format_failed_jobs()` helper