### PR TITLE
feat: add --admin flag to gg land for PR approval bypass

### DIFF
--- a/crates/gg-cli/src/main.rs
+++ b/crates/gg-cli/src/main.rs
@@ -212,6 +212,10 @@ enum Commands {
         /// Disable automatic cleanup after landing (overrides config default)
         #[arg(long = "no-clean", conflicts_with = "clean")]
         no_clean: bool,
+
+        /// Use admin privileges to bypass branch protection approval requirements
+        #[arg(long)]
+        admin: bool,
     },
 
     /// Clean up merged stacks
@@ -467,6 +471,7 @@ fn main() {
             until,
             clean,
             no_clean,
+            admin,
         }) => {
             // Determine auto_clean based on flags and config
             let auto_clean = if clean {
@@ -485,9 +490,17 @@ fn main() {
                 }
             };
 
+            let admin = admin
+                || match gg_core::git::open_repo()
+                    .and_then(|repo| gg_core::config::Config::load_with_global(repo.commondir()))
+                {
+                    Ok(cfg) => cfg.get_land_admin(),
+                    Err(_) => false,
+                };
+
             (
                 gg_core::commands::land::run(
-                    all, json, !no_squash, wait, auto_clean, auto_merge, until,
+                    all, json, !no_squash, wait, auto_clean, auto_merge, until, admin,
                 ),
                 json,
             )

--- a/crates/gg-cli/src/main.rs
+++ b/crates/gg-cli/src/main.rs
@@ -473,35 +473,34 @@ fn main() {
             no_clean,
             admin,
         }) => {
-            // Determine auto_clean based on flags and config
+            // Load config once for resolving defaults
+            let land_cfg = gg_core::git::open_repo()
+                .and_then(|repo| gg_core::config::Config::load_with_global(repo.commondir()))
+                .ok();
+
             let auto_clean = if clean {
-                // --clean explicitly passed
                 true
             } else if no_clean {
-                // --no-clean explicitly passed
                 false
             } else {
-                // No explicit flag, use config default
-                match gg_core::git::open_repo()
-                    .and_then(|repo| gg_core::config::Config::load_with_global(repo.commondir()))
-                {
-                    Ok(cfg) => cfg.get_land_auto_clean(),
-                    Err(_) => false, // If we can't load config, default to false
-                }
+                land_cfg
+                    .as_ref()
+                    .is_some_and(|cfg| cfg.get_land_auto_clean())
             };
 
-            let admin = admin
-                || match gg_core::git::open_repo()
-                    .and_then(|repo| gg_core::config::Config::load_with_global(repo.commondir()))
-                {
-                    Ok(cfg) => cfg.get_land_admin(),
-                    Err(_) => false,
-                };
+            let admin = admin || land_cfg.as_ref().is_some_and(|cfg| cfg.get_land_admin());
 
             (
-                gg_core::commands::land::run(
-                    all, json, !no_squash, wait, auto_clean, auto_merge, until, admin,
-                ),
+                gg_core::commands::land::run(gg_core::commands::land::LandOptions {
+                    land_all: all,
+                    json,
+                    squash: !no_squash,
+                    wait,
+                    auto_clean,
+                    auto_merge_flag: auto_merge,
+                    until,
+                    admin,
+                }),
                 json,
             )
         }

--- a/crates/gg-cli/tests/integration_tests.rs
+++ b/crates/gg-cli/tests/integration_tests.rs
@@ -3251,6 +3251,75 @@ fn test_land_clean_and_no_clean_conflict() {
 }
 
 // ============================================================
