### PR TITLE
Fix split empty commit message error when editor unchanged

### DIFF
--- a/crates/gg-core/src/commands/split.rs
+++ b/crates/gg-core/src/commands/split.rs
@@ -545,6 +545,7 @@ fn get_new_commit_message(options: &SplitOptions, target: &git2::Commit) -> Resu
 
     match edited {
         Some(msg) if !msg.trim().is_empty() => Ok(msg.trim().to_string()),
+        None => Ok(default_msg),
         _ => Err(GgError::Other(
             "Empty commit message, aborting split".to_string(),
         )),


### PR DESCRIPTION
## Summary

- Fix `get_new_commit_message()` in split.rs to fall back to the default message when `dialoguer::Editor::edit()` returns `None` (user saved without modifying)
- Previously, saving the editor unchanged was treated the same as clearing the message, producing a false "empty commit message" error
- Matches the existing pattern used by `get_remainder_message()` which already handles `None` correctly

## Test plan

- [x] All 54 existing split tests pass
- [x] Compilation verified with `cargo check`
- [ ] Manual test: run `gg split` without `--no-tui` and without `-m`, save editor unchanged — should succeed with default message

🤖 Generated with [Claude Code](https://claude.com/claude-code)