### PR TITLE
fix(clean): fallback to HEAD detach when checkout fails due to linked worktree

### DIFF
--- a/crates/gg-cli/tests/integration_tests.rs
+++ b/crates/gg-cli/tests/integration_tests.rs
@@ -6976,7 +6976,10 @@ fn test_gg_clean_current_branch_with_main_in_linked_worktree() {
     );
 
     // Merge the stack onto main so gg clean considers it cleaned
-    run_git(&linked_path, &["merge", "--ff-only", "testuser/broken-windows"]);
+    run_git(
+        &linked_path,
+        &["merge", "--ff-only", "testuser/broken-windows"],
+    );
 
     // Now: main worktree is on testuser/broken-windows, linked worktree has main.
     // gg clean must handle checking out main (the base) gracefully.
@@ -6984,8 +6987,7 @@ fn test_gg_clean_current_branch_with_main_in_linked_worktree() {
     assert!(
         success,
         "gg clean should succeed even when main is in a linked worktree.\nstdout={}\nstderr={}",
-        stdout,
-        stderr
+        stdout, stderr
     );
 
     // Stack branch must be gone
@@ -7003,7 +7005,12 @@ fn test_gg_clean_current_branch_with_main_in_linked_worktree() {
 
     // Clean up linked worktree
     let _ = Command::new("git")
-        .args(["worktree", "remove", "--force", linked_path.to_str().unwrap()])
+        .args([
+            "worktree",
+            "remove",
+            "--force",
+            linked_path.to_str().unwrap(),
+        ])
         .current_dir(&repo_path)
         .output();
 }

--- a/crates/gg-cli/tests/integration_tests.rs
+++ b/crates/gg-cli/tests/integration_tests.rs
@@ -6932,3 +6932,78 @@ fn test_drop_last_commit() {
     assert!(stdout.contains("Commit 2"));
     assert!(!stdout.contains("Commit 3"));
 }
+
+#[test]
+fn test_gg_clean_current_branch_with_main_in_linked_worktree() {
+    // Regression: gg clean crashed when user is on the stack branch and
+    // main is checked out in a linked worktree.
+    // Error was: "cannot set HEAD to reference 'refs/heads/main' as it is
+    // the current HEAD of a linked repository"
+    let (temp_dir, repo_path) = create_test_repo();
+
+    // Set up gg config
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .expect("Failed to write config");
+
+    // Create the stack and add a commit on it
+    let stack_name = "broken-windows";
+    let (success, _stdout, stderr) = run_gg(&repo_path, &["co", stack_name]);
+    assert!(success, "Failed to create stack: {}", stderr);
+
+    fs::write(repo_path.join("feat.txt"), "feature\n").expect("Failed to write feat.txt");
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "feat: add feature"]);
+
+    // Move HEAD back to the stack branch explicitly
+    run_git(&repo_path, &["checkout", "testuser/broken-windows"]);
+
+    // Create a linked worktree that checks out main — this is the trigger for the bug
+    let linked_path = temp_dir.path().join("linked-main");
+    let output = Command::new("git")
+        .args(["worktree", "add", linked_path.to_str().unwrap(), "main"])
+        .current_dir(&repo_path)
+        .output()
+        .expect("Failed to run git worktree add");
+    assert!(
+        output.status.success(),
+        "git worktree add failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Merge the stack onto main so gg clean considers it cleaned
+    run_git(&linked_path, &["merge", "--ff-only", "testuser/broken-windows"]);
+
+    // Now: main worktree is on testuser/broken-windows, linked worktree has main.
+    // gg clean must handle checking out main (the base) gracefully.
+    let (success, stdout, stderr) = run_gg(&repo_path, &["clean", "--json", "--all"]);
+    assert!(
+        success,
+        "gg clean should succeed even when main is in a linked worktree.\nstdout={}\nstderr={}",
+        stdout,
+        stderr
+    );
+
+    // Stack branch must be gone
+    let branch_output = Command::new("git")
+        .args(["branch", "--list", "testuser/broken-windows"])
+        .current_dir(&repo_path)
+        .output()
+        .expect("Failed to list branches");
+    assert!(
+        String::from_utf8_lossy(&branch_output.stdout)
+            .trim()
+            .is_empty(),
+        "Stack branch should have been deleted"
+    );
+
+    // Clean up linked worktree
+    let _ = Command::new("git")
+        .args(["worktree", "remove", "--force", linked_path.to_str().unwrap()])
+        .current_dir(&repo_path)
+        .output();
+}