+// Tests for --admin flag
+// ============================================================
+
+#[test]
+fn test_land_admin_flag_accepted() {
+    // Test that the --admin flag is recognized
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .expect("Failed to write config");
+
+    let (success, _, stderr) = run_gg(&repo_path, &["co", "test-stack"]);
+    assert!(success, "Failed to create stack: {}", stderr);
+
+    let (_, _stdout, stderr) = run_gg(&repo_path, &["land", "--admin"]);
+
+    assert!(
+        !stderr.contains("unexpected argument") && !stderr.contains("invalid value"),
+        "The --admin flag should be recognized, stderr: {}",
+        stderr
+    );
+}
+
+#[test]
+fn test_land_admin_config_default() {
+    // Test that land_admin config setting defaults to false
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(gg_dir.join("config.json"), r#"{"defaults":{}}"#).expect("Failed to write config");
+
+    let config_path = gg_dir.join("config.json");
+    let content = fs::read_to_string(config_path).expect("Failed to read config");
+
+    assert!(
+        !content.contains("land_admin"),
+        "Default config should not contain land_admin when false"
+    );
+}
+
+#[test]
+fn test_land_admin_config_enabled() {
+    // Test that land_admin can be set to true in config
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"land_admin":true}}"#,
+    )
+    .expect("Failed to write config");
+
+    let config_path = gg_dir.join("config.json");
+    let content = fs::read_to_string(config_path).expect("Failed to read config");
+
+    assert!(
+        content.contains("\"land_admin\":true"),
+        "Config should contain land_admin when enabled"
+    );
+}
+
+// ============================================================
 // Tests for PR #57 - rebase state handling fix
 // ============================================================
 

