### PR TITLE
feat(run): add gg run command

### DIFF
--- a/crates/gg-cli/src/main.rs
+++ b/crates/gg-cli/src/main.rs
@@ -253,6 +253,38 @@ enum Commands {
         json: bool,
     },
 
+    /// Run a command on each commit in the stack
+    #[command(name = "run")]
+    Run {
+        /// Command to run on each commit (use quotes for commands with args)
+        #[arg(trailing_var_arg = true, required = true)]
+        command: Vec<String>,
+
+        /// Stage and amend file changes into each commit
+        #[arg(long, group = "mode")]
+        amend: bool,
+
+        /// Discard file changes after each commit
+        #[arg(long, group = "mode")]
+        discard: bool,
+
+        /// Continue running on remaining commits after a failure
+        #[arg(long)]
+        keep_going: bool,
+
+        /// Stop at this commit position (default: current)
+        #[arg(short, long)]
+        until: Option<usize>,
+
+        /// Number of parallel jobs (0 = auto, 1 = sequential, default: 1)
+        #[arg(short, long, default_value = "1")]
+        jobs: usize,
+
+        /// Output structured JSON
+        #[arg(long)]
+        json: bool,
+    },
+
     /// Set up git-gud config for this repository
     #[command(name = "setup")]
     Setup {
@@ -468,6 +500,46 @@ fn main() {
             gg_core::commands::lint::run(until, json, json).map(|_| ()),
             json,
         ),
+        Some(Commands::Run {
+            command,
+            amend,
+            discard,
+            keep_going,
+            until,
+            jobs,
+            json,
+        }) => {
+            let change_mode = if amend {
+                gg_core::commands::run::ChangeMode::Amend
+            } else if discard {
+                gg_core::commands::run::ChangeMode::Discard
+            } else {
+                gg_core::commands::run::ChangeMode::ReadOnly
+            };
+
+            (
+                gg_core::commands::run::execute(gg_core::commands::run::RunOptions {
+                    commands: vec![command.join(" ")],
+                    change_mode,
+                    until,
+                    stop_on_error: !keep_going,
+                    json,
+                    emit_json_output: json,
+                    header_label: None,
+                    jobs,
+                })
+                .and_then(|all_passed| {
+                    if all_passed {
+                        Ok(())
+                    } else {
+                        Err(gg_core::error::GgError::Other(
+                            "Some commands failed".to_string(),
+                        ))
+                    }
+                }),
+                json,
+            )
+        }
         Some(Commands::Setup { all }) => (gg_core::commands::setup::run(all), false),
         Some(Commands::Absorb {
             dry_run,

--- a/crates/gg-cli/tests/integration_tests.rs
+++ b/crates/gg-cli/tests/integration_tests.rs
@@ -6932,3 +6932,343 @@ fn test_drop_last_commit() {
     assert!(stdout.contains("Commit 2"));
     assert!(!stdout.contains("Commit 3"));
 }
+
+// ==========================================================================
+// gg run tests
+// ==========================================================================
+
+#[test]
+fn test_gg_run_readonly_passing() {
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .expect("Failed to write config");
+
+    let (success, _, stderr) = run_gg(&repo_path, &["co", "run-test"]);
+    assert!(success, "Failed to create stack: {}", stderr);
+
+    fs::write(repo_path.join("test.txt"), "content").expect("Failed to write file");
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "Test commit"]);
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["run", "git", "--version"]);
+    assert!(
+        success,
+        "gg run should succeed: stdout={}, stderr={}",
+        stdout, stderr
+    );
+    assert!(
+        stdout.contains("all passed") || stdout.contains("OK"),
+        "Expected success message in: {}",
+        stdout
+    );
+}
+
+#[test]
+fn test_gg_run_readonly_failing() {
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .expect("Failed to write config");
+
+    let (success, _, stderr) = run_gg(&repo_path, &["co", "run-fail-test"]);
+    assert!(success, "Failed to create stack: {}", stderr);
+
+    fs::write(repo_path.join("test.txt"), "content").expect("Failed to write file");
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "Test commit"]);
+
+    let (success, _stdout, _stderr) = run_gg(&repo_path, &["run", "false"]);
+    assert!(!success, "gg run with 'false' should fail");
+}
+
+#[test]
+fn test_gg_run_json_output() {
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .expect("Failed to write config");
+
+    let (success, _, stderr) = run_gg(&repo_path, &["co", "run-json-test"]);
+    assert!(success, "Failed to create stack: {}", stderr);
+
+    fs::write(repo_path.join("test.txt"), "content").expect("Failed to write file");
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "Test commit"]);
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["run", "--json", "git", "--version"]);
+    assert!(success, "gg run --json failed: {}", stderr);
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("stdout must be valid JSON");
+    assert_eq!(parsed["version"], 1);
+    assert_eq!(parsed["run"]["all_passed"], true);
+
+    let results = parsed["run"]["results"]
+        .as_array()
+        .expect("run.results must be an array");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0]["position"], 1);
+    assert_eq!(results[0]["commands"][0]["command"], "git --version");
+    assert_eq!(results[0]["commands"][0]["passed"], true);
+}
+
+#[cfg(unix)]
+#[test]
+fn test_gg_run_amend_mode() {
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .expect("Failed to write config");
+
+    let (success, _, stderr) = run_gg(&repo_path, &["co", "run-amend-test"]);
+    assert!(success, "Failed to create stack: {}", stderr);
+
+    fs::write(repo_path.join("test.txt"), "content").expect("Failed to write file");
+    fs::write(
+        repo_path.join("modify.sh"),
+        "#!/bin/sh\necho \"modified\" >> test.txt\n",
+    )
+    .expect("Failed to write script");
+    let mut perms = fs::metadata(repo_path.join("modify.sh"))
+        .unwrap()
+        .permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(repo_path.join("modify.sh"), perms).unwrap();
+
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "Test commit"]);
+
+    let original = fs::read_to_string(repo_path.join("test.txt")).unwrap();
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["run", "--amend", "./modify.sh"]);
+    assert!(
+        success,
+        "gg run --amend should succeed: stdout={}, stderr={}",
+        stdout, stderr
+    );
+
+    let modified = fs::read_to_string(repo_path.join("test.txt")).unwrap();
+    assert_ne!(
+        original, modified,
+        "File should have been modified and amended"
+    );
+    assert!(
+        modified.contains("modified"),
+        "File should contain 'modified'"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_gg_run_discard_mode() {
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .expect("Failed to write config");
+
+    let (success, _, stderr) = run_gg(&repo_path, &["co", "run-discard-test"]);
+    assert!(success, "Failed to create stack: {}", stderr);
+
+    fs::write(repo_path.join("test.txt"), "content").expect("Failed to write file");
+    fs::write(
+        repo_path.join("modify.sh"),
+        "#!/bin/sh\necho \"modified\" >> test.txt\n",
+    )
+    .expect("Failed to write script");
+    let mut perms = fs::metadata(repo_path.join("modify.sh"))
+        .unwrap()
+        .permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(repo_path.join("modify.sh"), perms).unwrap();
+
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "Test commit"]);
+
+    let original = fs::read_to_string(repo_path.join("test.txt")).unwrap();
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["run", "--discard", "./modify.sh"]);
+    assert!(
+        success,
+        "gg run --discard should succeed: stdout={}, stderr={}",
+        stdout, stderr
+    );
+
+    let after = fs::read_to_string(repo_path.join("test.txt")).unwrap();
+    assert_eq!(original, after, "File should be unchanged after --discard");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_gg_run_readonly_fails_on_dirty_tree() {
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .expect("Failed to write config");
+
+    let (success, _, stderr) = run_gg(&repo_path, &["co", "run-readonly-dirty-test"]);
+    assert!(success, "Failed to create stack: {}", stderr);
+
+    fs::write(repo_path.join("test.txt"), "content").expect("Failed to write file");
+    fs::write(
+        repo_path.join("modify.sh"),
+        "#!/bin/sh\necho \"modified\" >> test.txt\n",
+    )
+    .expect("Failed to write script");
+    let mut perms = fs::metadata(repo_path.join("modify.sh"))
+        .unwrap()
+        .permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(repo_path.join("modify.sh"), perms).unwrap();
+
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "Test commit"]);
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["run", "./modify.sh"]);
+    assert!(
+        !success,
+        "gg run (read-only) should fail when command modifies files"
+    );
+    let combined = format!("{}{}", stdout, stderr);
+    assert!(
+        combined.contains("modified files") || combined.contains("--amend") || combined.contains("--discard"),
+        "Error should mention the file modification and suggest --amend/--discard: {}",
+        combined
+    );
+}
+
+#[test]
+fn test_gg_run_parallel_passing() {
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .expect("Failed to write config");
+
+    let (success, _, stderr) = run_gg(&repo_path, &["co", "parallel-pass"]);
+    assert!(success, "Failed to create stack: {}", stderr);
+
+    fs::write(repo_path.join("file1.txt"), "content1").expect("write");
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "First commit"]);
+
+    fs::write(repo_path.join("file2.txt"), "content2").expect("write");
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "Second commit"]);
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["run", "-j", "2", "git", "--version"]);
+    assert!(
+        success,
+        "gg run --jobs should succeed: stdout={}, stderr={}",
+        stdout, stderr
+    );
+    assert!(
+        stdout.contains("all passed") || stdout.contains("OK"),
+        "Expected success message in: {}",
+        stdout
+    );
+}
+
+#[test]
+fn test_gg_run_parallel_failing() {
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .expect("Failed to write config");
+
+    let (success, _, stderr) = run_gg(&repo_path, &["co", "parallel-fail"]);
+    assert!(success, "Failed to create stack: {}", stderr);
+
+    fs::write(repo_path.join("file1.txt"), "content1").expect("write");
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "First commit"]);
+
+    fs::write(repo_path.join("file2.txt"), "content2").expect("write");
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "Second commit"]);
+
+    let (success, _stdout, _stderr) = run_gg(&repo_path, &["run", "-j", "2", "false"]);
+    assert!(!success, "gg run parallel with 'false' should fail");
+}
+
+#[test]
+fn test_gg_run_parallel_json_output() {
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .expect("Failed to write config");
+
+    let (success, _, stderr) = run_gg(&repo_path, &["co", "parallel-json"]);
+    assert!(success, "Failed to create stack: {}", stderr);
+
+    fs::write(repo_path.join("file1.txt"), "content1").expect("write");
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "First commit"]);
+
+    fs::write(repo_path.join("file2.txt"), "content2").expect("write");
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "Second commit"]);
+
+    let (success, stdout, stderr) = run_gg(
+        &repo_path,
+        &["run", "-j", "2", "--json", "git", "--version"],
+    );
+    assert!(
+        success,
+        "gg run parallel --json should succeed: stderr={}",
+        stderr
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("should be valid JSON");
+    assert_eq!(json["run"]["all_passed"], true);
+    let results = json["run"]["results"].as_array().expect("results array");
+    assert_eq!(results.len(), 2);
+    // Results should be in commit position order
+    assert_eq!(results[0]["position"], 1);
+    assert_eq!(results[1]["position"], 2);
+}

