### PR TITLE
feat(core): add GG-Parent trailer for stack topology metadata

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,11 +85,11 @@ skills/
 
 ## Key Concepts
 
-### GG-ID System
+### GG-ID and GG-Parent System
 - Stable identifier format: `c-` + 7 UUID chars (e.g., `c-abc1234`)
-- Stored as trailer in commit messages: `GG-ID: c-abc1234`
-- Persists through rebases/reorders
-- Used to track commit-to-MR mappings
+- `GG-ID: c-abc1234` — identifies the commit; persists through rebases/reorders; used to track commit-to-MR mappings
+- `GG-Parent: c-1234567` — points to the previous entry's GG-ID; encodes stack topology in commit metadata
+- First entry has no GG-Parent; managed automatically by sync, reconcile, reorder, drop, split
 
 ### Branch Naming Convention
 - Stack branch: `<username>/<stack-name>` (e.g., `nacho/my-feature`)

--- a/README.md
+++ b/README.md
@@ -353,19 +353,23 @@ If no template file exists, git-gud uses the commit description directly, or a d
 - **Stack branch**: `<username>/<stack-name>` (e.g., `nacho/my-feature`)
 - **Per-commit branches**: `<username>/<stack-name>--<entry-id>` (e.g., `nacho/my-feature--c-abc1234`)
 
-### GG-ID Trailers
+### GG-ID and GG-Parent Trailers
 
-Each commit gets a stable `GG-ID` trailer that persists across rebases:
+Each commit gets stable trailers that persist across rebases:
 
 ```
 Add user authentication
 
 Implement JWT-based auth with refresh tokens.
 
+GG-Parent: c-1234567
 GG-ID: c-abc1234
 ```
 
-This ID is used to track which PR/MR corresponds to which commit, even after reordering or amending.
+- **GG-ID** tracks which PR/MR corresponds to which commit, even after reordering or amending.
+- **GG-Parent** records the previous entry's GG-ID, encoding stack topology directly in commit metadata. The first entry has no `GG-Parent`.
+
+Both trailers are managed automatically by `gg sync`, `gg reconcile`, `gg reorder`, `gg drop`, and `gg split`.
 
 ### PR/MR Dependencies
 
@@ -496,6 +500,7 @@ $ gg reconcile --dry-run
 → 2 commits need GG-IDs:
   • abc1234 Add data model
   • def5678 Add API endpoint
+→ GG-Parent chain needs normalization
 
 → 1 existing PRs found to map:
   • nacho/my-feature--c-9a8b7c6 → PR #42
@@ -506,14 +511,14 @@ $ gg reconcile --dry-run
 $ gg reconcile
 → Analyzing stack my-feature (3 commits)...
 → 2 commits need GG-IDs