--- a/crates/gg-core/src/commands/land.rs
+++ b/crates/gg-core/src/commands/land.rs
@@ -342,6 +342,7 @@ pub fn run(
     auto_clean: bool,
     auto_merge_flag: bool,
     until: Option<String>,
+    admin: bool,
 ) -> Result<()> {
     let repo = git::open_repo()?;
     let _lock = git::acquire_operation_lock(&repo, "land")?;
@@ -617,7 +618,7 @@ pub fn run(
                     if let Err(e) = wait_for_pr_ready(
                         &provider,
                         pr_num,
-                        land_all,
+                        land_all || admin,
                         timeout_minutes,
                         interrupted.as_ref(),
                         &stack.base,
@@ -635,7 +636,7 @@ pub fn run(
                         land_error = Some(e.to_string());
                         break 'landing_loop;
                     }
-                } else if !land_all {
+                } else if !land_all && !admin {
                     let approved = provider.check_pr_approved(pr_num)?;
                     if !approved {
                         land_error = Some(format!(
@@ -782,7 +783,10 @@ pub fn run(
             }
             break 'landing_loop;
         } else {
-            match provider.merge_pr(pr_num, squash, false) {
+            if admin {
+                eprintln!("⚠ Merging with admin override — bypassing approval requirements");
+            }
+            match provider.merge_pr(pr_num, squash, false, admin) {
                 Ok(()) => {
                     landed_entries.push(LandedEntryJson {
                         position: entry.position,

--- a/crates/gg-core/src/commands/land.rs
+++ b/crates/gg-core/src/commands/land.rs
@@ -333,17 +333,31 @@ fn rebase_remaining_branches(
     Ok(())
 }
 
+/// Options for the land command
+#[derive(Debug, Default)]
+pub struct LandOptions {
+    pub land_all: bool,
+    pub json: bool,
+    pub squash: bool,
+    pub wait: bool,
+    pub auto_clean: bool,
+    pub auto_merge_flag: bool,
+    pub until: Option<String>,
+    pub admin: bool,
+}
+
 /// Run the land command
-pub fn run(
-    land_all: bool,
-    json: bool,
-    squash: bool,
-    wait: bool,
-    auto_clean: bool,
-    auto_merge_flag: bool,
-    until: Option<String>,
-    admin: bool,
-) -> Result<()> {
+pub fn run(opts: LandOptions) -> Result<()> {
+    let LandOptions {
+        land_all,
+        json,
+        squash,
+        wait,
+        auto_clean,
+        auto_merge_flag,
+        until,
+        admin,
+    } = opts;
     let repo = git::open_repo()?;
     let _lock = git::acquire_operation_lock(&repo, "land")?;
 
@@ -618,7 +632,7 @@ pub fn run(
                     if let Err(e) = wait_for_pr_ready(
                         &provider,
                         pr_num,
-                        land_all || admin,
+                        land_all || (admin && provider == Provider::GitHub),
                         timeout_minutes,
                         interrupted.as_ref(),
                         &stack.base,
@@ -636,7 +650,7 @@ pub fn run(
                         land_error = Some(e.to_string());
                         break 'landing_loop;
                     }
-                } else if !land_all && !admin {
+                } else if !land_all && (!admin || provider != Provider::GitHub) {
                     let approved = provider.check_pr_approved(pr_num)?;
                     if !approved {
                         land_error = Some(format!(

--- a/crates/gg-core/src/config.rs
+++ b/crates/gg-core/src/config.rs
@@ -47,6 +47,10 @@ pub struct Defaults {
     #[serde(default)]
     pub land_auto_clean: bool,
 
+    /// Use admin privileges to bypass approval requirements on land (default: false)
+    #[serde(default)]
+    pub land_admin: bool,
+
     /// Automatically run lint before sync (default: false)
     #[serde(default)]
     pub sync_auto_lint: bool,
@@ -108,6 +112,7 @@ impl Default for Defaults {
             auto_add_gg_ids: true,
             land_wait_timeout_minutes: None,
             land_auto_clean: false,
+            land_admin: false,
             sync_auto_lint: false,
             sync_auto_rebase: false,
             sync_behind_threshold: default_sync_behind_threshold(),
@@ -322,6 +327,11 @@ impl Config {
         self.defaults.land_auto_clean
     }
 
+    /// Get whether to use admin privileges when landing (default: false)
+    pub fn get_land_admin(&self) -> bool {
+        self.defaults.land_admin
+    }
+
     /// Get whether GitLab auto-merge-on-land is enabled by default (default: false)
     pub fn get_gitlab_auto_merge_on_land(&self) -> bool {
         self.defaults.gitlab.auto_merge_on_land
@@ -532,6 +542,33 @@ mod tests {
 
         let loaded = Config::load(git_dir).unwrap();
         assert!(loaded.get_land_auto_clean());
+    }
+
+    #[test]
+    fn test_land_admin_default() {
+        let config = Config::default();
+        assert!(!config.get_land_admin());
+    }
+
+    #[test]
+    fn test_land_admin_enabled() {
+        let mut config = Config::default();
+        config.defaults.land_admin = true;
+        assert!(config.get_land_admin());
+    }
+
+    #[test]
+    fn test_land_admin_roundtrip() {
+        let temp_dir = TempDir::new().unwrap();
+        let git_dir = temp_dir.path();
+
+        let mut config = Config::default();
+        config.defaults.land_admin = true;
+
+        config.save(git_dir).unwrap();
+
+        let loaded = Config::load(git_dir).unwrap();
+        assert!(loaded.get_land_admin());
     }
 
     #[test]

--- a/crates/gg-core/src/gh.rs
+++ b/crates/gg-core/src/gh.rs
@@ -297,7 +297,7 @@ pub fn update_pr_title(pr_number: u64, title: &str) -> Result<()> {
 }
 
 /// Merge a PR
-pub fn merge_pr(pr_number: u64, squash: bool, delete_branch: bool) -> Result<()> {
+pub fn merge_pr(pr_number: u64, squash: bool, delete_branch: bool, admin: bool) -> Result<()> {
     let pr_num_str = pr_number.to_string();
     let mut args = vec!["pr", "merge", &pr_num_str];
 
@@ -309,6 +309,10 @@ pub fn merge_pr(pr_number: u64, squash: bool, delete_branch: bool) -> Result<()>
 
     if delete_branch {
         args.push("--delete-branch");
+    }
+
+    if admin {
+        args.push("--admin");
     }
 
     let output = Command::new("gh").args(&args).output()?;

--- a/crates/gg-core/src/provider.rs
+++ b/crates/gg-core/src/provider.rs
@@ -229,7 +229,13 @@ impl Provider {
     }
 
     /// Merge a PR/MR immediately.
-    pub fn merge_pr(&self, number: u64, squash: bool, delete_branch: bool, admin: bool) -> Result<()> {
+    pub fn merge_pr(
+        &self,
+        number: u64,
+        squash: bool,
+        delete_branch: bool,
+        admin: bool,
+    ) -> Result<()> {
         match self {
             Provider::GitHub => gh::merge_pr(number, squash, delete_branch, admin),
             Provider::GitLab => {

--- a/crates/gg-core/src/provider.rs
+++ b/crates/gg-core/src/provider.rs
@@ -229,10 +229,15 @@ impl Provider {
     }
 
     /// Merge a PR/MR immediately.
-    pub fn merge_pr(&self, number: u64, squash: bool, delete_branch: bool) -> Result<()> {
+    pub fn merge_pr(&self, number: u64, squash: bool, delete_branch: bool, admin: bool) -> Result<()> {
         match self {
-            Provider::GitHub => gh::merge_pr(number, squash, delete_branch),
-            Provider::GitLab => glab::merge_mr(number, squash, delete_branch),
+            Provider::GitHub => gh::merge_pr(number, squash, delete_branch, admin),
+            Provider::GitLab => {
+                if admin {
+                    eprintln!("⚠ --admin is not supported on GitLab; ignoring flag");
+                }
+                glab::merge_mr(number, squash, delete_branch)
+            }
         }
     }
 

--- a/crates/gg-mcp/src/tools.rs
+++ b/crates/gg-mcp/src/tools.rs
@@ -185,6 +185,9 @@ pub struct StackLandParams {
     /// Only land up to this position, GG-ID, or SHA
     #[serde(default)]
     pub until: Option<String>,
+    /// Use admin privileges to bypass approval requirements (GitHub only)
+    #[serde(default)]
+    pub admin: bool,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -645,6 +648,9 @@ impl GgMcpServer {
             args.push("--until".to_string());
             args.push(until.clone());
         }
+        if params.admin {
+            args.push("--admin".to_string());
+        }
         run_gg_command(&args)
     }
 
@@ -1000,6 +1006,7 @@ mod tests {
         assert!(!params.squash);
         assert!(!params.auto_clean);
         assert!(params.until.is_none());
+        assert!(!params.admin);
     }
 
     #[test]

--- a/docs/src/commands/land.md
+++ b/docs/src/commands/land.md
@@ -15,6 +15,7 @@ gg land [OPTIONS]
 - `-u, --until <UNTIL>`: Land up to a target entry (position, GG-ID, SHA)
 - `-c, --clean`: Clean stack automatically after landing all
 - `--no-clean`: Disable auto-clean for this run
+- `--admin`: *(GitHub only)* Use admin privileges to bypass branch protection approval requirements
 - `--json`: Emit machine-readable JSON output (no human logs)
 
 ## Examples
@@ -34,6 +35,12 @@ gg land --all --auto-merge
 
 # JSON output for automation
 gg land --all --json
+
+# Bypass approval requirements (GitHub admin)
+gg land --admin
+
+# Land full stack with admin override
+gg land --all --wait --admin
 ```
 
 ## Merge Trains (GitLab)

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -33,6 +33,7 @@ For global config, manually create `~/.config/gg/config.json` with your preferre
     "auto_add_gg_ids": true,
     "unstaged_action": "ask",
     "land_wait_timeout_minutes": 30,
+    "land_admin": false,
     "land_auto_clean": false,
     "sync_auto_lint": false,
     "sync_auto_rebase": false,
@@ -58,6 +59,7 @@ For global config, manually create `~/.config/gg/config.json` with your preferre
 | `auto_add_gg_ids` | `boolean` | **Deprecated** compatibility field. gg always enforces GG metadata normalization, regardless of this value. | `true` |
 | `unstaged_action` | `string` | Default behavior for `gg sc`/`gg amend` when unstaged changes exist: `ask`, `add`, `stash`, `continue`, or `abort` | `ask` |
 | `land_wait_timeout_minutes` | `number` | Timeout for `gg land --wait` polling | `30` |
+| `land_admin` | `boolean` | Use admin privileges to bypass approval requirements on land (GitHub only) | `false` |
 | `land_auto_clean` | `boolean` | Auto-run cleanup after full landing | `false` |
 | `sync_auto_lint` | `boolean` | Automatically run `gg lint` before `gg sync` | `false` |
 | `sync_auto_rebase` | `boolean` | Automatically run `gg rebase` before `gg sync` when behind threshold is reached | `false` |

--- a/skills/gg/SKILL.md
+++ b/skills/gg/SKILL.md
@@ -55,6 +55,7 @@ Store shared defaults in `~/.config/gg/config.json` that apply to all repos. Loc
     "sync_auto_lint": false,
     "sync_draft": false,
     "sync_update_descriptions": true,
+    "land_admin": false,
     "land_auto_clean": false,
     "land_wait_timeout_minutes": 30,
     "unstaged_action": "ask"

--- a/skills/gg/reference.md
+++ b/skills/gg/reference.md
@@ -88,6 +88,7 @@ Merge approved PRs/MRs from bottom up.
 - `-u, --until <UNTIL>`
 - `-c, --clean`
 - `--no-clean`
+- `--admin` *(GitHub only)* — bypass branch protection approval requirements
 - `--json`
 
 #### `gg clean [OPTIONS]`
@@ -467,7 +468,7 @@ Get detailed PR/MR information by number.
 #### `config_show`
 Show repository git-gud configuration.
 - **Params:** none
-- **Returns:** `{ provider, base_branch, branch_username, lint_commands, auto_add_gg_ids, land_auto_clean, sync_auto_lint, sync_auto_rebase }` (`auto_add_gg_ids` is a compatibility field and is always `true`).
+- **Returns:** `{ provider, base_branch, branch_username, lint_commands, auto_add_gg_ids, land_admin, land_auto_clean, sync_auto_lint, sync_auto_rebase }` (`auto_add_gg_ids` is a compatibility field and is always `true`).
 
 ### Environment Variables
 
@@ -486,7 +487,7 @@ Push branches and create/update PRs.
 
 #### `stack_land`
 Merge approved PRs.
-- **Params:** `all` (bool), `squash` (bool), `auto_clean` (bool), `until` (string)
+- **Params:** `all` (bool), `squash` (bool), `auto_clean` (bool), `until` (string), `admin` (bool)
 - **Returns:** JSON land results
 
 #### `stack_clean`


### PR DESCRIPTION
## Summary

- Adds `--admin` CLI flag to `gg land` that passes `--admin` to `gh pr merge`, bypassing branch protection approval requirements at the GitHub API level
- Adds `land_admin` config default so the flag can be set persistently (follows `land_auto_clean` pattern)
- On GitLab, `--admin` is a no-op with a warning — doesn't break cross-platform config
- When active, skips gg's client-side approval check and approval polling (`--wait` still waits for CI)
- Composes with all existing flags: `--all`, `--wait`, `--until`, `--no-squash`, `--clean`

Closes #260

## Test plan

- [x] 3 new config unit tests (default false, enabled, roundtrip serialization)
- [x] `cargo check` — clean compilation
- [x] `cargo test` — 174 passed (1 pre-existing failure in lint test, unrelated)
- [x] `gg land --help` shows `--admin` with description

🤖 Generated with [Claude Code](https://claude.com/claude-code)