--- a/crates/gg-core/src/commands/lint.rs
+++ b/crates/gg-core/src/commands/lint.rs
@@ -1,20 +1,20 @@
-//! `gg lint` - Run lint commands on each commit in the stack
-
-use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+//! `gg lint` - Run configured lint commands on each commit in the stack
+//!
+//! Thin wrapper around `gg run` that reads commands from config
+//! and uses `ChangeMode::Amend`.
 
 use console::style;
-use git2::Oid;
 
 use crate::config::Config;
-use crate::error::{GgError, Result};
+use crate::error::Result;
 use crate::git;
 use crate::output::{
     self, LintCommandResult, LintCommitResult, LintResponse, LintResultJson, OUTPUT_VERSION,
 };
-use crate::stack::{Stack, StackEntry};
 
-/// Run the lint command
+use super::run::{self, ChangeMode, RunOptions};
+
+/// Run the lint command.
 ///
 /// Returns `Ok(true)` when all lint commands passed for all linted commits,
 /// `Ok(false)` when one or more commits had lint failures.
@@ -22,10 +22,6 @@ pub fn run(until: Option<usize>, json: bool, emit_json_output: bool) -> Result<b
     let repo = git::open_repo()?;
     let config = Config::load_with_global(repo.commondir())?;
 
-    // Require clean working directory
-    git::require_clean_working_directory(&repo)?;
-
-    // Get lint commands from config
     let lint_commands = &config.defaults.lint;
     if lint_commands.is_empty() {
         if json && emit_json_output {
@@ -47,56 +43,49 @@ pub fn run(until: Option<usize>, json: bool, emit_json_output: bool) -> Result<b
         return Ok(true);
     }
 
-    // Load stack
-    let stack = Stack::load(&repo, &config)?;
+    let result = run::execute_raw(RunOptions {
+        commands: lint_commands.clone(),
+        change_mode: ChangeMode::Amend,
+        until,
+        stop_on_error: false,
+        json,
+        emit_json_output,
+        header_label: Some("lint".to_string()),
+        jobs: 1,
+    })?;
 
-    if stack.is_empty() {
-        if json && emit_json_output {
-            print_empty_response();
-        } else if !json {
-            println!("{}", style("Stack is empty. Nothing to lint.").dim());
-        }
-        return Ok(true);
+    if json && emit_json_output {
+        // Emit LintResponse (key: "lint") for backward compatibility
+        let lint_results: Vec<LintCommitResult> = result
+            .results
+            .into_iter()
+            .map(|r| LintCommitResult {
+                position: r.position,
+                sha: r.sha,
+                title: r.title,
+                passed: r.passed,
+                commands: r
+                    .commands
+                    .into_iter()
+                    .map(|c| LintCommandResult {
+                        command: c.command,
+                        passed: c.passed,
+                        output: c.output,
+                    })
+                    .collect(),
+            })
+            .collect();
+
+        output::print_json(&LintResponse {
+            version: OUTPUT_VERSION,
+            lint: LintResultJson {
+                results: lint_results,
+                all_passed: result.all_passed,
+            },
+        });
     }
 
-    // Determine the end position
-    let end_pos =
-        until.unwrap_or_else(|| stack.current_position.map(|p| p + 1).unwrap_or(stack.len()));
-
-    if end_pos > stack.len() {
-        return Err(GgError::Other(format!(
-            "Position {} is out of range (max: {})",
-            end_pos,
-            stack.len()
-        )));
-    }
-
-    if !json {
-        println!(
-            "{}",
-            style(format!(
-                "Running lint on commits 1-{} ({} lint commands)",
-                end_pos,
-                lint_commands.len()
-            ))
-            .dim()
-        );
-    }
-
-    // Remember current branch/HEAD
-    let original_branch = git::current_branch_name(&repo);
-    let original_head = repo.head()?.peel_to_commit()?.id();
-
-    // Run lint with cleanup on error
-    let result = run_lint_on_commits(&repo, stack, lint_commands, end_pos, json, emit_json_output);
-
-    // Try to restore original position on error, but NOT if there's a rebase in progress
-    // (user needs to resolve conflicts in place)
-    if result.is_err() && !git::is_rebase_in_progress(&repo) {
-        restore_original_position(&repo, original_branch.as_deref(), original_head, json);
-    }
-
-    result
+    Ok(result.all_passed)
 }
 
 fn print_empty_response() {
@@ -107,451 +96,4 @@ fn print_empty_response() {
             all_passed: true,
         },
     });