-Add GG-IDs to commits? (requires rebase) [y/n]: y
-OK Added GG-IDs to commits
+Normalize stack metadata? (adds GG-IDs and GG-Parents via rewrite) [y/n]: y
+OK Stack metadata normalized (2 GG-IDs added, 2 GG-Parents updated)
 OK Mapped c-9a8b7c6 → PR #42
 OK Reconciliation complete!
 ```
 
 **What reconcile does:**
-1. **Adds GG-IDs to commits** that don't have them (via rebase)
+1. **Normalizes stack metadata** — adds missing GG-IDs and fixes GG-Parent chains
 2. **Finds existing PRs/MRs** for your entry branches and maps them in config
 
 **When to use:**

--- a/crates/gg-cli/tests/integration_tests.rs
+++ b/crates/gg-cli/tests/integration_tests.rs
@@ -6886,3 +6886,207 @@ fn test_drop_last_commit() {
     assert!(stdout.contains("Commit 2"));
     assert!(!stdout.contains("Commit 3"));
 }
+
+// ── GG-Parent trailer integration tests ──────────────────────────────
+
+#[test]
+fn test_gg_parent_trailers_in_ls_json() {
+    // After a sync (which triggers metadata normalization), ls --json
+    // should expose gg_parent fields on stack entries.
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .expect("Failed to write config");
+
+    // Create a stack with two commits
+    let (success, _, stderr) = run_gg(&repo_path, &["co", "parent-test"]);
+    assert!(success, "checkout failed: {}", stderr);
+
+    fs::write(repo_path.join("a.txt"), "a").unwrap();
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "First commit"]);
+
+    fs::write(repo_path.join("b.txt"), "b").unwrap();
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "Second commit"]);
+
+    // ls --json to see entries — before sync they won't have GG-IDs/Parents
+    let (success, stdout, _) = run_gg(&repo_path, &["ls", "--json"]);
+    assert!(success);
+    let parsed: Value = serde_json::from_str(&stdout).expect("should be valid JSON");
+    let entries = &parsed["stack"]["entries"];
+
+    // Before normalization, commits should NOT have gg_parent or gg_id
+    assert!(entries[0]["gg_id"].is_null());
+    assert!(entries[0]["gg_parent"].is_null());
+}
+
+#[test]
+fn test_reorder_normalizes_gg_parent() {
+    // After reorder, GG-Parent chain should be updated
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .expect("Failed to write config");
+
+    let (success, _, stderr) = run_gg(&repo_path, &["co", "reorder-parent"]);
+    assert!(success, "checkout failed: {}", stderr);
+
+    // Create 3 commits with GG-IDs manually (simulating prior sync)
+    fs::write(repo_path.join("a.txt"), "a").unwrap();
+    run_git(&repo_path, &["add", "."]);
+    run_git(
+        &repo_path,
+        &["commit", "-m", "Commit A\n\nGG-ID: c-aaa0001"],
+    );
+
+    fs::write(repo_path.join("b.txt"), "b").unwrap();
+    run_git(&repo_path, &["add", "."]);
+    run_git(
+        &repo_path,
+        &[
+            "commit",
+            "-m",
+            "Commit B\n\nGG-Parent: c-aaa0001\nGG-ID: c-bbb0002",
+        ],
+    );
+
+    fs::write(repo_path.join("c.txt"), "c").unwrap();
+    run_git(&repo_path, &["add", "."]);
+    run_git(
+        &repo_path,
+        &[
+            "commit",
+            "-m",
+            "Commit C\n\nGG-Parent: c-bbb0002\nGG-ID: c-ccc0003",
+        ],
+    );
+
+    // Reorder: reverse to C, B, A (positions: 3, 2, 1)
+    let (success, _, stderr) = run_gg(&repo_path, &["reorder", "--order", "3,2,1"]);
+    assert!(success, "reorder failed: {}", stderr);
+
+    // Check that GG-Parent chain was re-normalized via git log
+    let (_, log_output) = run_git(
+        &repo_path,
+        &["log", "--format=---COMMIT---%n%B", "--reverse"],
+    );
+    let commits: Vec<&str> = log_output
+        .split("---COMMIT---")
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty() && !s.starts_with("Initial commit"))
+        .collect();
+
+    assert!(
+        commits.len() >= 2,
+        "Expected at least 2 commits after reorder, got {}",
+        commits.len()
+    );
+
+    // After reorder, first stack entry should have no GG-Parent
+    assert!(
+        !commits[0].contains("GG-Parent:"),
+        "First commit after reorder should have no GG-Parent. Got: {}",
+        commits[0]
+    );
+    // Should still have its GG-ID
+    assert!(
+        commits[0].contains("GG-ID:"),
+        "First commit should have GG-ID. Got: {}",
+        commits[0]
+    );
+}
+
+#[test]
+fn test_drop_normalizes_gg_parent() {
+    // After drop, GG-Parent chain should be updated
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .expect("Failed to write config");
+
+    let (success, _, stderr) = run_gg(&repo_path, &["co", "drop-parent"]);
+    assert!(success, "checkout failed: {}", stderr);
+
+    // Create 3 commits with GG-IDs
+    fs::write(repo_path.join("a.txt"), "a").unwrap();
+    run_git(&repo_path, &["add", "."]);
+    run_git(
+        &repo_path,
+        &["commit", "-m", "Commit A\n\nGG-ID: c-aaa0001"],
+    );
+
+    fs::write(repo_path.join("b.txt"), "b").unwrap();
+    run_git(&repo_path, &["add", "."]);
+    run_git(
+        &repo_path,
+        &[
+            "commit",
+            "-m",
+            "Commit B\n\nGG-Parent: c-aaa0001\nGG-ID: c-bbb0002",
+        ],
+    );
+
+    fs::write(repo_path.join("c.txt"), "c").unwrap();
+    run_git(&repo_path, &["add", "."]);
+    run_git(
+        &repo_path,
+        &[
+            "commit",
+            "-m",
+            "Commit C\n\nGG-Parent: c-bbb0002\nGG-ID: c-ccc0003",
+        ],
+    );
+
+    // Drop commit B (position 2)
+    let (success, _, stderr) = run_gg(&repo_path, &["drop", "2", "--force"]);
+    assert!(success, "drop failed: {}", stderr);
+
+    // Check that GG-Parent chain was re-normalized
+    // Use --format=%s%n%b to get subject + body per commit
+    let (_, log_output) = run_git(
+        &repo_path,
+        &["log", "--format=---COMMIT---%n%B", "--reverse"],
+    );
+    let commits: Vec<&str> = log_output
+        .split("---COMMIT---")
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty() && !s.starts_with("Initial commit"))
+        .collect();
+
+    assert!(
+        commits.len() >= 2,
+        "Expected at least 2 commits after drop, got {}. Log:\n{}",
+        commits.len(),
+        log_output
+    );
+
+    // A should have no GG-Parent (it's the first)
+    assert!(
+        !commits[0].contains("GG-Parent:"),
+        "First commit should have no GG-Parent. Got: {}",
+        commits[0]
+    );
+
+    // C should now have GG-Parent pointing to A's GG-ID
+    assert!(
+        commits[1].contains("GG-Parent: c-aaa0001"),
+        "Second commit should point to first commit's GG-ID. Got: {}",
+        commits[1]
+    );
+}

--- a/crates/gg-core/src/commands/drop_cmd.rs
+++ b/crates/gg-core/src/commands/drop_cmd.rs
@@ -161,6 +161,9 @@ pub fn run(options: DropOptions) -> Result<()> {
         return Err(GgError::Other(format!("Rebase failed: {}", stderr)));
     }
 
+    // Normalize GG-Parent trailers after drop
+    let _ = git::normalize_current_stack_metadata(&repo, &config);
+
     // Clean up per-commit branches for dropped commits
     for entry in &dropped_entries {
         // Find the matching stack entry to get the GG-ID for branch name

--- a/crates/gg-core/src/commands/land.rs
+++ b/crates/gg-core/src/commands/land.rs
@@ -2195,6 +2195,7 @@ mod tests {
             short_sha: "abc1234".to_string(),
             title: "New commit without MR".to_string(),
             gg_id: Some("c-abc1234".to_string()),
+            gg_parent: None,
             mr_number: None, // No MR = unsynced
             mr_state: None,
             approved: false,
@@ -2213,6 +2214,7 @@ mod tests {
             short_sha: "def5678".to_string(),
             title: "Merged commit".to_string(),
             gg_id: Some("c-def5678".to_string()),
+            gg_parent: None,
             mr_number: Some(123), // Has MR = synced
             mr_state: Some(crate::provider::PrState::Merged),
             approved: true,
@@ -2249,6 +2251,7 @@ mod tests {
                 short_sha: "a1".to_string(),
                 title: "Merged".to_string(),
                 gg_id: Some("c-aaa".to_string()),
+                gg_parent: None,
                 mr_number: Some(1),
                 mr_state: Some(crate::provider::PrState::Merged),
                 approved: true,
@@ -2262,6 +2265,7 @@ mod tests {
                 short_sha: "b2".to_string(),
                 title: "Also merged".to_string(),
                 gg_id: Some("c-bbb".to_string()),
+                gg_parent: None,
                 mr_number: Some(2),
                 mr_state: Some(crate::provider::PrState::Merged),
                 approved: true,
@@ -2275,6 +2279,7 @@ mod tests {
                 short_sha: "c3".to_string(),
                 title: "New unsynced commit".to_string(),
                 gg_id: Some("c-ccc".to_string()),
+                gg_parent: None,
                 mr_number: None, // No MR
                 mr_state: None,
                 approved: false,
@@ -2288,6 +2293,7 @@ mod tests {
                 short_sha: "d4".to_string(),
                 title: "Another new commit".to_string(),
                 gg_id: Some("c-ddd".to_string()),
+                gg_parent: None,
                 mr_number: None, // No MR
                 mr_state: None,
                 approved: false,

--- a/crates/gg-core/src/commands/ls.rs
+++ b/crates/gg-core/src/commands/ls.rs
@@ -527,6 +527,7 @@ fn show_stack(stack: &Stack, json: bool) -> Result<()> {
                     sha: entry.short_sha.clone(),
                     title: entry.title.clone(),
                     gg_id: entry.gg_id.clone(),
+                    gg_parent: entry.gg_parent.clone(),
                     pr_number: entry.mr_number,
                     pr_state: entry.mr_state.as_ref().map(pr_state_to_json),
                     approved: entry.approved,

--- a/crates/gg-core/src/commands/reconcile.rs
+++ b/crates/gg-core/src/commands/reconcile.rs
@@ -4,7 +4,7 @@
 //! someone does `gg co mystack` → commit → `git push` (skipping `gg sync`).
 //!
 //! It will:
-//! 1. Add GG-IDs to commits that don't have them (via rebase)
+//! 1. Normalize GG-ID and GG-Parent trailers on all commits
 //! 2. Search for existing PRs/MRs for the stack's entry branches and map them
 
 use console::style;
@@ -12,8 +12,8 @@ use dialoguer::Confirm;
 use git2::Repository;
 
 use crate::config::Config;
-use crate::error::Result;
-use crate::git::{self, generate_gg_id, get_gg_id, set_gg_id_in_message};
+use crate::error::{GgError, Result};
+use crate::git;
 use crate::provider::Provider;
 use crate::stack::Stack;
 
@@ -125,25 +125,27 @@ pub fn run(dry_run: bool) -> Result<()> {
         return Ok(());
     }
 
-    // Confirm before proceeding
+    // Normalize stack metadata (GG-IDs + GG-Parents) automatically
     if !actions.commits_needing_ids.is_empty() {
         let should_add_ids = Confirm::new()
-            .with_prompt("Add GG-IDs to commits? (requires rebase)")
+            .with_prompt("Normalize stack metadata? (adds GG-IDs and GG-Parents via rewrite)")
             .default(true)
             .interact()
             .unwrap_or(false);
 
         if should_add_ids {
-            add_gg_ids_to_commits(&repo, &stack)?;
-            // Reload stack after rebase to get updated GG-IDs
+            normalize_stack_trailers(&repo, &stack)?;
+            // Reload stack after rewrite to get updated GG-IDs
             let stack = Stack::load(&repo, &config)?;
             // Re-search for PRs with the new stack
             let prs_to_map = find_unmapped_prs(&repo, &stack, &config, &provider)?;
             map_prs(&mut config, &stack.name, &prs_to_map, &provider)?;
         } else {
-            println!("{}", style("Skipping GG-ID addition.").dim());
+            println!("{}", style("Skipping metadata normalization.").dim());
         }
     } else {
+        // Even when all commits have GG-IDs, normalize GG-Parent chain
+        normalize_stack_trailers(&repo, &stack)?;
         // Just map the PRs
         map_prs(&mut config, &stack.name, &actions.prs_to_map, &provider)?;
     }
@@ -273,44 +275,58 @@ fn map_prs(
     Ok(())
 }
 
-/// Add GG-IDs to commits that are missing them via interactive rebase
-fn add_gg_ids_to_commits(repo: &Repository, stack: &Stack) -> Result<()> {
-    println!("{}", style("Adding GG-IDs via rebase...").dim());
+/// Normalize GG-ID and GG-Parent trailers for all commits in the stack.
+fn normalize_stack_trailers(repo: &Repository, stack: &Stack) -> Result<()> {
+    println!(
+        "{}",
+        style("Normalizing stack metadata (GG-IDs + GG-Parents)...").dim()
+    );
 
     let base_ref = repo
         .revparse_single(&stack.base)
         .or_else(|_| repo.revparse_single(&format!("origin/{}", stack.base)))?;
 
-    use git2::RebaseOptions;
+    let entry_oids: Vec<git2::Oid> = stack.entries.iter().map(|e| e.oid).collect();
 
-    let base_commit = repo.find_annotated_commit(base_ref.id())?;
+    let (new_tip, counts) = git::normalize_stack_metadata(repo, base_ref.id(), &entry_oids)?;
 
-    let mut rebase_opts = RebaseOptions::new();
-    let mut rebase = repo.rebase(None, Some(&base_commit), None, Some(&mut rebase_opts))?;
-
-    let sig = git::get_signature(repo)?;
-
-    while let Some(op) = rebase.next() {
-        let op = op?;
-        let commit = repo.find_commit(op.id())?;
-
-        // Check if this commit needs a GG-ID
-        let needs_id = get_gg_id(&commit).is_none();
-
-        let message = commit.message().unwrap_or("");
-        let new_message = if needs_id {
-            let new_id = generate_gg_id();
-            set_gg_id_in_message(message, &new_id)
-        } else {
-            message.to_string()
-        };
-
-        rebase.commit(None, &sig, Some(&new_message))?;
+    // Update the branch reference
+    let head = repo.head()?;
+    if let Some(branch_name) = head.shorthand() {
+        repo.reference(
+            &format!("refs/heads/{}", branch_name),
+            new_tip,
+            true,
+            "gg reconcile: normalized stack metadata",
+        )?;
+    } else {
+        return Err(GgError::Other(
+            "Cannot normalize metadata: HEAD is detached".to_string(),
+        ));
     }
 
-    rebase.finish(None)?;
-
-    println!("{} Added GG-IDs to commits", style("OK").green().bold());
+    let mut parts = Vec::new();
+    if counts.gg_ids_added > 0 {
+        parts.push(format!("{} GG-IDs added", counts.gg_ids_added));
+    }
+    if counts.gg_parents_updated > 0 {
+        parts.push(format!("{} GG-Parents updated", counts.gg_parents_updated));
+    }
+    if counts.gg_parents_removed > 0 {
+        parts.push(format!("{} GG-Parents removed", counts.gg_parents_removed));
+    }
+    if parts.is_empty() {
+        println!(
+            "{} Stack metadata already normalized",
+            style("OK").green().bold()
+        );
+    } else {
+        println!(
+            "{} Stack metadata normalized ({})",
+            style("OK").green().bold(),
+            parts.join(", ")
+        );
+    }
 
     Ok(())
 }

--- a/crates/gg-core/src/commands/reorder.rs
+++ b/crates/gg-core/src/commands/reorder.rs
@@ -89,6 +89,9 @@ pub fn run(options: ReorderOptions) -> Result<()> {
     // Perform the rebase with the new order
     perform_reorder(&repo, &stack, &new_order)?;
 
+    // Normalize GG-Parent trailers after reorder
+    let _ = git::normalize_current_stack_metadata(&repo, &config);
+
     if dropped_count > 0 {
         println!(
             "{} Arranged stack: {} commits kept, {} dropped",
@@ -370,6 +373,7 @@ mod tests {
             short_sha: sha.to_string(),
             title: title.to_string(),
             gg_id: Some(gg_id.to_string()),
+            gg_parent: None,
             mr_number: None,
             mr_state: None,
             approved: false,

--- a/crates/gg-core/src/commands/split.rs
+++ b/crates/gg-core/src/commands/split.rs
@@ -307,6 +307,9 @@ pub fn run(options: SplitOptions) -> Result<()> {
         );
     }
 
+    // Normalize GG-Parent trailers after split
+    let _ = git::normalize_current_stack_metadata(&repo, &config);
+
     Ok(())
 }
 

--- a/crates/gg-core/src/commands/sync.rs
+++ b/crates/gg-core/src/commands/sync.rs
@@ -7,11 +7,9 @@ use indicatif::{ProgressBar, ProgressStyle};
 
 use crate::config::Config;
 use crate::error::{GgError, Result};
-use crate::git::{
-    self, generate_gg_id, get_commit_description, set_gg_id_in_message, strip_gg_id_from_message,
-};
+use crate::git::{self, get_commit_description, strip_gg_id_from_message};
 use crate::output::{
-    print_json, SyncEntryResultJson, SyncResponse, SyncResultJson, OUTPUT_VERSION,
+    print_json, SyncEntryResultJson, SyncMetadataJson, SyncResponse, SyncResultJson, OUTPUT_VERSION,
 };
 use crate::provider::Provider;
 use crate::stack::{resolve_target, Stack};
@@ -187,6 +185,7 @@ pub fn run(
                     stack: initial_stack.name.clone(),
                     base: initial_stack.base.clone(),
                     rebased_before_sync: false,
+                    metadata: None,
                     warnings: vec![],
                     entries: vec![],
                 },
@@ -257,140 +256,40 @@ pub fn run(
         }
     }
 
-    // Now handle GG-ID addition in a loop (lint may have changed commits)
-    // This loop ensures the operation lock is held for the entire operation
-    let stack = loop {
-        let stack = Stack::load(&repo, &config)?;
+    // Normalize stack metadata (GG-ID + GG-Parent trailers) before syncing.
+    // This replaces the old GG-ID-only addition loop with a single pass that
+    // ensures every commit has a GG-ID and the correct GG-Parent chain.
+    let stack = Stack::load(&repo, &config)?;
 
-        if stack.is_empty() {
-            if json {
-                print_json(&SyncResponse {
-                    version: OUTPUT_VERSION,
-                    sync: SyncResultJson {
-                        stack: stack.name.clone(),
-                        base: stack.base.clone(),
-                        rebased_before_sync,
-                        warnings: warnings.clone(),
-                        entries: vec![],
-                    },
-                });
-            } else {
-                println!("{}", style("Stack is empty. Nothing to sync.").dim());
-            }
-            return Ok(());
-        }
-
-        // Re-validate --until against potentially updated stack
-        if let Some(ref target) = until {
-            resolve_target(&stack, target)?;
-        }
-
-        // Check for missing GG-IDs
-        let missing_ids = stack.entries_needing_gg_ids();
-        if missing_ids.is_empty() {
-            // All commits have GG-IDs, proceed with sync
-            break stack;
-        }
-
-        if !json {
-            println!(
-                "{} {} commits are missing GG-IDs:",
-                style("→").cyan(),
-                missing_ids.len()
-            );
-            for entry in &missing_ids {
-                println!("  [{}] {} {}", entry.position, entry.short_sha, entry.title);
-            }
-        }
-
-        // Check config for auto_add_gg_ids (default: true)
-        let should_add = if config.defaults.auto_add_gg_ids || json {
-            true
+    if stack.is_empty() {
+        if json {
+            print_json(&SyncResponse {
+                version: OUTPUT_VERSION,
+                sync: SyncResultJson {
+                    stack: stack.name.clone(),
+                    base: stack.base.clone(),
+                    rebased_before_sync,
+                    metadata: None,
+                    warnings: warnings.clone(),
+                    entries: vec![],
+                },
+            });
         } else {
-            Confirm::new()
-                .with_prompt("Add GG-IDs to these commits? (requires rebase)")
-                .default(true)
-                .interact()
-                .unwrap_or(true)
-        };
-
-        if !should_add {
-            return Err(GgError::Other(
-                "Cannot sync without GG-IDs. Aborting.".to_string(),
-            ));
+            println!("{}", style("Stack is empty. Nothing to sync.").dim());
         }
+        return Ok(());
+    }
 
-        let needs_stash = !git::is_working_directory_clean(&repo)?;
-        if needs_stash {
-            if !json {
-                println!("{}", style("Auto-stashing uncommitted changes...").dim());
-            }
-            git::run_git_command(&["stash", "push", "-m", "gg-sync-autostash"])?;
-        }
+    // Re-validate --until against potentially updated stack
+    if let Some(ref target) = until {
+        resolve_target(&stack, target)?;
+    }
 
-        if let Err(err) = add_gg_ids_to_commits(&repo, &stack, json) {
-            if needs_stash && !git::is_rebase_in_progress(&repo) {
-                if !json {
-                    println!(
-                        "{}",
-                        style("Attempting to restore stashed changes...").dim()
-                    );
-                }
-                let _ = git::run_git_command(&["stash", "pop"]);
-            }
-            return Err(err);
-        }
+    // Normalize metadata: add missing GG-IDs, set/fix GG-Parent chain
+    let metadata_json = normalize_metadata_for_sync(&repo, &stack, json, &mut warnings)?;
 
-        // Check if rebase completed successfully
-        if git::is_rebase_in_progress(&repo) {
-            let note = if needs_stash {
-                "\nNote: Your uncommitted changes are stashed and will be restored after the rebase completes."
-            } else {
-                ""
-            };
-            return Err(GgError::Other(format!(
-                "Rebase in progress after adding GG-IDs.\n\
-                 Please resolve any conflicts, then run:\n\
-                 - 'git rebase --continue' (or 'gg continue') to finish the rebase\n\
-                 - 'gg sync' again once the rebase is complete{}",
-                note
-            )));
-        }
-
-        if needs_stash {
-            if !json {
-                println!("{}", style("Restoring stashed changes...").dim());
-            }
-            match git::run_git_command(&["stash", "pop"]) {
-                Ok(_) => {
-                    if !json {
-                        println!("{}", style("Changes restored").cyan());
-                    }
-                }
-                Err(e) => {
-                    let warning = format!(
-                        "Could not restore stashed changes: {}. Your changes are in the stash. Run 'git stash pop' manually.",
-                        e
-                    );
-                    if json {
-                        warnings.push(warning);
-                    } else {
-                        println!("{} {}", style("Warning:").yellow(), warning);
-                    }
-                }
-            }
-        }
-
-        if !json {
-            println!(
-                "{}",
-                console::style("GG-IDs added successfully. Re-syncing...").dim()
-            );
-        }
-
-        // Loop continues: reload stack and check for any remaining missing GG-IDs
-        // (or proceed to sync if all commits now have GG-IDs)
-    };
+    // Reload stack after normalization (commits have been rewritten)
+    let stack = Stack::load(&repo, &config)?;
 
     // Determine sync range based on --until flag
     let sync_until = if let Some(ref target) = until {
@@ -742,6 +641,7 @@ pub fn run(
                 stack: stack.name,
                 base: stack.base,
                 rebased_before_sync,
+                metadata: metadata_json,
                 warnings,
                 entries: json_entries,
             },
@@ -870,70 +770,106 @@ fn create_entry_branch(
     Ok(())
 }
 
-/// Add GG-IDs to commits that are missing them by rewriting commit messages
-/// This preserves the exact tree (including any lint changes) while only updating messages
-fn add_gg_ids_to_commits(repo: &Repository, stack: &Stack, json: bool) -> Result<()> {
-    if !json {
-        println!("{}", style("Adding GG-IDs...").dim());
-    }
-
+/// Normalize GG-ID and GG-Parent trailers for all commits in the stack.
+///
+/// This replaces the old GG-ID-only rewrite with a generalized metadata pass:
+/// - Adds missing GG-IDs automatically
+/// - Sets/fixes GG-Parent chain to match stack order
+/// - Returns metadata JSON for the sync response (None if no changes were needed)
+fn normalize_metadata_for_sync(
+    repo: &Repository,
+    stack: &Stack,
+    json: bool,
+    warnings: &mut Vec<String>,
+) -> Result<Option<SyncMetadataJson>> {
     let base_ref = repo
         .revparse_single(&stack.base)
         .or_else(|_| repo.revparse_single(&format!("origin/{}", stack.base)))?;
-    let base_commit = repo.find_commit(base_ref.id())?;
 
-    let mut parent_oid = base_commit.id();
+    let entry_oids: Vec<git2::Oid> = stack.entries.iter().map(|e| e.oid).collect();
 
-    // Walk through all entries in order, rewriting each commit
-    for entry in &stack.entries {
-        let original_commit = repo.find_commit(entry.oid)?;
-        let original_message = original_commit.message().unwrap_or("");
+    let (new_tip, counts) = git::normalize_stack_metadata(repo, base_ref.id(), &entry_oids)?;
 
-        // Determine if we need a new GG-ID for this commit
-        let new_message = if entry.gg_id.is_none() {
-            let new_id = generate_gg_id();
-            set_gg_id_in_message(original_message, &new_id)
-        } else {
-            // Even if this commit already has a GG-ID, we still need to rewrite it
-            // because the parent has changed (due to previous rewrites in the stack)
-            original_message.to_string()
-        };
-
-        // Create a new commit with the same tree but updated parent and message
-        let new_oid = repo.commit(
-            None, // Don't update any reference yet
-            &original_commit.author(),
-            &original_commit.committer(),
-            &new_message,
-            &original_commit.tree()?,
-            &[&repo.find_commit(parent_oid)?],
-        )?;
-
-        // This new commit becomes the parent for the next one
-        parent_oid = new_oid;
-    }
-
-    // Update the current branch to point to the last rewritten commit
-    let head = repo.head()?;
-    if let Some(branch_name) = head.shorthand() {
-        // Update the branch reference
-        repo.reference(
-            &format!("refs/heads/{}", branch_name),
-            parent_oid,
-            true,
-            "gg sync: added GG-IDs",
-        )?;
-    } else {
-        return Err(GgError::Other(
-            "Cannot add GG-IDs: HEAD is detached".to_string(),
-        ));
+    if !counts.has_changes() {
+        return Ok(None);
     }
 
     if !json {
-        println!("{} Added GG-IDs to commits", style("OK").green().bold());
+        println!("{}", style("Normalizing stack metadata...").dim());
     }
 
-    Ok(())
+    // Auto-stash if needed
+    let needs_stash = !git::is_working_directory_clean(repo)?;
+    if needs_stash {
+        if !json {
+            println!("{}", style("Auto-stashing uncommitted changes...").dim());
+        }
+        git::run_git_command(&["stash", "push", "-m", "gg-sync-autostash"])?;
+    }
+
+    // Update the branch reference to the new tip
+    let head = repo.head()?;
+    if let Some(branch_name) = head.shorthand() {
+        repo.reference(
+            &format!("refs/heads/{}", branch_name),
+            new_tip,
+            true,
+            "gg sync: normalized stack metadata",
+        )?;
+    } else {
+        return Err(GgError::Other(
+            "Cannot normalize metadata: HEAD is detached".to_string(),
+        ));
+    }
+
+    // Restore stash
+    if needs_stash {
+        if !json {
+            println!("{}", style("Restoring stashed changes...").dim());
+        }
+        match git::run_git_command(&["stash", "pop"]) {
+            Ok(_) => {
+                if !json {
+                    println!("{}", style("Changes restored").cyan());
+                }
+            }
+            Err(e) => {
+                let warning = format!(
+                    "Could not restore stashed changes: {}. Your changes are in the stash. Run 'git stash pop' manually.",
+                    e
+                );
+                if json {
+                    warnings.push(warning);
+                } else {
+                    println!("{} {}", style("Warning:").yellow(), warning);
+                }
+            }
+        }
+    }
+
+    if !json {
+        let mut parts = Vec::new();
+        if counts.gg_ids_added > 0 {
+            parts.push(format!("{} GG-IDs added", counts.gg_ids_added));
+        }
+        if counts.gg_parents_updated > 0 {
+            parts.push(format!("{} GG-Parents updated", counts.gg_parents_updated));
+        }
+        if counts.gg_parents_removed > 0 {
+            parts.push(format!("{} GG-Parents removed", counts.gg_parents_removed));
+        }
+        println!(
+            "{} Stack metadata normalized ({})",
+            style("OK").green().bold(),
+            parts.join(", ")
+        );
+    }
+
+    Ok(Some(SyncMetadataJson {
+        gg_ids_added: counts.gg_ids_added,
+        gg_parents_updated: counts.gg_parents_updated,
+        gg_parents_removed: counts.gg_parents_removed,
+    }))
 }
 
 #[cfg(test)]
@@ -1126,6 +1062,7 @@ mod tests {
                 stack: "test-stack".to_string(),
                 base: "main".to_string(),
                 rebased_before_sync: false,
+                metadata: None,
                 warnings: vec![],
                 entries: vec![SyncEntryResultJson {
                     position: 1,

--- a/crates/gg-core/src/git.rs
+++ b/crates/gg-core/src/git.rs
@@ -21,6 +21,9 @@ use crate::error::{GgError, Result};
 /// Prefix for GG-ID trailers in commit messages
 pub const GG_ID_PREFIX: &str = "GG-ID:";
 
+/// Prefix for GG-Parent trailers in commit messages
+pub const GG_PARENT_PREFIX: &str = "GG-Parent:";
+
 /// Open the repository at the current directory or its parents
 pub fn open_repo() -> Result<Repository> {
     Repository::discover(".").map_err(|_| GgError::NotInRepo)
@@ -389,8 +392,106 @@ pub fn strip_gg_id_from_message(message: &str) -> String {
     result.trim_end().to_string()
 }
 
+/// Extract the GG-Parent trailer value from a commit message
+pub fn get_gg_parent_from_message(message: &str) -> Option<String> {
+    let re = Regex::new(r"(?i)^GG-Parent:\s*(.+)$").ok()?;
+    for line in message.lines() {
+        if let Some(captures) = re.captures(line.trim()) {
+            let raw = captures.get(1).map(|m| m.as_str().trim())?;
+            return normalize_gg_id(raw);
+        }
+    }
+    None
+}
+
+/// Extract the GG-Parent from a commit object
+pub fn get_gg_parent(commit: &Commit) -> Option<String> {
+    let message = commit.message()?;
+    get_gg_parent_from_message(message)
+}
+
+/// Add or update GG-Parent trailer in a message
+pub fn set_gg_parent_in_message(message: &str, parent: &str) -> String {
+    let re = Regex::new(r"(?im)^GG-Parent:\s*.+$").unwrap();
+
+    if re.is_match(message) {
+        re.replace(message, format!("{} {}", GG_PARENT_PREFIX, parent))
+            .to_string()
+    } else {
+        // Insert GG-Parent before GG-ID if present, otherwise append
+        let gg_id_re = Regex::new(r"(?im)^GG-ID:\s*.+$").unwrap();
+        if let Some(m) = gg_id_re.find(message) {
+            let before = message[..m.start()].trim_end_matches('\n');
+            let gg_id_line = &message[m.start()..m.end()];
+            let after = &message[m.end()..];
+            let sep = if before.is_empty() { "" } else { "\n" };
+            format!(
+                "{}{}{} {}\n{}{}",
+                before, sep, GG_PARENT_PREFIX, parent, gg_id_line, after
+            )
+        } else {
+            let trimmed = message.trim_end();
+            format!("{}\n\n{} {}", trimmed, GG_PARENT_PREFIX, parent)
+        }
+    }
+}
+
+/// Remove GG-Parent trailer from a message
+pub fn strip_gg_parent_from_message(message: &str) -> String {
+    let re = Regex::new(r"(?im)^GG-Parent:\s*.+\n?").unwrap();
+    let result = re.replace_all(message, "");
+    result.trim_end().to_string()
+}
+
+/// Strip all GG trailers (GG-ID and GG-Parent) from a message
+pub fn strip_gg_trailers_from_message(message: &str) -> String {
+    let re = Regex::new(r"(?im)^GG-(ID|Parent):\s*.+\n?").unwrap();
+    let result = re.replace_all(message, "");
+    result.trim_end().to_string()
+}
+
+/// Normalize both GG-ID and GG-Parent trailers in a commit message.
+///
+/// - Ensures a GG-ID is present (uses `gg_id` param).
+/// - Sets/removes GG-Parent based on `parent_gg_id`.
+/// - Preserves all non-GG content.
+///
+/// Returns the normalized message.
+pub fn normalize_gg_trailers(message: &str, gg_id: &str, parent_gg_id: Option<&str>) -> String {
+    // Strip existing GG trailers
+    let clean = strip_gg_trailers_from_message(message);
+    let trimmed = clean.trim_end();
+
+    // Build trailer block
+    let mut trailers = String::new();
+    if let Some(parent) = parent_gg_id {
+        trailers.push_str(&format!("{} {}\n", GG_PARENT_PREFIX, parent));
+    }
+    trailers.push_str(&format!("{} {}", GG_ID_PREFIX, gg_id));
+
+    if trimmed.is_empty() {
+        trailers
+    } else {
+        format!("{}\n\n{}", trimmed, trailers)
+    }
+}
+
+/// Counts of metadata changes made during normalization
+#[derive(Debug, Default, Clone)]
+pub struct MetadataNormalizationCounts {
+    pub gg_ids_added: usize,
+    pub gg_parents_updated: usize,
+    pub gg_parents_removed: usize,
+}
+
+impl MetadataNormalizationCounts {
+    pub fn has_changes(&self) -> bool {
+        self.gg_ids_added > 0 || self.gg_parents_updated > 0 || self.gg_parents_removed > 0
+    }
+}
+
 fn extract_description_from_message(message: &str) -> Option<String> {
-    let stripped = strip_gg_id_from_message(message);
+    let stripped = strip_gg_trailers_from_message(message);
     let newline_idx = stripped.find('\n')?;
     let description = stripped[newline_idx + 1..].trim();
     if description.is_empty() {
@@ -411,6 +512,76 @@ pub fn get_commit_description(commit: &Commit) -> Option<String> {
     extract_description_from_message(message)
 }
 
+/// Normalize GG-ID and GG-Parent trailers for all commits in a stack.
+///
+/// Walks the commits from base to HEAD, ensuring each has a GG-ID and
+/// the correct GG-Parent pointing to the previous entry's GG-ID.
+/// The first entry has no GG-Parent. Returns the new tip OID and counts.
+///
+/// `entry_oids` must be ordered from base to HEAD.
+pub fn normalize_stack_metadata(
+    repo: &Repository,
+    base_oid: Oid,
+    entry_oids: &[Oid],
+) -> Result<(Oid, MetadataNormalizationCounts)> {
+    let mut counts = MetadataNormalizationCounts::default();
+    let mut parent_oid = base_oid;
+    let mut prev_gg_id: Option<String> = None;
+
+    for (i, &oid) in entry_oids.iter().enumerate() {
+        let original_commit = repo.find_commit(oid)?;
+        let original_message = original_commit.message().unwrap_or("");
+
+        // Determine the GG-ID for this commit
+        let existing_gg_id = get_gg_id(&original_commit);
+        let gg_id = match &existing_gg_id {
+            Some(id) => id.clone(),
+            None => {
+                counts.gg_ids_added += 1;
+                generate_gg_id()
+            }
+        };
+
+        // Determine expected parent
+        let expected_parent = if i == 0 { None } else { prev_gg_id.as_deref() };
+
+        // Check current parent
+        let current_parent = get_gg_parent_from_message(original_message);
+
+        // Detect if parent needs updating
+        let parent_changed = current_parent.as_deref() != expected_parent;
+        if parent_changed {
+            if expected_parent.is_none() && current_parent.is_some() {
+                counts.gg_parents_removed += 1;
+            } else if expected_parent.is_some() {
+                counts.gg_parents_updated += 1;
+            }
+        }
+
+        // Build the normalized message (always rewrite because git parent chain changes)
+        let new_message = if existing_gg_id.is_none() || parent_changed {
+            normalize_gg_trailers(original_message, &gg_id, expected_parent)
+        } else {
+            original_message.to_string()
+        };
+
+        // Create a new commit with updated parent and message
+        let new_oid = repo.commit(
+            None,
+            &original_commit.author(),
+            &original_commit.committer(),
+            &new_message,
+            &original_commit.tree()?,
+            &[&repo.find_commit(parent_oid)?],
+        )?;
+
+        prev_gg_id = Some(gg_id);
+        parent_oid = new_oid;
+    }
+
+    Ok((parent_oid, counts))
+}
+
 /// Checkout a branch by name
 pub fn checkout_branch(repo: &Repository, branch_name: &str) -> Result<()> {
     let refname = format!("refs/heads/{}", branch_name);
@@ -419,6 +590,41 @@ pub fn checkout_branch(repo: &Repository, branch_name: &str) -> Result<()> {
     repo.checkout_tree(&obj, None)?;
     repo.set_head(&refname)?;
     Ok(())
+}
+
+/// Normalize GG-ID and GG-Parent trailers for the current branch's stack.
+///
+/// Loads the stack, runs the normalization pass, and updates the branch ref.
+/// Designed to be called after structural operations (reorder, drop, split).
+pub fn normalize_current_stack_metadata(
+    repo: &Repository,
+    config: &crate::config::Config,
+) -> Result<MetadataNormalizationCounts> {
+    let stack = crate::stack::Stack::load(repo, config)?;
+    if stack.is_empty() {
+        return Ok(MetadataNormalizationCounts::default());
+    }
+
+    let base_ref = repo
+        .revparse_single(&stack.base)
+        .or_else(|_| repo.revparse_single(&format!("origin/{}", stack.base)))?;
+
+    let entry_oids: Vec<Oid> = stack.entries.iter().map(|e| e.oid).collect();
+    let (new_tip, counts) = normalize_stack_metadata(repo, base_ref.id(), &entry_oids)?;
+
+    if counts.has_changes() {
+        let head = repo.head()?;
+        if let Some(branch_name) = head.shorthand() {
+            repo.reference(
+                &format!("refs/heads/{}", branch_name),
+                new_tip,
+                true,
+                "gg: normalized stack metadata",
+            )?;
+        }
+    }
+
+    Ok(counts)
 }
 
 /// Ensure HEAD is attached to the given branch.
@@ -1616,6 +1822,290 @@ mod tests {
 
         // Clean up
         std::fs::remove_file(&index_lock).ok();
+    }
+
+    // ── GG-Parent trailer tests ──────────────────────────────────────────
+
+    #[test]
+    fn test_get_gg_parent_from_message_present() {
+        let msg = "Title\n\nBody\n\nGG-Parent: c-abc1234\nGG-ID: c-def5678";
+        assert_eq!(
+            get_gg_parent_from_message(msg),
+            Some("c-abc1234".to_string())
+        );
+    }
+
+    #[test]
+    fn test_get_gg_parent_from_message_absent() {
+        let msg = "Title\n\nGG-ID: c-def5678";
+        assert_eq!(get_gg_parent_from_message(msg), None);
+    }
+
+    #[test]
+    fn test_get_gg_parent_from_message_case_insensitive() {
+        let msg = "Title\n\ngg-parent: c-abc1234\nGG-ID: c-def5678";
+        assert_eq!(
+            get_gg_parent_from_message(msg),
+            Some("c-abc1234".to_string())
+        );
+    }
+
+    #[test]
+    fn test_set_gg_parent_in_message_new() {
+        let msg = "Title\n\nBody\n\nGG-ID: c-def5678";
+        let result = set_gg_parent_in_message(msg, "c-abc1234");
+        assert!(result.contains("GG-Parent: c-abc1234"));
+        assert!(result.contains("GG-ID: c-def5678"));
+        // GG-Parent should appear before GG-ID
+        let parent_pos = result.find("GG-Parent:").unwrap();
+        let id_pos = result.find("GG-ID:").unwrap();
+        assert!(parent_pos < id_pos);
+    }
+
+    #[test]
+    fn test_set_gg_parent_in_message_replace() {
+        let msg = "Title\n\nGG-Parent: c-old1234\nGG-ID: c-def5678";
+        let result = set_gg_parent_in_message(msg, "c-new5678");
+        assert!(result.contains("GG-Parent: c-new5678"));
+        assert!(!result.contains("c-old1234"));
+        assert!(result.contains("GG-ID: c-def5678"));
+    }
+
+    #[test]
+    fn test_set_gg_parent_in_message_no_gg_id() {
+        let msg = "Title\n\nBody text";
+        let result = set_gg_parent_in_message(msg, "c-abc1234");
+        assert!(result.contains("GG-Parent: c-abc1234"));
+        assert!(result.contains("Title"));
+        assert!(result.contains("Body text"));
+    }
+
+    #[test]
+    fn test_strip_gg_parent_from_message() {
+        let msg = "Title\n\nBody\n\nGG-Parent: c-abc1234\nGG-ID: c-def5678";
+        let result = strip_gg_parent_from_message(msg);
+        assert!(!result.contains("GG-Parent"));
+        assert!(result.contains("GG-ID: c-def5678"));
+        assert!(result.contains("Title"));
+        assert!(result.contains("Body"));
+    }
+
+    #[test]
+    fn test_strip_gg_trailers_from_message() {
+        let msg = "Title\n\nBody\n\nGG-Parent: c-abc1234\nGG-ID: c-def5678";
+        let result = strip_gg_trailers_from_message(msg);
+        assert!(!result.contains("GG-Parent"));
+        assert!(!result.contains("GG-ID"));
+        assert!(result.contains("Title"));
+        assert!(result.contains("Body"));
+    }
+
+    #[test]
+    fn test_strip_gg_trailers_preserves_non_gg_trailers() {
+        let msg = "Title\n\nBody\n\nSigned-off-by: Dev <dev@example.com>\nGG-Parent: c-abc1234\nGG-ID: c-def5678";
+        let result = strip_gg_trailers_from_message(msg);
+        assert!(!result.contains("GG-Parent"));
+        assert!(!result.contains("GG-ID"));
+        assert!(result.contains("Signed-off-by: Dev <dev@example.com>"));
+    }
+
+    #[test]
+    fn test_normalize_gg_trailers_first_entry() {
+        let msg = "Title\n\nBody text";
+        let result = normalize_gg_trailers(msg, "c-abc1234", None);
+        assert!(result.contains("GG-ID: c-abc1234"));
+        assert!(!result.contains("GG-Parent"));
+        assert!(result.contains("Title"));
+        assert!(result.contains("Body text"));
+    }
+
+    #[test]
+    fn test_normalize_gg_trailers_with_parent() {
+        let msg = "Title\n\nBody text";
+        let result = normalize_gg_trailers(msg, "c-def5678", Some("c-abc1234"));
+        assert!(result.contains("GG-Parent: c-abc1234"));
+        assert!(result.contains("GG-ID: c-def5678"));
+        // Parent before ID
+        let parent_pos = result.find("GG-Parent:").unwrap();
+        let id_pos = result.find("GG-ID:").unwrap();
+        assert!(parent_pos < id_pos);
+    }
+
+    #[test]
+    fn test_normalize_gg_trailers_replaces_existing() {
+        let msg = "Title\n\nBody\n\nGG-Parent: c-old0000\nGG-ID: c-old1111";
+        let result = normalize_gg_trailers(msg, "c-new2222", Some("c-new1111"));
+        assert!(result.contains("GG-Parent: c-new1111"));
+        assert!(result.contains("GG-ID: c-new2222"));
+        assert!(!result.contains("c-old0000"));
+        assert!(!result.contains("c-old1111"));
+    }
+
+    #[test]
+    fn test_normalize_gg_trailers_preserves_body() {
+        let msg = "feat: add thing\n\nThis is a detailed description.\n\n- Point 1\n- Point 2\n\nSigned-off-by: Dev <dev@example.com>";
+        let result = normalize_gg_trailers(msg, "c-abc1234", Some("c-parent0"));
+        assert!(result.contains("This is a detailed description."));
+        assert!(result.contains("- Point 1"));
+        assert!(result.contains("Signed-off-by: Dev <dev@example.com>"));
+        assert!(result.contains("GG-Parent: c-parent0"));
+        assert!(result.contains("GG-ID: c-abc1234"));
+    }
+
+    #[test]
+    fn test_metadata_normalization_counts_default() {
+        let counts = MetadataNormalizationCounts::default();
+        assert!(!counts.has_changes());
+        assert_eq!(counts.gg_ids_added, 0);
+        assert_eq!(counts.gg_parents_updated, 0);
+        assert_eq!(counts.gg_parents_removed, 0);
+    }
+
+    #[test]
+    fn test_metadata_normalization_counts_has_changes() {
+        let counts = MetadataNormalizationCounts {
+            gg_ids_added: 1,
+            ..Default::default()
+        };
+        assert!(counts.has_changes());
+    }
+
+    #[test]
+    fn test_normalize_stack_metadata_basic() {
+        // Create a temp repo with commits, run normalization, verify trailers
+        let temp_dir = tempfile::tempdir().unwrap();
+        let repo = git2::Repository::init(temp_dir.path()).unwrap();
+
+        // Create initial commit (base)
+        let sig = git2::Signature::now("Test", "test@test.com").unwrap();
+        let tree_id = {
+            let mut index = repo.index().unwrap();
+            std::fs::write(temp_dir.path().join("file.txt"), "base").unwrap();
+            index.add_path(std::path::Path::new("file.txt")).unwrap();
+            index.write_tree().unwrap()
+        };
+        let tree = repo.find_tree(tree_id).unwrap();
+        let base_oid = repo
+            .commit(
+                Some("refs/heads/main"),
+                &sig,
+                &sig,
+                "Initial commit",
+                &tree,
+                &[],
+            )
+            .unwrap();
+
+        // Create two stack commits without GG trailers
+        let base_commit = repo.find_commit(base_oid).unwrap();
+
+        let tree_id2 = {
+            let mut index = repo.index().unwrap();
+            std::fs::write(temp_dir.path().join("a.txt"), "a").unwrap();
+            index.add_path(std::path::Path::new("a.txt")).unwrap();
+            index.write_tree().unwrap()
+        };
+        let tree2 = repo.find_tree(tree_id2).unwrap();
+        let commit1_oid = repo
+            .commit(None, &sig, &sig, "First commit", &tree2, &[&base_commit])
+            .unwrap();
+
+        let commit1 = repo.find_commit(commit1_oid).unwrap();
+        let tree_id3 = {
+            let mut index = repo.index().unwrap();
+            std::fs::write(temp_dir.path().join("b.txt"), "b").unwrap();
+            index.add_path(std::path::Path::new("b.txt")).unwrap();
+            index.write_tree().unwrap()
+        };
+        let tree3 = repo.find_tree(tree_id3).unwrap();
+        let commit2_oid = repo
+            .commit(None, &sig, &sig, "Second commit", &tree3, &[&commit1])
+            .unwrap();
+
+        // Run normalization
+        let (new_tip, counts) =
+            normalize_stack_metadata(&repo, base_oid, &[commit1_oid, commit2_oid]).unwrap();
+
+        // Verify counts
+        assert_eq!(counts.gg_ids_added, 2);
+        assert!(counts.gg_parents_updated > 0); // Second commit gets a parent
+
+        // Verify the new commits have correct trailers
+        let new_tip_commit = repo.find_commit(new_tip).unwrap();
+        let tip_msg = new_tip_commit.message().unwrap();
+        assert!(tip_msg.contains("GG-ID:"));
+        assert!(tip_msg.contains("GG-Parent:"));
+
+        // First commit should have GG-ID but no GG-Parent
+        let first_new_oid = new_tip_commit.parent_id(0).unwrap();
+        let first_new_commit = repo.find_commit(first_new_oid).unwrap();
+        let first_msg = first_new_commit.message().unwrap();
+        assert!(first_msg.contains("GG-ID:"));
+        assert!(!first_msg.contains("GG-Parent:"));
+
+        // The second commit's GG-Parent should match the first commit's GG-ID
+        let first_gg_id = get_gg_id(&first_new_commit).unwrap();
+        let second_parent = get_gg_parent(&new_tip_commit).unwrap();
+        assert_eq!(first_gg_id, second_parent);
+    }
+
+    #[test]
+    fn test_normalize_stack_metadata_preserves_existing_gg_ids() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let repo = git2::Repository::init(temp_dir.path()).unwrap();
+
+        let sig = git2::Signature::now("Test", "test@test.com").unwrap();
+        let tree_id = {
+            let mut index = repo.index().unwrap();
+            std::fs::write(temp_dir.path().join("file.txt"), "base").unwrap();
+            index.add_path(std::path::Path::new("file.txt")).unwrap();
+            index.write_tree().unwrap()
+        };
+        let tree = repo.find_tree(tree_id).unwrap();
+        let base_oid = repo
+            .commit(
+                Some("refs/heads/main"),
+                &sig,
+                &sig,
+                "Initial commit",
+                &tree,
+                &[],
+            )
+            .unwrap();
+
+        // Create a commit WITH a GG-ID already
+        let base_commit = repo.find_commit(base_oid).unwrap();
+        let commit1_oid = repo
+            .commit(
+                None,
+                &sig,
+                &sig,
+                "First commit\n\nGG-ID: c-abc1234",
+                &tree,
+                &[&base_commit],
+            )
+            .unwrap();
+
+        let (new_tip, counts) = normalize_stack_metadata(&repo, base_oid, &[commit1_oid]).unwrap();
+
+        // GG-ID should be preserved
+        assert_eq!(counts.gg_ids_added, 0);
+        let new_commit = repo.find_commit(new_tip).unwrap();
+        assert_eq!(get_gg_id(&new_commit), Some("c-abc1234".to_string()));
+        // First entry, no parent
+        assert_eq!(get_gg_parent(&new_commit), None);
+    }
+
+    #[test]
+    fn test_extract_description_strips_gg_parent() {
+        // Ensure GG-Parent trailer is also stripped from descriptions
+        let msg = "Title\n\nBody text\n\nGG-Parent: c-abc1234\nGG-ID: c-def5678";
+        let desc = extract_description_from_message(msg);
+        assert!(desc.is_some());
+        let desc = desc.unwrap();
+        assert!(!desc.contains("GG-Parent"));
+        assert!(!desc.contains("GG-ID"));
+        assert!(desc.contains("Body text"));
     }
 }
 

--- a/crates/gg-core/src/output.rs
+++ b/crates/gg-core/src/output.rs
@@ -47,6 +47,7 @@ pub struct StackEntryJson {
     pub sha: String,
     pub title: String,
     pub gg_id: Option<String>,
+    pub gg_parent: Option<String>,
     pub pr_number: Option<u64>,
     pub pr_state: Option<String>,
     pub approved: bool,
@@ -105,8 +106,16 @@ pub struct SyncResultJson {
     pub stack: String,
     pub base: String,
     pub rebased_before_sync: bool,
+    pub metadata: Option<SyncMetadataJson>,
     pub warnings: Vec<String>,
     pub entries: Vec<SyncEntryResultJson>,
+}
+
+#[derive(Serialize)]
+pub struct SyncMetadataJson {
+    pub gg_ids_added: usize,
+    pub gg_parents_updated: usize,
+    pub gg_parents_removed: usize,
 }
 
 #[derive(Serialize)]

--- a/crates/gg-core/src/stack.rs
+++ b/crates/gg-core/src/stack.rs
@@ -10,7 +10,7 @@ use git2::{Commit, Repository};
 
 use crate::config::Config;
 use crate::error::{GgError, Result};
-use crate::git::{self, get_gg_id, short_sha};
+use crate::git::{self, get_gg_id, get_gg_parent, short_sha};
 use crate::provider::{CiStatus, PrState, Provider};
 
 /// File to store the current stack when in detached HEAD mode
@@ -27,6 +27,8 @@ pub struct StackEntry {
     pub title: String,
     /// GG-ID (stable identifier)
     pub gg_id: Option<String>,
+    /// GG-Parent (previous entry's GG-ID in stack order)
+    pub gg_parent: Option<String>,
     /// PR number if synced
     pub mr_number: Option<u64>,
     /// PR state if synced
@@ -51,6 +53,7 @@ impl StackEntry {
             short_sha: short_sha(commit),
             title: git::get_commit_title(commit),
             gg_id: get_gg_id(commit),
+            gg_parent: get_gg_parent(commit),
             mr_number: None,
             mr_state: None,
             approved: false,

--- a/docs/plans/2026-03-24-stack-parent-trailers-design.md
+++ b/docs/plans/2026-03-24-stack-parent-trailers-design.md
@@ -1,0 +1,253 @@
+# Stack Parent Trailers Design
+
+**Status:** proposed  
+**Date:** 2026-03-24  
+**Scope:** Replace the discarded PR-description breadcrumb approach with stable commit-local stack metadata.
+
+---
+
+## Problem
+
+The original roadmap item proposed storing stack breadcrumbs in PR/MR descriptions during `gg sync`.
+
+That approach has two problems:
+
+1. It stores stack context in the wrong place. The stack structure belongs to commits, not remote PR/MR text.
+2. It encodes presentation-oriented data (`position`, `prev`, `next`) that changes frequently and is not stable across stack edits.
+
+We want a solution that behaves more like `GG-ID`: stable metadata attached to commits and preserved across rebases.
+
+---
+
+## Goals
+
+1. Persist stack topology in commit trailers.
+2. Keep the metadata stable across rebases, reorder, drop, split, and future reparent/restack operations.
+3. Avoid storing presentation/UI breadcrumbs in remote PR/MR descriptions.
+4. Make the topology derivable by both CLI and MCP consumers from commit-local metadata.
+5. Preserve existing `GG-ID` semantics and PR/MR mapping behavior.
+
+---
+
+## Non-goals
+
+- Do **not** update PR/MR descriptions with breadcrumb blocks.
+- Do **not** store `position`, `prev`, or `next` as trailers.
+- Do **not** introduce a new remote-only synchronization mechanism.
+- Do **not** add a full smartlog UI in this change (that remains a later roadmap task).
+
+---
+
+## Proposed metadata model
+
+Add a new commit trailer:
+
+```text
+GG-ID: c-abc1234
+GG-Parent: c-1234567
+```
+
+### Semantics
+
+- `GG-ID` continues to identify the commit itself.
+- `GG-Parent` identifies the immediate previous stack entry by its **GG-ID**.
+- The first entry in the stack has **no `GG-Parent` trailer**.
+- Because stacks are linear, child relationships are derived by scanning entries whose `GG-Parent` matches another entry's `GG-ID`.
+
+### Why `GG-Parent` only
+
+We intentionally avoid storing:
+- `GG-Position`
+- `GG-Prev`
+- `GG-Next`
+- stack breadcrumb text
+
+These are all derived, presentation-oriented values. They change whenever the stack is reordered, split, or pruned. `GG-Parent` is the smallest stable structural fact that lets higher-level views reconstruct stack relationships.
+
+---
+
+## Invariants
+
+For a loaded stack ordered from base to HEAD:
+
+- entry `0`: has `GG-ID`, has **no** `GG-Parent`
+- entry `n > 0`: has `GG-ID`, and `GG-Parent == entries[n - 1].gg_id`
+
+Additional rules:
+
+- `GG-Parent` must always reference another valid GG-ID in the same stack.
+- There must be no self-parent reference.
+- There must be no duplicate GG-IDs.
+- A stack should remain linear; multiple children for the same parent are considered invalid for this first version.
+
+---
+
+## Behavioral changes
+
+### `gg sync`
+
+`gg sync` should normalize stack trailers before pushing:
+
+- add missing `GG-ID`s if needed (existing behavior)
+- update/remove `GG-Parent` trailers to match current stack order
+
+`gg sync` should report this in JSON output, for example:
+
+```json
+{
+  "sync": {
+    "metadata": {
+      "gg_ids_added": 1,
+      "gg_parents_updated": 2,
+      "gg_parents_removed": 1
+    }
+  }
+}
+```
+
+### `gg reconcile`
+
+`gg reconcile` should also detect and fix missing/incorrect `GG-Parent` trailers alongside GG-ID maintenance.
+
+### Structural commands
+
+Commands that change stack shape should leave the stack with normalized trailers:
+
+- `gg reorder`
+- `gg drop`
+- `gg split`
+- future `gg reparent` / `gg restack`
+
+Commands that do not change stack topology (for example squash/amend) should preserve trailers unchanged.
+
+---
+
+## Command-specific expectations
+
+### Reorder
+
+After reorder, rewrite `GG-Parent` trailers to match the new order.
+
+### Drop
+
+After drop, the commit immediately above the removed region should point to the nearest surviving predecessor, or have no `GG-Parent` if it becomes the first entry.
+
+### Split
+
+When splitting an original commit `B` into `B1` + `B2`:
+
+- `B1` gets a new `GG-ID`
+- `B1.GG-Parent` becomes the original predecessor's GG-ID (or none if first)
+- `B2` keeps the original `GG-ID`
+- `B2.GG-Parent` becomes `B1`'s new GG-ID
+- descendants of `B2` keep referencing `B2`'s GG-ID, so they do not need logical parent changes beyond normal stack rewrite
+
+### Sync after existing history edits
+
+If a user edited history externally and left `GG-Parent` stale, `gg sync` should repair it automatically.
+
+---
+
+## Implementation approach
+
+### 1. Add GG-Parent trailer helpers in `git.rs`
+
+Add helpers parallel to existing GG-ID utilities:
+
+- `pub const GG_PARENT_PREFIX: &str = "GG-Parent:";`
+- `get_gg_parent(commit: &Commit) -> Option<String>`
+- `set_gg_parent_in_message(message: &str, parent: Option<&str>) -> String`
+- `strip_gg_parent_from_message(message: &str) -> String`
+
+Also add a higher-level helper that normalizes both trailers together so the logic is centralized.
+
+### 2. Extend `StackEntry`
+
+Include optional parent GG-ID on loaded entries:
+
+```rust
+pub gg_parent: Option<String>
+```
+
+This keeps the topology visible to higher layers and JSON output in the future.
+
+### 3. Introduce a reusable trailer normalization pass
+
+Create a small helper in `gg-core` that rewrites a stack in order while preserving:
+
+- tree contents
+- author/committer
+- GG-ID continuity
+
+and normalizing:
+
+- `GG-ID`
+- `GG-Parent`
+
+This replaces the current `add_gg_ids_to_commits()`-only approach with a generalized metadata rewrite.
+
+### 4. Use the normalization pass in `sync` and `reconcile`
+
+`sync` and `reconcile` are the natural places to auto-heal metadata drift.
+
+### 5. Update structural commands only where necessary
+
+Commands that already rewrite history should either:
+
+- run the normalization helper afterwards, or
+- set correct trailers directly during rewrite if that is simpler/safer
+
+The simplest first implementation is to run one post-operation normalization pass after `drop`, `reorder`, and `split`.
+
+---
+
+## Alternatives considered
+
+### A. PR/MR description breadcrumbs
+
+Rejected.
+
+They are remote presentation data, not durable stack metadata, and they do not belong in commit-local state.
+
+### B. Store `GG-Position`, `GG-Prev`, `GG-Next`
+
+Rejected.
+
+Those values are derived and volatile. They change often and create unnecessary rewrite churn.
+
+### C. Store only current Git parent SHA
+
+Rejected.
+
+The Git parent SHA is not stable across rebases. The whole point of GG metadata is durable identity across rewritten history.
+
+---
+
+## Risks
+
+1. **More history rewriting**  
+   Normalizing trailers can rewrite commits even when file trees are unchanged.
+
+2. **Message trailer edge cases**  
+   We must preserve user-authored message body and non-GG trailers.
+
+3. **Mixed old/new stacks**  
+   Existing stacks without `GG-Parent` should be upgraded automatically without breaking sync.
+
+---
+
+## Mitigations
+
+- Keep normalization logic centralized and test-heavy.
+- Only manage `GG-ID` / `GG-Parent`; leave all other message content intact.
+- Report metadata rewrites in JSON output and human messages so automation is not surprised.
+
+---
+
+## Success criteria
+
+- A synced stack contains stable `GG-ID` + `GG-Parent` trailers.
+- Reordering, dropping, and splitting leave the stack with correct parent metadata.
+- No PR/MR description breadcrumbs are written.
+- `gg sync --json` exposes metadata rewrite counts.
+- The feature is fully covered by unit + integration tests.

--- a/docs/plans/2026-03-24-stack-parent-trailers-plan.md
+++ b/docs/plans/2026-03-24-stack-parent-trailers-plan.md
@@ -1,0 +1,108 @@
+# Stack Parent Trailers Implementation Plan
+
+**Goal:** Replace the discarded PR-description breadcrumb approach with stable commit-local stack metadata using `GG-Parent` trailers.
+**Architecture:** Extend existing GG-ID trailer handling in `gg-core/src/git.rs`, expose parent metadata on stack entries, and add one reusable trailer-normalization pass that `sync`, `reconcile`, and structural stack-editing commands can reuse.
+**Tech Stack:** Rust, `git2`, existing stack model (`Stack`, `StackEntry`), existing sync/reconcile rewrite flows, CLI/integration tests.
+
+---
+
+### Task 1: Add GG-Parent trailer parsing and message helpers
+
+**Files:**
+- Modify: `crates/gg-core/src/git.rs`
+- Test: `crates/gg-core/src/git.rs`
+
+**Steps:**
+1. Add `GG_PARENT_PREFIX` constant.
+2. Add `get_gg_parent(commit: &Commit) -> Option<String>`.
+3. Add helpers to set/remove GG-Parent in a commit message without disturbing non-GG content.
+4. Add a higher-level helper that normalizes both GG trailers in one pass.
+5. Add unit tests for:
+   - missing parent trailer
+   - setting parent trailer
+   - replacing parent trailer
+   - removing parent trailer for first stack entry
+   - preserving body + non-GG trailers
+
+### Task 2: Expose parent metadata in the stack model
+
+**Files:**
+- Modify: `crates/gg-core/src/stack.rs`
+- Test: `crates/gg-core/src/stack.rs` (or integration if existing unit coverage is insufficient)
+
+**Steps:**
+1. Add `gg_parent: Option<String>` to `StackEntry`.
+2. Populate it in `StackEntry::from_commit()`.
+3. Add a helper to compute the expected parent GG-ID for each loaded entry from stack order.
+4. Add tests covering:
+   - first entry has no expected parent
+   - middle/head entries resolve expected parent correctly
+
+### Task 3: Replace GG-ID-only rewrite with generalized metadata normalization
+
+**Files:**
+- Modify: `crates/gg-core/src/commands/sync.rs`
+- Modify: `crates/gg-core/src/commands/reconcile.rs`
+- Modify: `crates/gg-core/src/output.rs`
+- Test: `crates/gg-core/src/commands/sync.rs`
+
+**Steps:**
+1. Replace `add_gg_ids_to_commits()` with a generalized stack metadata normalization helper.
+2. The helper should, for each entry in order:
+   - preserve existing GG-ID when present
+   - generate one if missing
+   - set/remove `GG-Parent` to match stack order
+3. Return structured counts:
+   - `gg_ids_added`
+   - `gg_parents_updated`
+   - `gg_parents_removed`
+4. Extend sync JSON output with a `metadata` block.
+5. Update reconcile to detect and repair GG-Parent drift.
+6. Add tests for:
+   - sync adds missing GG-ID and GG-Parent together
+   - sync repairs stale GG-Parent after history edits
+   - JSON output includes metadata counts
+
+### Task 4: Normalize metadata after structural stack changes
+
+**Files:**
+- Modify: `crates/gg-core/src/commands/reorder.rs`
+- Modify: `crates/gg-core/src/commands/drop_cmd.rs`
+- Modify: `crates/gg-core/src/commands/split.rs`
+- Possibly modify: `crates/gg-core/src/commands/mod.rs` (if shared helper placement requires it)
+- Test: `crates/gg-cli/tests/integration_tests.rs`
+
+**Steps:**
+1. After `reorder`, run trailer normalization and verify parent chain matches new order.
+2. After `drop`, run trailer normalization and verify the first surviving child points to the correct predecessor.
+3. After `split`, ensure:
+   - new lower commit gets a fresh GG-ID
+   - original upper commit keeps its GG-ID
+   - both end up with correct GG-Parent trailers after normalization
+4. Add integration tests for reorder/drop/split covering GG-Parent behavior.
+
+### Task 5: Update docs and skills
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/src/core-concepts.md`
+- Modify: `docs/src/commands/sync.md`
+- Modify: `docs/src/commands/reconcile.md`
+- Modify: `skills/gg/SKILL.md`
+- Modify: `skills/gg/reference.md`
+
+**Steps:**
+1. Document `GG-Parent` as the stable structural trailer.
+2. Remove/replace any description of PR/MR breadcrumb syncing.
+3. Document that `sync` and `reconcile` may rewrite commit metadata to normalize stack topology.
+
+### Task 6: Full verification and PR
+
+**Files:**
+- No code changes expected unless fixes are needed.
+
+**Steps:**
+1. Run `cargo fmt --all`.
+2. Run `cargo clippy --all-targets --all-features -- -D warnings`.
+3. Run `cargo test --all-features`.
+4. Open a PR with design/plan references.