--- a/crates/gg-core/src/commands/clean.rs
+++ b/crates/gg-core/src/commands/clean.rs
@@ -68,7 +68,27 @@ pub fn run_for_stack_with_repo(repo: &Repository, stack_name: &str, force: bool)
                 .or_else(|| git::find_base_branch(repo).ok())
                 .unwrap_or_else(|| "main".to_string());
 
-            git::checkout_branch(repo, &base)?;
+            // The pre-detection above can miss worktrees if
+            // Repository::open_from_worktree fails on them. Add a
+            // defensive fallback: if checkout fails because the branch is
+            // in a linked worktree, detach HEAD instead.
+            if let Err(e) = git::checkout_branch(repo, &base) {
+                let msg = e.to_string();
+                if msg.contains("current HEAD of a linked") {
+                    println!(
+                        "{} '{}' is checked out in another worktree; detaching HEAD before branch deletion.",
+                        style("Note:").cyan(),
+                        base
+                    );
+                    if let Ok(head) = repo.head() {
+                        if let Some(oid) = head.target() {
+                            repo.set_head_detached(oid)?;
+                        }
+                    }
+                } else {
+                    return Err(e);
+                }
+            }
         }
 
         // Check if branch is HEAD of a worktree
@@ -235,7 +255,26 @@ pub fn run(clean_all: bool, json: bool) -> Result<()> {
                         .or_else(|| git::find_base_branch(&repo).ok())
                         .unwrap_or_else(|| "main".to_string());
 
-                    git::checkout_branch(&repo, &base)?;
+                    // Defensive fallback for the same linked-worktree case.
+                    if let Err(e) = git::checkout_branch(&repo, &base) {
+                        let msg = e.to_string();
+                        if msg.contains("current HEAD of a linked") {
+                            if !json {
+                                println!(
+                                    "{} '{}' is checked out in another worktree; detaching HEAD before branch deletion.",
+                                    style("Note:").cyan(),
+                                    base
+                                );
+                            }
+                            if let Ok(head) = repo.head() {
+                                if let Some(oid) = head.target() {
+                                    repo.set_head_detached(oid)?;
+                                }
+                            }
+                        } else {
+                            return Err(e);
+                        }
+                    }
                 }
 
                 // Check if branch is HEAD of a worktree


### PR DESCRIPTION
## Summary

- `gg clean` crashed with `cannot set HEAD to reference 'refs/heads/main' as it is the current HEAD of a linked repository` when the user was on the stack branch being cleaned and `main` was checked out in a linked worktree
- Added a defensive fallback in both `run_for_stack_with_repo` and `run`: if `checkout_branch` returns the "current HEAD of a linked" libgit2 error, detach HEAD instead of propagating — same outcome as the intentional `base_in_use` guard path
- Added a regression test that reproduces the exact failure scenario (main worktree on stack branch, linked worktree on main)

## Root cause

The existing `base_in_use` guard calls `is_branch_checked_out_in_worktree`, which iterates linked worktrees via `repo.worktrees()` + `Repository::open_from_worktree`. If `open_from_worktree` fails for any worktree (locked, stale path, permission issue), that worktree is silently skipped and `base_in_use` returns `false`. The code then calls `checkout_branch` which fails at the libgit2 level.

## Test plan

- [x] Regression test `test_gg_clean_current_branch_with_main_in_linked_worktree` confirmed **failing** before fix, **passing** after
- [x] All `test_gg_clean_*` tests pass
- [x] Full test suite passes (`cargo test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)