-}
-
-/// Run lint commands on commits, returning the result
-fn run_lint_on_commits(
-    repo: &git2::Repository,
-    stack: Stack,
-    lint_commands: &[String],
-    end_pos: usize,
-    json: bool,
-    emit_json_output: bool,
-) -> Result<bool> {
-    let original_branch = git::current_branch_name(repo);
-    let original_head = repo.head()?.peel_to_commit()?.id();
-    let repo_root = repo
-        .workdir()
-        .ok_or_else(|| GgError::Other("Repository has no working directory".to_string()))?;
-    let mut had_changes = false;
-    let base_branch = stack.base.clone();
-    let stack_branch = stack.branch_name();
-    let mut entries = stack.entries.clone();
-    let mut lint_results: Vec<LintCommitResult> = Vec::with_capacity(end_pos);
-
-    // Process each commit from first to end_pos
-    let mut i = 0;
-    while i < end_pos {
-        let entry = entries[i].clone();
-        let mut had_changes_this_commit = false;
-
-        if !json {
-            println!();
-            println!(
-                "{} Linting [{}] {} {}",
-                style("→").cyan(),
-                entry.position,
-                style(&entry.short_sha).yellow(),
-                entry.title
-            );
-        }
-
-        // Checkout this commit
-        let commit = repo.find_commit(entry.oid)?;
-        git::checkout_commit(repo, &commit)?;
-
-        // Run lint commands
-        let mut commit_passed = true;
-        let mut command_results = Vec::with_capacity(lint_commands.len());
-
-        for cmd in lint_commands {
-            if !json {
-                print!("  Running: {} ... ", style(cmd).dim());
-            }
-
-            let parts: Vec<&str> = cmd.split_whitespace().collect();
-            if parts.is_empty() {
-                continue;
-            }
-
-            // Resolve .git/ paths to the real git common directory so that
-            // scripts like `./.git/gg/lint.sh` work in linked worktrees
-            // (where `.git` is a file, not a directory).
-            let resolved_cmd = resolve_git_path(parts[0], repo);
-            let cmd_str = resolved_cmd
-                .as_ref()
-                .map(|p| p.to_string_lossy())
-                .unwrap_or_else(|| parts[0].into());
-
-            let output = match Command::new(cmd_str.as_ref())
-                .args(&parts[1..])
-                .current_dir(repo_root)
-                .output()
-            {
-                Ok(output) => output,
-                Err(e) => {
-                    if !json {
-                        println!("{}", style("ERROR").red().bold());
-                    }
-                    let error_msg = if e.kind() == std::io::ErrorKind::NotFound {
-                        format!(
-                            "Command '{}' not found. Make sure it's installed and in your PATH.\n\
-                             Note: Shell aliases don't work here. Use the full command (e.g., './gradlew' instead of 'gw').",
-                            parts[0]
-                        )
-                    } else {
-                        format!("Failed to run '{}': {}", parts[0], e)
-                    };
-                    return Err(GgError::Other(error_msg));
-                }
-            };
-
-            let passed = output.status.success();
-            if passed {
-                if !json {
-                    println!("{}", style("OK").green());
-                }
-            } else {
-                commit_passed = false;
-                if !json {
-                    println!("{}", style("FAILED").red());
-                    let stderr = String::from_utf8_lossy(&output.stderr);
-                    if !stderr.is_empty() {
-                        for line in stderr.lines().take(5) {
-                            println!("    {}", style(line).dim());
-                        }
-                    }
-                }
-            }
-
-            let combined_output = if passed {
-                None
-            } else {
-                let stderr = String::from_utf8_lossy(&output.stderr);
-                let stdout = String::from_utf8_lossy(&output.stdout);
-                let mut text = String::new();
-                if !stderr.trim().is_empty() {
-                    text.push_str(stderr.trim_end());
-                }
-                if !stdout.trim().is_empty() {
-                    if !text.is_empty() {
-                        text.push('\n');
-                    }
-                    text.push_str(stdout.trim_end());
-                }
-                if text.is_empty() {
-                    None
-                } else {
-                    Some(text)
-                }
-            };
-
-            command_results.push(LintCommandResult {
-                command: cmd.clone(),
-                passed,
-                output: combined_output,
-            });
-        }
-
-        // Check if lint made changes
-        if !git::is_working_directory_clean(repo)? {
-            if !json {
-                println!("  {} Lint made changes, squashing...", style("!").yellow());
-            }
-
-            // Stage all changes
-            let add_output = Command::new("git")
-                .args(["add", "-A"])
-                .current_dir(repo_root)
-                .output()?;
-
-            if !add_output.status.success() {
-                return Err(GgError::Other(format!(
-                    "Failed to stage changes: {}",
-                    String::from_utf8_lossy(&add_output.stderr).trim()
-                )));
-            }
-
-            // Amend the commit
-            let amend_output = Command::new("git")
-                .args(["commit", "--amend", "--no-edit"])
-                .current_dir(repo_root)
-                .stdin(Stdio::null())
-                .output()?;
-
-            if !amend_output.status.success() {
-                return Err(GgError::Other(format!(
-                    "Failed to amend commit: {}",
-                    String::from_utf8_lossy(&amend_output.stderr).trim()
-                )));
-            }
-
-            had_changes = true;
-            had_changes_this_commit = true;
-            if !json {
-                println!("  {} Changes squashed", style("OK").green());
-            }
-
-            // Rebase remaining commits in the lint range onto the amended commit
-            if i + 1 < end_pos {
-                let new_commit_oid = repo.head()?.peel_to_commit()?.id();
-                let old_tip_oid = entries[end_pos - 1].oid;
-
-                let new_commit = new_commit_oid.to_string();
-                let old_commit = entry.oid.to_string();
-                let old_tip = old_tip_oid.to_string();
-
-                let target_branch = original_branch.as_deref().unwrap_or(stack_branch.as_str());
-
-                // Ensure rebase is performed on the stack branch so it updates the branch
-                // and avoids leaving the user in detached HEAD after conflicts. We force the
-                // branch to the old tip so we only rebase the intended range.
-                git::run_git_command(&["branch", "-f", target_branch, &old_tip])?;
-                git::checkout_branch(repo, target_branch)?;
-
-                if let Err(e) = git::run_git_command(&[
-                    "rebase",
-                    "--onto",
-                    &new_commit,
-                    &old_commit,
-                    target_branch,
-                ]) {
-                    // Check if this is a rebase conflict
-                    if git::is_rebase_in_progress(repo) {
-                        print_rebase_conflict_help(repo_root, json);
-                        return Err(GgError::Other(
-                            "Rebase conflict occurred. Resolve conflicts and run `gg continue`."
-                                .to_string(),
-                        ));
-                    }
-                    return Err(e);
-                }
-
-                entries = refresh_stack_entries(repo, &base_branch, None)?;
-            }
-        }
-
-        let final_sha = if had_changes_this_commit {
-            let head = repo.head()?.peel_to_commit()?;
-            git::short_sha(&head)
-        } else {
-            entry.short_sha.clone()
-        };
-
-        lint_results.push(LintCommitResult {
-            position: entry.position,
-            sha: final_sha,
-            title: entry.title.clone(),
-            passed: commit_passed,
-            commands: command_results,
-        });
-
-        i += 1;
-    }
-
-    // Return to original position
-    if !json {
-        println!();
-    }
-    if let Some(branch) = original_branch {
-        if had_changes {
-            // Move the stack branch to the current HEAD (last linted commit)
-            // and checkout the branch to avoid leaving user in detached HEAD
-            git::move_branch_to_head(repo, &branch)?;
-            git::checkout_branch(repo, &branch)?;
-
-            if !json {
-                if end_pos < stack.len() {
-                    // Partial lint: remaining commits need rebasing
-                    println!(
-                        "{}",
-                        style("Lint made changes. Run `gg rebase` to update remaining commits, then `gg sync`.").dim()
-                    );
-                } else {
-                    println!(
-                        "{}",
-                        style("Lint made changes. Review with `gg ls` and sync with `gg sync`.")
-                            .dim()
-                    );
-                }
-            }
-        } else {
-            git::checkout_branch(repo, &branch)?;
-        }
-    } else {
-        // Return to original detached HEAD if no changes
-        if !had_changes {
-            let commit = repo.find_commit(original_head)?;
-            git::checkout_commit(repo, &commit)?;
-        }
-    }
-
-    let all_passed = lint_results.iter().all(|result| result.passed);
-
-    if json && emit_json_output {
-        output::print_json(&LintResponse {
-            version: OUTPUT_VERSION,
-            lint: LintResultJson {
-                results: lint_results,
-                all_passed,
-            },
-        });
-    } else if !json {
-        println!("{} Linted {} commits", style("OK").green().bold(), end_pos);
-    }
-
-    Ok(all_passed)
-}
-
-fn refresh_stack_entries(
-    repo: &git2::Repository,
-    base_branch: &str,
-    stack_branch: Option<&str>,
-) -> Result<Vec<StackEntry>> {
-    let oids = git::get_stack_commit_oids(repo, base_branch, stack_branch)?;
-
-    let mut entries = Vec::with_capacity(oids.len());
-    for (i, oid) in oids.iter().enumerate() {
-        let commit = repo.find_commit(*oid)?;
-        entries.push(StackEntry::from_commit(&commit, i + 1));
-    }
-
-    Ok(entries)
-}
-
-/// Restore the original branch/HEAD position
-fn restore_original_position(
-    repo: &git2::Repository,
-    original_branch: Option<&str>,
-    original_head: Oid,
-    json: bool,
-) {
-    if !json {
-        println!();
-        println!("{} Restoring original position...", style("→").cyan());
-    }
-
-    let restored = if let Some(branch) = original_branch {
-        git::checkout_branch(repo, branch).is_ok()
-    } else if let Ok(commit) = repo.find_commit(original_head) {
-        git::checkout_commit(repo, &commit).is_ok()
-    } else {
-        false
-    };
-
-    if !json {
-        if restored {
-            println!("{} Restored to original position", style("OK").green());
-        } else {
-            println!(
-                "{} Could not restore original position. You may be in detached HEAD.",
-                style("Warning:").yellow()
-            );
-        }
-    }
-}
-
-/// Resolve a command path that starts with `.git/` or `./.git/` to the real
-/// git common directory.  In a normal repo `commondir()` already points at
-/// `.git`, but in a linked worktree it points at the **main** repo's `.git`
-/// directory, so scripts stored there (e.g. `.git/gg/lint.sh`) are reachable.
-fn resolve_git_path(cmd: &str, repo: &git2::Repository) -> Option<PathBuf> {
-    let remainder = if let Some(rest) = cmd.strip_prefix("./.git/") {
-        rest
-    } else if let Some(rest) = cmd.strip_prefix(".git/") {
-        rest
-    } else {
-        return None;
-    };
-
-    Some(repo.commondir().join(remainder))
-}
-
-/// Get list of files with conflicts
-fn get_conflicted_files(repo_root: &Path) -> Vec<String> {
-    let output = Command::new("git")
-        .args(["diff", "--name-only", "--diff-filter=U"])
-        .current_dir(repo_root)
-        .output();
-
-    match output {
-        Ok(output) if output.status.success() => String::from_utf8_lossy(&output.stdout)
-            .lines()
-            .map(|s| s.to_string())
-            .filter(|s| !s.is_empty())
-            .collect(),
-        _ => Vec::new(),
-    }
-}
-
-/// Print helpful message when rebase conflict occurs during lint
-fn print_rebase_conflict_help(repo_root: &Path, json: bool) {
-    if json {
-        return;
-    }
-
-    println!();
-    println!(
-        "{} Rebase conflict while rebasing after lint changes",
-        style("⚠️").yellow()
-    );
-    println!();
-
-    let conflicted_files = get_conflicted_files(repo_root);
-    if !conflicted_files.is_empty() {
-        println!("The following files have conflicts:");
-        for file in &conflicted_files {
-            println!("  {} {}", style("-").dim(), file);
-        }
-        println!();
-    }
-
-    println!("To resolve:");
-    println!("  1. Edit the conflicting files to resolve conflicts");
-    println!("  2. {}", style("git add <resolved-files>").cyan());
-    println!("  3. {}", style("gg continue").cyan());
-    println!();
-    println!("To abort and undo lint changes:");
-    println!("  {}", style("gg abort").cyan());
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn temp_repo() -> (tempfile::TempDir, git2::Repository) {
-        let dir = tempfile::TempDir::new().unwrap();
-        let repo = git2::Repository::init(dir.path()).unwrap();
-        (dir, repo)
-    }
-
-    #[test]
-    fn test_resolve_git_path_with_dot_slash_prefix() {
-        let (_dir, repo) = temp_repo();
-        let result = resolve_git_path("./.git/gg/lint.sh", &repo);
-        assert!(result.is_some());
-        let resolved = result.unwrap();
-        assert!(
-            resolved.ends_with("gg/lint.sh"),
-            "Expected path ending with gg/lint.sh, got: {}",
-            resolved.display()
-        );
-        // Should point into the real .git directory
-        assert!(
-            resolved.starts_with(repo.commondir()),
-            "Should be under commondir: {}",
-            resolved.display()
-        );
-    }
-
-    #[test]
-    fn test_resolve_git_path_without_dot_slash_prefix() {
-        let (_dir, repo) = temp_repo();
-        let result = resolve_git_path(".git/gg/lint.sh", &repo);
-        assert!(result.is_some());
-        let resolved = result.unwrap();
-        assert!(
-            resolved.ends_with("gg/lint.sh"),
-            "Expected path ending with gg/lint.sh, got: {}",
-            resolved.display()
-        );
-    }
-
-    #[test]
-    fn test_resolve_git_path_non_git_path_returns_none() {
-        let (_dir, repo) = temp_repo();
-        assert!(resolve_git_path("cargo", &repo).is_none());
-        assert!(resolve_git_path("./scripts/lint.sh", &repo).is_none());
-        assert!(resolve_git_path("/usr/bin/lint", &repo).is_none());
-    }
 }