--- a/docs/src/commands/reconcile.md
+++ b/docs/src/commands/reconcile.md
@@ -12,7 +12,8 @@ gg reconcile [OPTIONS]
 
 ## What it does
 
-- Adds missing GG-ID trailers to stack commits
+- Normalizes GG-ID and GG-Parent trailers on all stack commits
+- Adds missing GG-IDs, fixes stale GG-Parent chains
 - Maps existing remote PRs/MRs back to local stack entries
 
 ## Examples

--- a/docs/src/commands/sync.md
+++ b/docs/src/commands/sync.md
@@ -49,6 +49,16 @@ gg sync --no-rebase-check
 gg sync --json
 ```
 
+## Metadata normalization
+
+Before pushing, `gg sync` normalizes stack metadata trailers on every commit:
+
+- Adds missing `GG-ID` trailers automatically
+- Sets/fixes `GG-Parent` trailers to match the current stack order
+- The first entry has no `GG-Parent`; subsequent entries point to the previous entry's `GG-ID`
+
+This normalization is fully automatic — no flags or prompts. If no trailers need updating, no commits are rewritten.
+
 Example JSON (shape):
 
 ```json
@@ -58,6 +68,11 @@ Example JSON (shape):
     "stack": "my-stack",
     "base": "main",
     "rebased_before_sync": false,
+    "metadata": {
+      "gg_ids_added": 1,
+      "gg_parents_updated": 2,
+      "gg_parents_removed": 0
+    },
     "entries": [
       {
         "position": 1,
@@ -76,3 +91,5 @@ Example JSON (shape):
   }
 }
 ```
+
+The `metadata` field is `null` when no normalization was needed.

--- a/docs/src/core-concepts.md
+++ b/docs/src/core-concepts.md
@@ -15,19 +15,20 @@ In git-gud, each commit is an "entry" in the stack:
 
 That gives reviewers small units, while preserving execution order.
 
-## GG-IDs
+## GG-IDs and GG-Parent trailers
 
-Each stack commit carries a stable trailer, for example:
+Each stack commit carries stable trailers that persist across rebases:
 
 ```text
+GG-Parent: c-1234567
 GG-ID: c-abc1234
 ```
 
-Why GG-IDs matter:
+**GG-ID** identifies the commit itself — it keeps commit-to-PR/MR mappings stable across rebases, lets git-gud identify entries by a durable ID (not just SHA), and makes reconcile and navigation safer after history edits.
 
-- They keep commit-to-PR/MR mappings stable across rebases
-- They let git-gud identify entries by a durable ID (not just SHA)
-- They make reconcile and navigation safer after history edits
+**GG-Parent** records the GG-ID of the previous entry in the stack. The first entry has no `GG-Parent`. This trailer encodes the stack's topology directly in commit metadata, so higher-level tools (CLI, MCP, agents) can reconstruct the dependency chain from commits alone — without relying on PR description breadcrumbs or remote state.
+
+Both trailers are managed automatically. `gg sync`, `gg reconcile`, `gg reorder`, `gg drop`, and `gg split` all normalize the trailer chain after any stack changes.
 
 ## Branch naming convention
 

--- a/skills/gg/reference.md
+++ b/skills/gg/reference.md
@@ -222,6 +222,7 @@ All JSON payloads include `version` (`u32`, current value: `1`).
         "sha": "string",
         "title": "string",
         "gg_id": "c-...",
+        "gg_parent": "c-... | null",
         "pr_number": 123,
         "pr_state": "open",
         "approved": false,
@@ -239,6 +240,7 @@ Field types:
 - `current_position`: `number | null`
 - `behind_base`: `number | null`
 - `gg_id`: `string | null`
+- `gg_parent`: `string | null` — GG-ID of the previous stack entry (null for first entry)
 - `pr_number`: `number | null`
 - `pr_state`: `"open" | "merged" | "closed" | "draft" | null`
 - `ci_status`: `string | null`
@@ -291,6 +293,11 @@ Field types:
     "stack": "feature-auth",
     "base": "main",
     "rebased_before_sync": false,
+    "metadata": {
+      "gg_ids_added": 0,
+      "gg_parents_updated": 0,
+      "gg_parents_removed": 0
+    },
     "warnings": [],
     "entries": [
       {
@@ -426,7 +433,7 @@ Transport: stdio (JSON-RPC over stdin/stdout).
 #### `stack_list`
 List the current stack with commit entries and PR/MR status.
 - **Params:** `refresh` (bool, default false) — refresh PR status from remote
-- **Returns:** `{ name, base, total_commits, synced_commits, current_position, entries: [{ position, sha, title, gg_id, pr_number, pr_state, approved, ci_status, is_current }] }`
+- **Returns:** `{ name, base, total_commits, synced_commits, current_position, entries: [{ position, sha, title, gg_id, gg_parent, pr_number, pr_state, approved, ci_status, is_current }] }`
 
 #### `stack_list_all`
 List all stacks in the repository.


### PR DESCRIPTION
## Summary

- Adds `GG-Parent: <gg-id>` trailer to commit messages, encoding stack topology directly in commit metadata (replacing PR-description breadcrumbs)
- Centralizes all trailer management into a single `normalize_stack_metadata()` pass that ensures correct GG-ID + GG-Parent chain
- Makes metadata normalization fully automatic — no more prompts for GG-ID addition during sync/reconcile
- Normalizes GG-Parent chain after all structural operations (reorder, drop, split)
- Exposes `gg_parent` in JSON output and adds `metadata` counts to sync JSON

## Design reference

Implements the approved design from `68fccd6` (docs/plan: design GG-Parent stack metadata).

## Changes by area

**Core (`git.rs`)** — +492 lines
- GG-Parent trailer helpers: parse, set, strip, normalize
- `normalize_stack_metadata()`: single-pass rewrite ensuring GG-ID + GG-Parent chain
- `normalize_current_stack_metadata()`: convenience wrapper for structural commands
- `MetadataNormalizationCounts` struct tracking ids_added, parents_updated, parents_removed
- 18 unit tests covering all new functions

**Stack model (`stack.rs`, `output.rs`)**
- `gg_parent: Option<String>` on `StackEntry`
- `gg_parent` in `StackEntryJson`, `SyncMetadataJson` in output

**Commands**
- `sync.rs`: Replaced `add_gg_ids_to_commits()` + prompt with automatic `normalize_metadata_for_sync()`
- `reconcile.rs`: Replaced old GG-ID-only logic with `normalize_stack_trailers()`
- `reorder.rs`, `drop_cmd.rs`, `split.rs`: Added normalization after structural changes
- `ls.rs`: Exposed `gg_parent` in JSON output

**Tests** — 3 new integration tests
- `test_gg_parent_trailers_in_ls_json`
- `test_reorder_normalizes_gg_parent`
- `test_drop_normalizes_gg_parent`

**Docs/Skills** — Updated core-concepts, sync, reconcile docs, reference.md, README, CLAUDE.md

## Test plan

- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — no warnings
- [x] 321 unit tests pass (`cargo test --lib --all-features`)
- [x] 139 integration tests pass (`cargo test --test integration_tests --all-features -- --skip absorb`)
- [ ] Verify sync creates proper GG-Parent chain on real stack
- [ ] Verify reconcile fixes stale GG-Parent after manual rebase
- [ ] Verify reorder/drop/split maintain correct GG-Parent chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)