--- a/crates/gg-core/src/commands/mod.rs
+++ b/crates/gg-core/src/commands/mod.rs
@@ -10,6 +10,7 @@ pub mod lint;
 pub mod ls;
 pub mod nav;
 pub mod rebase;
+pub mod run;
 pub mod reconcile;
 pub mod reorder;
 pub mod reorder_tui;

--- a/crates/gg-core/src/commands/run.rs
+++ b/crates/gg-core/src/commands/run.rs
@@ -1,0 +1,1073 @@
+//! `gg run` - Run a command on each commit in the stack
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+
+use console::style;
+use git2::Oid;
+
+use crate::error::{GgError, Result};
+use crate::git;
+use crate::output::{
+    self, RunCommandResult, RunCommitResult, RunResponse, RunResultJson, OUTPUT_VERSION,
+};
+use crate::stack::{Stack, StackEntry};
+
+/// How to handle working-tree changes after running commands on a commit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChangeMode {
+    /// Fail with error if the working tree is dirty after running commands.
+    /// This is the default — safe for read-only validation (build, test).
+    ReadOnly,
+    /// Stage all changes and amend them into the commit.
+    /// Used by `gg lint` and auto-fixers (formatters, codemods).
+    Amend,
+    /// Discard all working-tree changes after each commit.
+    /// For commands with known side effects you want to ignore.
+    Discard,
+}
+
+/// Options for `run::execute()`.
+pub struct RunOptions {
+    /// Commands to execute on each commit.
+    pub commands: Vec<String>,
+    /// How to handle file modifications.
+    pub change_mode: ChangeMode,
+    /// Stop at this commit position (1-indexed). None = current position or full stack.
+    pub until: Option<usize>,
+    /// Stop on first command failure instead of continuing.
+    pub stop_on_error: bool,
+    /// Output structured JSON instead of text.
+    pub json: bool,
+    /// Whether to actually emit JSON output (false when called from sync).
+    pub emit_json_output: bool,
+    /// Optional label for the header (e.g. "lint" instead of "run").
+    pub header_label: Option<String>,
+    /// Number of parallel jobs. 0 = auto (num CPUs), 1 = sequential.
+    /// Parallel only applies to ReadOnly mode.
+    pub jobs: usize,
+}
+
+/// Raw result from running commands on the stack.
+pub struct RunResult {
+    pub all_passed: bool,
+    pub results: Vec<RunCommitResult>,
+}
+
+/// Run commands on each commit in the stack and print output.
+///
+/// Returns `Ok(true)` when all commands passed on all commits,
+/// `Ok(false)` when one or more had failures.
+pub fn execute(options: RunOptions) -> Result<bool> {
+    let json = options.json;
+    let emit_json_output = options.emit_json_output;
+    let result = execute_raw(options)?;
+
+    if json && emit_json_output {
+        output::print_json(&RunResponse {
+            version: OUTPUT_VERSION,
+            run: RunResultJson {
+                results: result.results,
+                all_passed: result.all_passed,
+            },
+        });
+    }
+
+    Ok(result.all_passed)
+}
+
+/// Execute and return raw results (for `gg lint` to wrap in LintResponse).
+pub fn execute_raw(options: RunOptions) -> Result<RunResult> {
+    let repo = git::open_repo()?;
+
+    // Require clean working directory
+    git::require_clean_working_directory(&repo)?;
+
+    // Load stack
+    let config = crate::config::Config::load_with_global(repo.commondir())?;
+    let stack = Stack::load(&repo, &config)?;
+
+    if stack.is_empty() {
+        if !options.json {
+            println!("{}", style("Stack is empty. Nothing to run.").dim());
+        }
+        return Ok(RunResult {
+            all_passed: true,
+            results: vec![],
+        });
+    }
+
+    // Determine the end position
+    let end_pos = options
+        .until
+        .unwrap_or_else(|| stack.current_position.map(|p| p + 1).unwrap_or(stack.len()));
+
+    if end_pos > stack.len() {
+        return Err(GgError::Other(format!(
+            "Position {} is out of range (max: {})",
+            end_pos,
+            stack.len()
+        )));
+    }
+
+    // Determine whether to use parallel execution
+    let use_parallel = options.change_mode == ChangeMode::ReadOnly && options.jobs != 1;
+
+    if use_parallel {
+        if !options.json {
+            let jobs = effective_jobs(options.jobs);
+            let header = format!(
+                "Running {} command(s) on commits 1-{} (mode: read-only, jobs: {})",
+                options.commands.len(),
+                end_pos,
+                if options.jobs == 0 {
+                    format!("auto={}", jobs)
+                } else {
+                    jobs.to_string()
+                },
+            );
+            println!("{}", style(header).dim());
+        }
+
+        return run_on_commits_parallel(&repo, &stack, &options, end_pos);
+    }
+
+    // --- Sequential path ---
+    if !options.json {
+        let header = if let Some(ref label) = options.header_label {
+            format!(
+                "Running {} on commits 1-{} ({} {} commands)",
+                label,
+                end_pos,
+                options.commands.len(),
+                label,
+            )
+        } else {
+            let mode_label = match options.change_mode {
+                ChangeMode::ReadOnly => "read-only",
+                ChangeMode::Amend => "amend",
+                ChangeMode::Discard => "discard",
+            };
+            format!(
+                "Running {} command(s) on commits 1-{} (mode: {})",
+                options.commands.len(),
+                end_pos,
+                mode_label,
+            )
+        };
+        println!("{}", style(header).dim());
+    }
+
+    if options.jobs > 1 && options.change_mode != ChangeMode::ReadOnly && !options.json {
+        println!(
+            "{}",
+            style("Note: --jobs is ignored in amend/discard mode (requires sequential execution)")
+                .dim()
+        );
+    }
+
+    let original_branch = git::current_branch_name(&repo);
+    let original_head = repo.head()?.peel_to_commit()?.id();
+
+    let result = run_on_commits(&repo, stack, &options, end_pos);
+
+    if result.is_err() && !git::is_rebase_in_progress(&repo) {
+        restore_original_position(&repo, original_branch.as_deref(), original_head, options.json);
+    }
+
+    result
+}
+
+fn run_on_commits(
+    repo: &git2::Repository,
+    stack: Stack,
+    options: &RunOptions,
+    end_pos: usize,
+) -> Result<RunResult> {
+    let original_branch = git::current_branch_name(repo);
+    let original_head = repo.head()?.peel_to_commit()?.id();
+    let repo_root = repo
+        .workdir()
+        .ok_or_else(|| GgError::Other("Repository has no working directory".to_string()))?;
+    let mut had_changes = false;
+    let base_branch = stack.base.clone();
+    let stack_branch = stack.branch_name();
+    let mut entries = stack.entries.clone();
+    let mut run_results: Vec<RunCommitResult> = Vec::with_capacity(end_pos);
+    let mut all_passed = true;
+
+    let mut i = 0;
+    while i < end_pos {
+        let entry = entries[i].clone();
+        let mut had_changes_this_commit = false;
+
+        if !options.json {
+            println!();
+            println!(
+                "{} Running on [{}] {} {}",
+                style("→").cyan(),
+                entry.position,
+                style(&entry.short_sha).yellow(),
+                entry.title
+            );
+        }
+
+        // Checkout this commit
+        let commit = repo.find_commit(entry.oid)?;
+        git::checkout_commit(repo, &commit)?;
+
+        // Run commands
+        let mut commit_passed = true;
+        let mut command_results = Vec::with_capacity(options.commands.len());
+
+        for cmd in &options.commands {
+            if !options.json {
+                print!("  Running: {} ... ", style(cmd).dim());
+            }
+
+            let output = match execute_command(cmd, repo_root, repo) {
+                Ok(output) => output,
+                Err(e) => {
+                    if !options.json {
+                        println!("{}", style("ERROR").red().bold());
+                    }
+                    let error_msg = if e.kind() == std::io::ErrorKind::NotFound {
+                        format!(
+                            "Command '{}' not found. Make sure it's installed and in your PATH.\n\
+                             Note: Shell aliases don't work here. Use the full command (e.g., './gradlew' instead of 'gw').",
+                            cmd
+                        )
+                    } else {
+                        format!("Failed to run '{}': {}", cmd, e)
+                    };
+                    return Err(GgError::Other(error_msg));
+                }
+            };
+
+            let passed = output.status.success();
+            if passed {
+                if !options.json {
+                    println!("{}", style("OK").green());
+                }
+            } else {
+                commit_passed = false;
+                all_passed = false;
+                if !options.json {
+                    println!("{}", style("FAILED").red());
+                    let stderr = String::from_utf8_lossy(&output.stderr);
+                    if !stderr.is_empty() {
+                        for line in stderr.lines().take(5) {
+                            println!("    {}", style(line).dim());
+                        }
+                    }
+                }
+            }
+
+            let combined_output = if passed {
+                None
+            } else {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                let mut text = String::new();
+                if !stderr.trim().is_empty() {
+                    text.push_str(stderr.trim_end());
+                }
+                if !stdout.trim().is_empty() {
+                    if !text.is_empty() {
+                        text.push('\n');
+                    }
+                    text.push_str(stdout.trim_end());
+                }
+                if text.is_empty() {
+                    None
+                } else {
+                    Some(text)
+                }
+            };
+
+            command_results.push(RunCommandResult {
+                command: cmd.clone(),
+                passed,
+                output: combined_output,
+            });
+        }
+
+        // Handle file changes based on mode
+        if !git::is_working_directory_clean(repo)? {
+            match options.change_mode {
+                ChangeMode::ReadOnly => {
+                    return Err(GgError::Other(format!(
+                        "Command modified files on commit [{}] {}.\n\
+                         Use --amend to fold changes into each commit, or --discard to ignore them.",
+                        entry.position, entry.short_sha
+                    )));
+                }
+                ChangeMode::Amend => {
+                    if !options.json {
+                        println!(
+                            "  {} Command made changes, squashing...",
+                            style("!").yellow()
+                        );
+                    }
+
+                    // Stage all changes
+                    let add_output = Command::new("git")
+                        .args(["add", "-A"])
+                        .current_dir(repo_root)
+                        .output()?;
+
+                    if !add_output.status.success() {
+                        return Err(GgError::Other(format!(
+                            "Failed to stage changes: {}",
+                            String::from_utf8_lossy(&add_output.stderr).trim()
+                        )));
+                    }
+
+                    // Amend the commit
+                    let amend_output = Command::new("git")
+                        .args(["commit", "--amend", "--no-edit"])
+                        .current_dir(repo_root)
+                        .stdin(Stdio::null())
+                        .output()?;
+
+                    if !amend_output.status.success() {
+                        return Err(GgError::Other(format!(
+                            "Failed to amend commit: {}",
+                            String::from_utf8_lossy(&amend_output.stderr).trim()
+                        )));
+                    }
+
+                    had_changes = true;
+                    had_changes_this_commit = true;
+                    if !options.json {
+                        println!("  {} Changes squashed", style("OK").green());
+                    }
+
+                    // Rebase remaining commits onto the amended commit
+                    if i + 1 < end_pos {
+                        let new_commit_oid = repo.head()?.peel_to_commit()?.id();
+                        let old_tip_oid = entries[end_pos - 1].oid;
+
+                        let new_commit = new_commit_oid.to_string();
+                        let old_commit = entry.oid.to_string();
+                        let old_tip = old_tip_oid.to_string();
+
+                        let target_branch =
+                            original_branch.as_deref().unwrap_or(stack_branch.as_str());
+
+                        git::run_git_command(&["branch", "-f", target_branch, &old_tip])?;
+                        git::checkout_branch(repo, target_branch)?;
+
+                        if let Err(e) = git::run_git_command(&[
+                            "rebase",
+                            "--onto",
+                            &new_commit,
+                            &old_commit,
+                            target_branch,
+                        ]) {
+                            if git::is_rebase_in_progress(repo) {
+                                print_rebase_conflict_help(repo_root, options.json);
+                                return Err(GgError::Other(
+                                    "Rebase conflict occurred. Resolve conflicts and run `gg continue`."
+                                        .to_string(),
+                                ));
+                            }
+                            return Err(e);
+                        }
+
+                        entries = refresh_stack_entries(repo, &base_branch, None)?;
+                    }
+                }
+                ChangeMode::Discard => {
+                    if !options.json {
+                        println!("  {} Discarding changes...", style("!").yellow());
+                    }
+
+                    let checkout_output = Command::new("git")
+                        .args(["checkout", "."])
+                        .current_dir(repo_root)
+                        .output()?;
+
+                    if !checkout_output.status.success() {
+                        return Err(GgError::Other(format!(
+                            "Failed to discard changes: {}",
+                            String::from_utf8_lossy(&checkout_output.stderr).trim()
+                        )));
+                    }
+
+                    // Also clean untracked files created by the command
+                    let clean_output = Command::new("git")
+                        .args(["clean", "-fd"])
+                        .current_dir(repo_root)
+                        .output()?;
+
+                    if !clean_output.status.success() {
+                        return Err(GgError::Other(format!(
+                            "Failed to clean untracked files: {}",
+                            String::from_utf8_lossy(&clean_output.stderr).trim()
+                        )));
+                    }
+
+                    if !options.json {
+                        println!("  {} Changes discarded", style("OK").green());
+                    }
+                }
+            }
+        }
+
+        let final_sha = if had_changes_this_commit {
+            let head = repo.head()?.peel_to_commit()?;
+            git::short_sha(&head)
+        } else {
+            entry.short_sha.clone()
+        };
+
+        run_results.push(RunCommitResult {
+            position: entry.position,
+            sha: final_sha,
+            title: entry.title.clone(),
+            passed: commit_passed,
+            commands: command_results,
+        });
+
+        // Stop on first failure if requested
+        if !commit_passed && options.stop_on_error {
+            if !options.json {
+                println!();
+                println!(
+                    "{} Stopping at commit [{}] due to failure",
+                    style("!").yellow(),
+                    entry.position,
+                );
+            }
+            break;
+        }
+
+        i += 1;
+    }
+
+    // Return to original position
+    if !options.json {
+        println!();
+    }
+    if let Some(branch) = original_branch {
+        if had_changes {
+            git::move_branch_to_head(repo, &branch)?;
+            git::checkout_branch(repo, &branch)?;
+
+            if !options.json {
+                if end_pos < stack.len() {
+                    println!(
+                        "{}",
+                        style("Changes were made. Run `gg rebase` to update remaining commits, then `gg sync`.")
+                            .dim()
+                    );
+                } else {
+                    println!(
+                        "{}",
+                        style("Changes were made. Review with `gg ls` and sync with `gg sync`.")
+                            .dim()
+                    );
+                }
+            }
+        } else {
+            git::checkout_branch(repo, &branch)?;
+        }
+    } else if !had_changes {
+        let commit = repo.find_commit(original_head)?;
+        git::checkout_commit(repo, &commit)?;
+    }
+
+    if !options.json {
+        let status_msg = if all_passed {
+            format!(
+                "{} Ran on {} commit(s) — all passed",
+                style("OK").green().bold(),
+                run_results.len()
+            )
+        } else {
+            format!(
+                "{} Ran on {} commit(s) — some failed",
+                style("FAIL").red().bold(),
+                run_results.len()
+            )
+        };
+        println!("{}", status_msg);
+    }
+
+    Ok(RunResult {
+        all_passed,
+        results: run_results,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Parallel execution
+// ---------------------------------------------------------------------------
+
+/// RAII guard that ensures temporary worktrees are cleaned up on all exit paths.
+struct WorktreeGuard {
+    repo_root: PathBuf,
+    base_dir: PathBuf,
+    paths: Vec<PathBuf>,
+}
+
+impl WorktreeGuard {
+    fn new(repo_root: &Path) -> Result<Self> {
+        let base_dir = std::env::temp_dir().join(format!("gg-run-{}", std::process::id()));
+        std::fs::create_dir_all(&base_dir).map_err(|e| {
+            GgError::Other(format!(
+                "Failed to create temp directory for worktrees: {}",
+                e
+            ))
+        })?;
+        Ok(Self {
+            repo_root: repo_root.to_path_buf(),
+            base_dir,
+            paths: Vec::new(),
+        })
+    }
+
+    /// Create a detached worktree for the given commit OID.
+    fn add(&mut self, index: usize, oid: Oid) -> Result<PathBuf> {
+        let wt_path = self.base_dir.join(format!("commit-{}", index));
+        let sha = oid.to_string();
+        let wt_str = wt_path.to_string_lossy().to_string();
+
+        let output = Command::new("git")
+            .args(["worktree", "add", "--detach", &wt_str, &sha])
+            .current_dir(&self.repo_root)
+            .output()
+            .map_err(|e| GgError::Other(format!("Failed to run git worktree add: {}", e)))?;
+
+        if !output.status.success() {
+            return Err(GgError::Other(format!(
+                "git worktree add failed: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            )));
+        }
+
+        self.paths.push(wt_path.clone());
+        Ok(wt_path)
+    }
+}
+
+impl Drop for WorktreeGuard {
+    fn drop(&mut self) {
+        for path in &self.paths {
+            let _ = Command::new("git")
+                .args([
+                    "worktree",
+                    "remove",
+                    "--force",
+                    &path.to_string_lossy(),
+                ])
+                .current_dir(&self.repo_root)
+                .output();
+        }
+        let _ = std::fs::remove_dir_all(&self.base_dir);
+    }
+}
+
+/// Pre-resolve commands that reference `.git/` paths to the repo's commondir.
+fn pre_resolve_commands(commands: &[String], repo: &git2::Repository) -> Vec<String> {
+    commands
+        .iter()
+        .map(|cmd| {
+            let parts: Vec<&str> = cmd.split_whitespace().collect();
+            if parts.is_empty() {
+                return cmd.clone();
+            }
+            match resolve_git_path(parts[0], repo) {
+                Some(resolved) => {
+                    let mut new_cmd = resolved.to_string_lossy().to_string();
+                    for part in &parts[1..] {
+                        new_cmd.push(' ');
+                        new_cmd.push_str(part);
+                    }
+                    new_cmd
+                }
+                None => cmd.clone(),
+            }
+        })
+        .collect()
+}
+
+/// Execute a command in a specific directory, without repo-aware path resolution.
+/// Used by parallel execution where commands run in isolated worktrees.
+fn execute_command_in_dir(cmd: &str, dir: &Path) -> std::io::Result<Output> {
+    if cmd.contains("&&")
+        || cmd.contains("||")
+        || cmd.contains('|')
+        || cmd.contains('>')
+        || cmd.contains('<')
+        || cmd.contains(';')
+    {
+        Command::new("sh")
+            .args(["-c", cmd])
+            .current_dir(dir)
+            .output()
+    } else {
+        let parts: Vec<&str> = cmd.split_whitespace().collect();
+        if parts.is_empty() {
+            return Command::new("true").output();
+        }
+        Command::new(parts[0])
+            .args(&parts[1..])
+            .current_dir(dir)
+            .output()
+    }
+}
+
+/// Run all commands on a single commit in its isolated worktree directory.
+fn run_commands_in_worktree(
+    commands: &[String],
+    wt_path: &Path,
+    entry: &StackEntry,
+) -> RunCommitResult {
+    let mut commit_passed = true;
+    let mut command_results = Vec::with_capacity(commands.len());
+
+    for cmd in commands {
+        let output = execute_command_in_dir(cmd, wt_path);
+
+        let passed = output.as_ref().map(|o| o.status.success()).unwrap_or(false);
+        if !passed {
+            commit_passed = false;
+        }
+
+        let combined_output = if passed {
+            None
+        } else {
+            match output {
+                Ok(ref o) => {
+                    let stderr = String::from_utf8_lossy(&o.stderr);
+                    let stdout = String::from_utf8_lossy(&o.stdout);
+                    let mut text = String::new();
+                    if !stderr.trim().is_empty() {
+                        text.push_str(stderr.trim_end());
+                    }
+                    if !stdout.trim().is_empty() {
+                        if !text.is_empty() {
+                            text.push('\n');
+                        }
+                        text.push_str(stdout.trim_end());
+                    }
+                    if text.is_empty() {
+                        None
+                    } else {
+                        Some(text)
+                    }
+                }
+                Err(ref e) => Some(format!("Failed to execute: {}", e)),
+            }
+        };
+
+        command_results.push(RunCommandResult {
+            command: cmd.clone(),
+            passed,
+            output: combined_output,
+        });
+    }
+
+    RunCommitResult {
+        position: entry.position,
+        sha: entry.short_sha.clone(),
+        title: entry.title.clone(),
+        passed: commit_passed,
+        commands: command_results,
+    }
+}
+
+/// Parallel execution path: creates isolated worktrees, runs commands concurrently,
+/// collects results in commit order. Only valid for ReadOnly mode.
+fn run_on_commits_parallel(
+    repo: &git2::Repository,
+    stack: &Stack,
+    options: &RunOptions,
+    end_pos: usize,
+) -> Result<RunResult> {
+    let repo_root = repo
+        .workdir()
+        .ok_or_else(|| GgError::Other("Repository has no working directory".to_string()))?;
+    let jobs = effective_jobs(options.jobs);
+    let entries = &stack.entries[..end_pos];
+
+    let resolved_commands = pre_resolve_commands(&options.commands, repo);
+
+    // Create worktrees (sequential — git requires this)
+    let mut guard = WorktreeGuard::new(repo_root)?;
+    let mut worktree_paths: Vec<PathBuf> = Vec::with_capacity(end_pos);
+
+    if !options.json {
+        println!(
+            "{}",
+            style(format!(
+                "Creating {} worktree(s) for parallel execution...",
+                end_pos
+            ))
+            .dim()
+        );
+    }
+
+    for (i, entry) in entries.iter().enumerate() {
+        let wt_path = guard.add(i, entry.oid)?;
+        worktree_paths.push(wt_path);
+    }
+
+    // Progress bar for non-JSON output
+    let pb = if !options.json {
+        let pb = indicatif::ProgressBar::new(end_pos as u64);
+        pb.set_style(
+            indicatif::ProgressStyle::with_template(
+                "  {spinner:.cyan} [{bar:30.cyan/dim}] {pos}/{len} commits ({elapsed})",
+            )
+            .unwrap()
+            .progress_chars("━╸─"),
+        );
+        Some(pb)
+    } else {
+        None
+    };
+
+    // Build work items: (index, entry, worktree_path)
+    let work_items: Vec<(usize, &StackEntry, &Path)> = entries
+        .iter()
+        .zip(worktree_paths.iter())
+        .enumerate()
+        .map(|(i, (entry, path))| (i, entry, path.as_path()))
+        .collect();
+
+    // Run in parallel with bounded concurrency
+    let work = std::sync::Mutex::new(work_items.into_iter());
+    let collected: std::sync::Mutex<Vec<(usize, RunCommitResult)>> =
+        std::sync::Mutex::new(Vec::with_capacity(end_pos));
+
+    std::thread::scope(|s| {
+        let num_workers = jobs.min(end_pos);
+        for _ in 0..num_workers {
+            s.spawn(|| {
+                loop {
+                    let item = { work.lock().unwrap().next() };
+                    match item {
+                        Some((idx, entry, wt_path)) => {
+                            let result =
+                                run_commands_in_worktree(&resolved_commands, wt_path, entry);
+                            collected.lock().unwrap().push((idx, result));
+                            if let Some(ref pb) = pb {
+                                pb.inc(1);
+                            }
+                        }
+                        None => break,
+                    }
+                }
+            });
+        }
+        // Threads join here when scope exits
+    });
+
+    let results = collected.into_inner().unwrap();
+
+    if let Some(ref pb) = pb {
+        pb.finish_and_clear();
+    }
+
+    // Sort results by commit position
+    let mut sorted_results: Vec<RunCommitResult> = {
+        let mut indexed = results;
+        indexed.sort_by_key(|(idx, _)| *idx);
+        indexed.into_iter().map(|(_, r)| r).collect()
+    };
+
+    let all_passed = sorted_results.iter().all(|r| r.passed);
+
+    // Apply stop_on_error: truncate after first failure
+    if options.stop_on_error && !all_passed {
+        if let Some(first_fail) = sorted_results.iter().position(|r| !r.passed) {
+            sorted_results.truncate(first_fail + 1);
+        }
+    }
+
+    // Print results in commit order (non-JSON)
+    if !options.json {
+        for result in &sorted_results {
+            println!();
+            let status_icon = if result.passed {
+                style("✓").green()
+            } else {
+                style("✗").red()
+            };
+            println!(
+                "{} [{}] {} {}",
+                status_icon, result.position,
+                style(&result.sha).yellow(),
+                result.title,
+            );
+            for cmd_result in &result.commands {
+                let cmd_status = if cmd_result.passed {
+                    style("OK").green().to_string()
+                } else {
+                    style("FAILED").red().to_string()
+                };
+                println!(
+                    "  {} {} {}",
+                    style("→").dim(),
+                    cmd_result.command,
+                    cmd_status
+                );
+                if let Some(ref output) = cmd_result.output {
+                    for line in output.lines().take(5) {
+                        println!("    {}", style(line).dim());
+                    }
+                }
+            }
+        }
+        println!();
+        let status_msg = if all_passed {
+            format!(
+                "{} Ran on {} commit(s) across {} worker(s) — all passed",
+                style("OK").green().bold(),
+                sorted_results.len(),
+                jobs.min(end_pos),
+            )
+        } else {
+            format!(
+                "{} Ran on {} commit(s) across {} worker(s) — some failed",
+                style("FAIL").red().bold(),
+                sorted_results.len(),
+                jobs.min(end_pos),
+            )
+        };
+        println!("{}", status_msg);
+    }
+
+    // guard is dropped here — worktrees cleaned up automatically
+
+    Ok(RunResult {
+        all_passed,
+        results: sorted_results,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Resolve the effective number of parallel jobs.
+/// 0 = auto (available parallelism), 1+ = explicit count.
+fn effective_jobs(jobs: usize) -> usize {
+    if jobs == 0 {
+        std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(4)
+    } else {
+        jobs
+    }
+}
+
+/// Execute a command string, using `sh -c` if it contains shell metacharacters.
+fn execute_command(cmd: &str, repo_root: &Path, repo: &git2::Repository) -> std::io::Result<Output> {
+    if cmd.contains("&&")
+        || cmd.contains("||")
+        || cmd.contains('|')
+        || cmd.contains('>')
+        || cmd.contains('<')
+        || cmd.contains(';')
+    {
+        Command::new("sh")
+            .args(["-c", cmd])
+            .current_dir(repo_root)
+            .output()
+    } else {
+        let parts: Vec<&str> = cmd.split_whitespace().collect();
+        if parts.is_empty() {
+            return Command::new("true").output();
+        }
+
+        let resolved_cmd = resolve_git_path(parts[0], repo);
+        let cmd_str = resolved_cmd
+            .as_ref()
+            .map(|p| p.to_string_lossy())
+            .unwrap_or_else(|| parts[0].into());
+
+        Command::new(cmd_str.as_ref())
+            .args(&parts[1..])
+            .current_dir(repo_root)
+            .output()
+    }
+}
+
+fn refresh_stack_entries(
+    repo: &git2::Repository,
+    base_branch: &str,
+    stack_branch: Option<&str>,
+) -> Result<Vec<StackEntry>> {
+    let oids = git::get_stack_commit_oids(repo, base_branch, stack_branch)?;
+
+    let mut entries = Vec::with_capacity(oids.len());
+    for (i, oid) in oids.iter().enumerate() {
+        let commit = repo.find_commit(*oid)?;
+        entries.push(StackEntry::from_commit(&commit, i + 1));
+    }
+
+    Ok(entries)
+}
+
+/// Restore the original branch/HEAD position.
+fn restore_original_position(
+    repo: &git2::Repository,
+    original_branch: Option<&str>,
+    original_head: Oid,
+    json: bool,
+) {
+    if !json {
+        println!();
+        println!("{} Restoring original position...", style("→").cyan());
+    }
+
+    let restored = if let Some(branch) = original_branch {
+        git::checkout_branch(repo, branch).is_ok()
+    } else if let Ok(commit) = repo.find_commit(original_head) {
+        git::checkout_commit(repo, &commit).is_ok()
+    } else {
+        false
+    };
+
+    if !json {
+        if restored {
+            println!("{} Restored to original position", style("OK").green());
+        } else {
+            println!(
+                "{} Could not restore original position. You may be in detached HEAD.",
+                style("Warning:").yellow()
+            );
+        }
+    }
+}
+
+/// Resolve a command path that starts with `.git/` or `./.git/` to the real
+/// git common directory (for linked worktree support).
+pub(crate) fn resolve_git_path(cmd: &str, repo: &git2::Repository) -> Option<PathBuf> {
+    let remainder = if let Some(rest) = cmd.strip_prefix("./.git/") {
+        rest
+    } else if let Some(rest) = cmd.strip_prefix(".git/") {
+        rest
+    } else {
+        return None;
+    };
+
+    Some(repo.commondir().join(remainder))
+}
+
+/// Get list of files with conflicts.
+fn get_conflicted_files(repo_root: &Path) -> Vec<String> {
+    let output = Command::new("git")
+        .args(["diff", "--name-only", "--diff-filter=U"])
+        .current_dir(repo_root)
+        .output();
+
+    match output {
+        Ok(output) if output.status.success() => String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .map(|s| s.to_string())
+            .filter(|s| !s.is_empty())
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// Print helpful message when rebase conflict occurs.
+fn print_rebase_conflict_help(repo_root: &Path, json: bool) {
+    if json {
+        return;
+    }
+
+    println!();
+    println!(
+        "{} Rebase conflict while rebasing after changes",
+        style("⚠️").yellow()
+    );
+    println!();
+
+    let conflicted_files = get_conflicted_files(repo_root);
+    if !conflicted_files.is_empty() {
+        println!("The following files have conflicts:");
+        for file in &conflicted_files {
+            println!("  {} {}", style("-").dim(), file);
+        }
+        println!();
+    }
+
+    println!("To resolve:");
+    println!("  1. Edit the conflicting files to resolve conflicts");
+    println!("  2. {}", style("git add <resolved-files>").cyan());
+    println!("  3. {}", style("gg continue").cyan());
+    println!();
+    println!("To abort and undo changes:");
+    println!("  {}", style("gg abort").cyan());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_repo() -> (tempfile::TempDir, git2::Repository) {
+        let dir = tempfile::TempDir::new().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+        (dir, repo)
+    }
+
+    #[test]
+    fn test_resolve_git_path_with_dot_slash_prefix() {
+        let (_dir, repo) = temp_repo();
+        let result = resolve_git_path("./.git/gg/lint.sh", &repo);
+        assert!(result.is_some());
+        let resolved = result.unwrap();
+        assert!(resolved.ends_with("gg/lint.sh"));
+        assert!(resolved.starts_with(repo.commondir()));
+    }
+
+    #[test]
+    fn test_resolve_git_path_without_dot_slash_prefix() {
+        let (_dir, repo) = temp_repo();
+        let result = resolve_git_path(".git/gg/lint.sh", &repo);
+        assert!(result.is_some());
+        assert!(result.unwrap().ends_with("gg/lint.sh"));
+    }
+
+    #[test]
+    fn test_resolve_git_path_non_git_path_returns_none() {
+        let (_dir, repo) = temp_repo();
+        assert!(resolve_git_path("cargo", &repo).is_none());
+        assert!(resolve_git_path("./scripts/lint.sh", &repo).is_none());
+    }
+
+    #[test]
+    fn test_effective_jobs() {
+        assert_eq!(effective_jobs(1), 1);
+        assert_eq!(effective_jobs(4), 4);
+        // jobs=0 means auto — should return at least 1
+        assert!(effective_jobs(0) >= 1);
+    }
+
+    #[test]
+    fn test_execute_command_in_dir_simple() {
+        let dir = tempfile::tempdir().unwrap();
+        let output = execute_command_in_dir("echo hello", dir.path()).unwrap();
+        assert!(output.status.success());
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            "hello"
+        );
+    }
+
+    #[test]
+    fn test_execute_command_in_dir_shell_metacharacters() {
+        let dir = tempfile::tempdir().unwrap();
+        let output = execute_command_in_dir("echo a && echo b", dir.path()).unwrap();
+        assert!(output.status.success());
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(stdout.contains("a"));
+        assert!(stdout.contains("b"));
+    }
+}

--- a/crates/gg-core/src/output.rs
+++ b/crates/gg-core/src/output.rs
@@ -162,6 +162,34 @@ pub struct LintCommandResult {
 }
 
 #[derive(Serialize)]
+pub struct RunResponse {
+    pub version: u32,
+    pub run: RunResultJson,
+}
+
+#[derive(Serialize)]
+pub struct RunResultJson {
+    pub results: Vec<RunCommitResult>,
+    pub all_passed: bool,
+}
+
+#[derive(Serialize)]
+pub struct RunCommitResult {
+    pub position: usize,
+    pub sha: String,
+    pub title: String,
+    pub passed: bool,
+    pub commands: Vec<RunCommandResult>,
+}
+
+#[derive(Serialize)]
+pub struct RunCommandResult {
+    pub command: String,
+    pub passed: bool,
+    pub output: Option<String>,
+}
+
+#[derive(Serialize)]
 pub struct LandResponse {
     pub version: u32,
     pub land: LandResultJson,
@@ -192,6 +220,37 @@ pub struct LandedEntryJson {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn run_response_serializes() {
+        let response = RunResponse {
+            version: OUTPUT_VERSION,
+            run: RunResultJson {
+                all_passed: false,
+                results: vec![RunCommitResult {
+                    position: 1,
+                    sha: "abc1234".to_string(),
+                    title: "Test commit".to_string(),
+                    passed: false,
+                    commands: vec![RunCommandResult {
+                        command: "cargo test".to_string(),
+                        passed: false,
+                        output: Some("test failed".to_string()),
+                    }],
+                }],
+            },
+        };
+
+        let value = serde_json::to_value(&response).expect("should serialize");
+        assert_eq!(value["version"], OUTPUT_VERSION);
+        assert_eq!(value["run"]["all_passed"], false);
+        assert_eq!(value["run"]["results"][0]["position"], 1);
+        assert_eq!(value["run"]["results"][0]["commands"][0]["passed"], false);
+        assert_eq!(
+            value["run"]["results"][0]["commands"][0]["output"],
+            "test failed"
+        );
+    }
 
     #[test]
     fn lint_response_serializes() {


### PR DESCRIPTION
## Summary
- Adds `gg run <command>` that executes arbitrary commands on each commit in the stack, inspired by `jj run` from Jujutsu
- Supports three change modes: read-only (default), `--amend` (fold changes into commits), `--discard` (ignore changes)
- Supports parallel execution via `--jobs`/`-j` using isolated git worktrees with RAII cleanup
- Includes `--keep-going`, `--until`, `--json` flags for flexible usage
- Refactors `gg lint` to be a thin wrapper around the new run engine, preserving backward-compatible JSON output

## Test plan
- [x] 9 new integration tests covering all modes (read-only pass/fail, amend, discard, readonly-dirty-tree-detection, parallel pass/fail/json)
- [x] 6 unit tests (resolve_git_path, effective_jobs, execute_command_in_dir)
- [x] All 505 existing tests pass (no regressions)
- [x] All 10 existing lint tests pass (backward compatibility verified)
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)