### PR TITLE
feat!(split): make interactive hunk selection the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ gg clean
 | `gg sc` / `gg amend` | Squash staged changes into current commit |
 | `gg sc --all` | Squash all changes (staged + unstaged) |
 | `gg reorder` | Reorder commits interactively (TUI with `J`/`K` to move) |
-| `gg split` | Split a commit into two (use `-i` for TUI hunk selection) |
+| `gg split` | Split a commit into two (interactive TUI hunk selection) |
 | `gg absorb` | Auto-distribute changes to appropriate commits |
 
 ### Landing

--- a/crates/gg-cli/src/main.rs
+++ b/crates/gg-cli/src/main.rs
@@ -165,10 +165,6 @@ enum Commands {
         #[arg(long)]
         no_edit: bool,
 
-        /// Select hunks interactively (like git add -p)
-        #[arg(short, long)]
-        interactive: bool,
-
         /// Disable TUI, use sequential prompt instead
         #[arg(long)]
         no_tui: bool,
@@ -444,7 +440,6 @@ fn main() {
             commit,
             message,
             no_edit,
-            interactive,
             no_tui,
             files,
         }) => (
@@ -453,7 +448,6 @@ fn main() {
                 files,
                 message,
                 no_edit,
-                interactive,
                 no_tui,
             }),
             false,

--- a/crates/gg-cli/tests/integration_tests.rs
+++ b/crates/gg-cli/tests/integration_tests.rs
@@ -6021,20 +6021,6 @@ fn test_split_single_file_commit_errors() {
     // Either way, we're testing that the behavior changed
 }
 
-#[test]
-fn test_split_interactive_flag_exists() {
-    let (_temp_dir, repo_path) = create_test_repo();
-
-    // Verify -i/--interactive flag is documented in help
-    let (success, stdout, _stderr) = run_gg(&repo_path, &["split", "--help"]);
-    assert!(success, "split --help should succeed");
-    assert!(
-        stdout.contains("-i") || stdout.contains("--interactive"),
-        "split help should mention -i/--interactive flag: {}",
-        stdout
-    );
-}
-
 /// Helper to run gg with stdin input
 fn run_gg_with_stdin(
     repo_path: &std::path::Path,
@@ -6142,7 +6128,7 @@ line 20
     let (_, log_before, _) = run_git_full(&repo_path, &["log", "--oneline"]);
     let commit_count_before = log_before.lines().count();
 
-    // Try to split with interactive mode
+    // Try to split with hunk mode (now the default).
     // When stdin is piped (not TTY), the terminal library typically returns an error
     // or reads from stdin directly. We send "y\nn\n" to select first hunk, skip second.
     //
@@ -6150,7 +6136,7 @@ line 20
     // The test validates the command doesn't crash and exercises the code path.
     let (success, stdout, stderr) = run_gg_with_stdin(
         &repo_path,
-        &["split", "-i", "-m", "First hunk only", "--no-edit"],
+        &["split", "-m", "First hunk only", "--no-edit"],
         "y\nn\n",
     );
 
@@ -6178,51 +6164,6 @@ line 20
             stderr
         );
     }
-}
-
-#[test]
-fn test_split_hunk_sub_selection_logic() {
-    // Unit-style integration test: verify the split command parses correctly
-    // and the -i flag is accepted
-    let (_temp_dir, repo_path) = create_test_repo();
-
-    // Set up minimal gg config
-    let gg_dir = repo_path.join(".git").join("gg");
-    fs::create_dir_all(&gg_dir).expect("Failed to create .git/gg");
-    fs::write(
-        gg_dir.join("config.json"),
-        r#"{"defaults":{"branch_username":"testuser"}}"#,
-    )
-    .expect("Failed to write config");
-
-    // Create stack with a commit
-    let (success, _, stderr) = run_gg(&repo_path, &["co", "test-sub-select"]);
-    assert!(success, "Failed to create stack: {}", stderr);
-
-    fs::write(repo_path.join("test.txt"), "content").expect("Failed to write");
-    run_git(&repo_path, &["add", "-A"]);
-    run_git(&repo_path, &["commit", "-m", "Test commit"]);
-
-    // Verify split -i doesn't error on flag parsing (may error on no changes/TTY)
-    let (_success, stdout, _stderr) = run_gg(&repo_path, &["split", "-i", "--help"]);
-
-    // Help should show -i
-    assert!(
-        stdout.contains("-i") || stdout.contains("--interactive"),
-        "Help should mention -i flag: {}",
-        stdout
-    );
-
-    // Now try split -i on the commit (will fail due to no TTY, but flag is valid)
-    let (_success, _stdout, stderr) =
-        run_gg(&repo_path, &["split", "-i", "-m", "test", "--no-edit"]);
-
-    // Should NOT say "unrecognized" or "unknown" flag
-    assert!(
-        !stderr.contains("unrecognized") && !stderr.contains("unknown option"),
-        "The -i flag should be recognized: {}",
-        stderr
-    );
 }
 
 #[test]
@@ -6257,12 +6198,11 @@ fn test_split_no_tui_flag() {
     run_git(&repo_path, &["add", "file_a.txt", "file_b.txt"]);
     run_git(&repo_path, &["commit", "-m", "Two files"]);
 
-    // Use --no-tui with -i and file args to bypass interactive prompts entirely
+    // Use --no-tui with file args to bypass interactive prompts entirely
     let (success, stdout, stderr) = run_gg(
         &repo_path,
         &[
             "split",
-            "-i",
             "--no-tui",
             "-m",
             "Split file A",
@@ -6279,8 +6219,7 @@ fn test_split_no_tui_flag() {
         stderr
     );
 
-    // When file args are provided with -i, it may skip interactive selection.
-    // Either way, the --no-tui path was exercised (no TUI attempted).
+    // When file args are provided, all hunks for those files are auto-selected.
     // If it succeeded, verify the split happened.
     if success {
         let (_, log_output, _) = run_git_full(&repo_path, &["log", "--oneline"]);

--- a/crates/gg-cli/tests/integration_tests.rs
+++ b/crates/gg-cli/tests/integration_tests.rs
@@ -6232,6 +6232,122 @@ fn test_split_no_tui_flag() {
     }
 }
 
+#[test]
+fn test_split_file_args_auto_selects_hunks() {
+    // Verify that `gg split <file>` auto-selects all hunks for that file
+    // without prompting, and leaves the other file in the remainder commit.
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .expect("Failed to write config");
+
+    let (success, _, stderr) = run_gg(&repo_path, &["co", "test-auto-select"]);
+    assert!(success, "Failed to create stack: {}", stderr);
+
+    // Create a commit with two text files, each with multiple lines
+    fs::write(
+        repo_path.join("alpha.txt"),
+        "line1\nline2\nline3\n",
+    )
+    .expect("write");
+    fs::write(
+        repo_path.join("beta.txt"),
+        "lineA\nlineB\nlineC\n",
+    )
+    .expect("write");
+    run_git(&repo_path, &["add", "alpha.txt", "beta.txt"]);
+    run_git(&repo_path, &["commit", "-m", "Add alpha and beta"]);
+
+    // Split out alpha.txt only
+    let (success, stdout, stderr) = run_gg(
+        &repo_path,
+        &["split", "-m", "Split alpha", "--no-edit", "alpha.txt"],
+    );
+    assert!(
+        success,
+        "split should succeed: stdout={}, stderr={}",
+        stdout, stderr
+    );
+    assert!(
+        stdout.contains("Split complete"),
+        "Expected 'Split complete': {}",
+        stdout
+    );
+
+    // Verify the split commit only contains alpha.txt
+    let (_, diff_output, _) = run_git_full(&repo_path, &["diff", "HEAD~1", "HEAD", "--name-only"]);
+    assert!(
+        diff_output.contains("beta.txt"),
+        "Remainder commit should contain beta.txt: {}",
+        diff_output
+    );
+    assert!(
+        !diff_output.contains("alpha.txt"),
+        "Remainder commit should NOT contain alpha.txt: {}",
+        diff_output
+    );
+}
+
+#[test]
+fn test_split_binary_file_with_file_args() {
+    // Verify that `gg split <binary_file>` succeeds for a commit containing
+    // both a binary file and a text file, exercising the no_hunk_files path.
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .expect("Failed to write config");
+
+    let (success, _, stderr) = run_gg(&repo_path, &["co", "test-binary-split"]);
+    assert!(success, "Failed to create stack: {}", stderr);
+
+    // Create a commit with a text file and a binary file
+    fs::write(repo_path.join("readme.txt"), "hello\n").expect("write");
+    // Write a small PNG-like binary blob so git treats it as binary
+    let binary_content: Vec<u8> = vec![
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, // PNG header
+        0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52, // IHDR chunk
+        0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+    ];
+    fs::write(repo_path.join("image.png"), &binary_content).expect("write binary");
+    run_git(&repo_path, &["add", "readme.txt", "image.png"]);
+    run_git(&repo_path, &["commit", "-m", "Add readme and image"]);
+
+    // Split out the binary file
+    let (success, stdout, stderr) = run_gg(
+        &repo_path,
+        &["split", "-m", "Split binary", "--no-edit", "image.png"],
+    );
+    assert!(
+        success,
+        "split of binary file should succeed: stdout={}, stderr={}",
+        stdout, stderr
+    );
+    assert!(
+        stdout.contains("Split complete"),
+        "Expected 'Split complete': {}",
+        stdout
+    );
+
+    // Verify the stack now has 3 commits
+    let (_, log_output, _) = run_git_full(&repo_path, &["log", "--oneline"]);
+    let commit_count = log_output.lines().count();
+    assert!(
+        commit_count >= 3,
+        "Should have at least 3 commits after split: {}",
+        log_output
+    );
+}
+
 // ============================================================================
 // Clean command verification tests
 // ============================================================================

--- a/crates/gg-cli/tests/integration_tests.rs
+++ b/crates/gg-cli/tests/integration_tests.rs
@@ -6250,16 +6250,8 @@ fn test_split_file_args_auto_selects_hunks() {
     assert!(success, "Failed to create stack: {}", stderr);
 
     // Create a commit with two text files, each with multiple lines
-    fs::write(
-        repo_path.join("alpha.txt"),
-        "line1\nline2\nline3\n",
-    )
-    .expect("write");
-    fs::write(
-        repo_path.join("beta.txt"),
-        "lineA\nlineB\nlineC\n",
-    )
-    .expect("write");
+    fs::write(repo_path.join("alpha.txt"), "line1\nline2\nline3\n").expect("write");
+    fs::write(repo_path.join("beta.txt"), "lineA\nlineB\nlineC\n").expect("write");
     run_git(&repo_path, &["add", "alpha.txt", "beta.txt"]);
     run_git(&repo_path, &["commit", "-m", "Add alpha and beta"]);
 

--- a/crates/gg-cli/tests/integration_tests.rs
+++ b/crates/gg-cli/tests/integration_tests.rs
@@ -6056,7 +6056,7 @@ fn run_gg_with_stdin(
 fn test_split_hunk_mode_with_multiple_hunks() {
     // This test verifies that hunk-level splitting works correctly.
     // We create a file with multiple disjoint changes (multiple hunks),
-    // then use split -i to select only the first hunk.
+    // then use split to select only the first hunk.
     let (_temp_dir, repo_path) = create_test_repo();
 
     // Set up minimal gg config

--- a/crates/gg-core/src/commands/split.rs
+++ b/crates/gg-core/src/commands/split.rs
@@ -5,7 +5,7 @@ use std::io::{self, Write};
 use std::process::Command;
 
 use console::{style, Term};
-use dialoguer::{Editor, MultiSelect};
+use dialoguer::Editor;
 
 use crate::config::Config;
 use crate::error::{GgError, Result};
@@ -23,8 +23,6 @@ pub struct SplitOptions {
     pub message: Option<String>,
     /// If true, don't prompt for the remainder commit message (keep original).
     pub no_edit: bool,
-    /// If true, enter interactive hunk selection mode (like git add -p).
-    pub interactive: bool,
     /// If true, disable TUI and use sequential prompt instead.
     pub no_tui: bool,
 }
@@ -135,35 +133,32 @@ pub fn run(options: SplitOptions) -> Result<()> {
     let parent_tree = parent_commit.tree()?;
     let target_tree = target_commit.tree()?;
 
-    // Determine if we should use hunk mode:
-    // 1. Explicitly requested with -i
-    // 2. Single-file commit without file args (auto-enter hunk mode)
-    let use_hunk_mode =
-        options.interactive || (changed_files.len() < 2 && options.files.is_empty());
-
     // If the TUI provides commit messages inline, they're stored here to skip the editor
     let mut tui_commit_message: Option<String> = None;
     let mut tui_remainder_message: Option<String> = None;
 
-    let first_tree = if use_hunk_mode {
-        // === Hunk-level splitting ===
-        let mut hunks = get_hunks(&repo, &parent_commit, &target_commit)?;
+    // === Hunk-level splitting (always) ===
+    let mut hunks = get_hunks(&repo, &parent_commit, &target_commit)?;
 
-        // Filter hunks to specified files if any
-        if !options.files.is_empty() {
-            validate_file_selection(&options.files, &changed_files)?;
-            hunks.retain(|h| options.files.contains(&h.file_path));
-        }
+    // Filter hunks to specified files if any
+    if !options.files.is_empty() {
+        validate_file_selection(&options.files, &changed_files)?;
+        hunks.retain(|h| options.files.contains(&h.file_path));
+    }
 
-        if hunks.is_empty() {
-            return Err(GgError::Other("No hunks found to split".to_string()));
-        }
+    if hunks.is_empty() {
+        return Err(GgError::Other("No hunks found to split".to_string()));
+    }
 
+    // When FILES are specified, auto-select all hunks for those files (no interactive prompt needed)
+    let selected_indices = if !options.files.is_empty() {
+        (0..hunks.len()).collect()
+    } else {
         // Determine whether to use TUI or sequential prompt
         let is_tty = atty::is(atty::Stream::Stdin) && atty::is(atty::Stream::Stdout);
         let use_tui = !options.no_tui && is_tty;
 
-        let selected_indices = if use_tui {
+        if use_tui {
             let commit_title = git::get_commit_title(&target_commit);
             let original_msg = git::strip_gg_id_from_message(target_commit.message().unwrap_or(""));
             match super::split_tui::select_hunks_tui(
@@ -184,48 +179,25 @@ pub fn run(options: SplitOptions) -> Result<()> {
             }
         } else {
             select_hunks_interactive(&mut hunks)?
-        };
-
-        if selected_indices.is_empty() {
-            return Err(GgError::Other(
-                "No hunks selected, nothing to split".to_string(),
-            ));
         }
-
-        let all_selected = selected_indices.len() == hunks.len();
-        if all_selected {
-            println!(
-                "{}",
-                style("⚠ All hunks selected — the original commit will become empty.").yellow()
-            );
-        }
-
-        build_tree_from_hunks(&repo, &parent_tree, &target_tree, &hunks, &selected_indices)?
-    } else {
-        // === File-level splitting ===
-        // Determine which files go to the new (first/lower) commit
-        let selected_files = if options.files.is_empty() {
-            select_files_interactive(&changed_files)?
-        } else {
-            validate_file_selection(&options.files, &changed_files)?
-        };
-
-        if selected_files.is_empty() {
-            return Err(GgError::Other(
-                "No files selected, nothing to split".to_string(),
-            ));
-        }
-
-        let all_selected = selected_files.len() == changed_files.len();
-        if all_selected {
-            println!(
-                "{}",
-                style("⚠ All files selected — the original commit will become empty.").yellow()
-            );
-        }
-
-        build_partial_tree(&repo, &parent_tree, &target_tree, &selected_files)?
     };
+
+    if selected_indices.is_empty() {
+        return Err(GgError::Other(
+            "No hunks selected, nothing to split".to_string(),
+        ));
+    }
+
+    let all_selected = selected_indices.len() == hunks.len();
+    if all_selected {
+        println!(
+            "{}",
+            style("⚠ All hunks selected — the original commit will become empty.").yellow()
+        );
+    }
+
+    let first_tree =
+        build_tree_from_hunks(&repo, &parent_tree, &target_tree, &hunks, &selected_indices)?;
 
     // Get commit messages
     // Priority: -m flag > TUI inline message > editor prompt
@@ -365,31 +337,6 @@ fn get_changed_files(
     Ok(files)
 }
 
-/// Interactive file selection using dialoguer MultiSelect
-fn select_files_interactive(changed_files: &[ChangedFile]) -> Result<Vec<String>> {
-    let items: Vec<String> = changed_files.iter().map(|f| f.to_string()).collect();
-
-    println!();
-    println!(
-        "Select files for the {} (the rest stays in the original):",
-        style("new commit (inserted BEFORE the original in the stack)").bold()
-    );
-
-    let selections = MultiSelect::new()
-        .items(&items)
-        .interact()
-        .map_err(|e| GgError::Other(format!("Selection failed: {}", e)))?;
-
-    if selections.is_empty() {
-        return Ok(vec![]);
-    }
-
-    Ok(selections
-        .iter()
-        .map(|&i| changed_files[i].path.clone())
-        .collect())
-}
-
 /// Validate that CLI-provided file paths match changed files
 fn validate_file_selection(files: &[String], changed_files: &[ChangedFile]) -> Result<Vec<String>> {
     let mut selected = Vec::new();
@@ -404,53 +351,6 @@ fn validate_file_selection(files: &[String], changed_files: &[ChangedFile]) -> R
         selected.push(file.clone());
     }
     Ok(selected)
-}
-
-/// Build a tree that has the parent tree as base, with selected files replaced from target tree
-fn build_partial_tree<'a>(
-    repo: &'a git2::Repository,
-    parent_tree: &git2::Tree,
-    target_tree: &git2::Tree,
-    selected_files: &[String],
-) -> Result<git2::Tree<'a>> {
-    // We need to build a tree that contains:
-    // - All files from parent_tree EXCEPT selected files
-    // - Selected files from target_tree
-    //
-    // Since we want the FIRST commit to contain the SELECTED changes,
-    // we start with parent and add/modify the selected files from target.
-
-    let mut builder = repo.treebuilder(Some(parent_tree))?;
-
-    for file_path in selected_files {
-        let path = std::path::Path::new(file_path);
-
-        // Check if the file exists in target (added or modified)
-        if let Ok(entry) = target_tree.get_path(path) {
-            // File exists in target - add/update it
-            if path.parent().is_some() && path.parent() != Some(std::path::Path::new("")) {
-                // Nested path - need to handle directory structure
-                insert_nested_entry(repo, &mut builder, parent_tree, target_tree, file_path)?;
-            } else {
-                // Top-level file
-                let name = path.file_name().unwrap().to_string_lossy();
-                builder.insert(&*name, entry.id(), entry.filemode())?;
-            }
-        } else {
-            // File doesn't exist in target - it was deleted
-            // For the first commit, we want to include the deletion
-            let name = path.file_name().unwrap().to_string_lossy();
-            if path.parent().is_none() || path.parent() == Some(std::path::Path::new("")) {
-                let _ = builder.remove(&*name);
-            } else {
-                insert_nested_entry(repo, &mut builder, parent_tree, target_tree, file_path)?;
-            }
-        }
-    }
-
-    let tree_oid = builder.write()?;
-    let tree = repo.find_tree(tree_oid)?;
-    Ok(tree)
 }
 
 /// Insert a nested file entry by reconstructing intermediate directory trees
@@ -1347,7 +1247,6 @@ mod tests {
         assert!(opts.files.is_empty());
         assert!(opts.message.is_none());
         assert!(!opts.no_edit);
-        assert!(!opts.interactive);
     }
 
     #[test]

--- a/crates/gg-core/src/commands/split.rs
+++ b/crates/gg-core/src/commands/split.rs
@@ -140,13 +140,27 @@ pub fn run(options: SplitOptions) -> Result<()> {
     // === Hunk-level splitting (always) ===
     let mut hunks = get_hunks(&repo, &parent_commit, &target_commit)?;
 
+    // Track files specified via CLI that have no textual hunks (binary, mode-only, etc.)
+    // These need to be handled at the tree level since they have no patch hunks to select.
+    let mut no_hunk_files: Vec<String> = Vec::new();
+
     // Filter hunks to specified files if any
     if !options.files.is_empty() {
         validate_file_selection(&options.files, &changed_files)?;
         hunks.retain(|h| options.files.contains(&h.file_path));
+
+        // Identify specified files that have no hunks (binary, mode-only, renames, etc.)
+        let files_with_hunks: std::collections::HashSet<&str> =
+            hunks.iter().map(|h| h.file_path.as_str()).collect();
+        no_hunk_files = options
+            .files
+            .iter()
+            .filter(|f| !files_with_hunks.contains(f.as_str()))
+            .cloned()
+            .collect();
     }
 
-    if hunks.is_empty() {
+    if hunks.is_empty() && no_hunk_files.is_empty() {
         return Err(GgError::Other("No hunks found to split".to_string()));
     }
 
@@ -188,7 +202,7 @@ pub fn run(options: SplitOptions) -> Result<()> {
         ));
     }
 
-    let all_selected = selected_indices.len() == hunks.len();
+    let all_selected = options.files.is_empty() && selected_indices.len() == hunks.len();
     if all_selected {
         println!(
             "{}",
@@ -196,8 +210,18 @@ pub fn run(options: SplitOptions) -> Result<()> {
         );
     }
 
-    let first_tree =
+    let mut first_tree =
         build_tree_from_hunks(&repo, &parent_tree, &target_tree, &hunks, &selected_indices)?;
+
+    // For FILES without textual hunks (binary, mode-only, renames), copy tree entries directly
+    if !no_hunk_files.is_empty() {
+        let mut builder = repo.treebuilder(Some(&first_tree))?;
+        for file_path in &no_hunk_files {
+            update_tree_entry(&repo, &mut builder, &parent_tree, &target_tree, file_path)?;
+        }
+        let tree_oid = builder.write()?;
+        first_tree = repo.find_tree(tree_oid)?;
+    }
 
     // Get commit messages
     // Priority: -m flag > TUI inline message > editor prompt

--- a/crates/gg-core/src/commands/split.rs
+++ b/crates/gg-core/src/commands/split.rs
@@ -208,7 +208,7 @@ pub fn run(options: SplitOptions) -> Result<()> {
         }
     };
 
-    if selected_indices.is_empty() {
+    if selected_indices.is_empty() && no_hunk_files.is_empty() {
         return Err(GgError::Other(
             "No hunks selected, nothing to split".to_string(),
         ));
@@ -229,7 +229,12 @@ pub fn run(options: SplitOptions) -> Result<()> {
     if !no_hunk_files.is_empty() {
         let mut builder = repo.treebuilder(Some(&first_tree))?;
         for file_path in &no_hunk_files {
-            update_tree_entry(&repo, &mut builder, &parent_tree, &target_tree, file_path)?;
+            let path = std::path::Path::new(file_path);
+            if target_tree.get_path(path).is_ok() {
+                update_tree_entry(&repo, &mut builder, &parent_tree, &target_tree, file_path)?;
+            } else {
+                remove_tree_entry(&repo, &mut builder, &parent_tree, file_path)?;
+            }
         }
         let tree_oid = builder.write()?;
         first_tree = repo.find_tree(tree_oid)?;

--- a/crates/gg-core/src/commands/split.rs
+++ b/crates/gg-core/src/commands/split.rs
@@ -161,6 +161,18 @@ pub fn run(options: SplitOptions) -> Result<()> {
     }
 
     if hunks.is_empty() && no_hunk_files.is_empty() {
+        // If there are changed files but no textual hunks, the commit only has
+        // non-textual changes (binary, mode-only, renames) that can't be displayed
+        // in the hunk selection TUI. Guide the user to the file-args path.
+        if !changed_files.is_empty() {
+            let file_list: Vec<&str> = changed_files.iter().map(|f| f.path.as_str()).collect();
+            return Err(GgError::Other(format!(
+                "No textual hunks to split. The commit only contains non-textual changes \
+                 (binary, mode-only, or renames).\n\
+                 To split by file, specify files explicitly: gg split {}",
+                file_list.join(" ")
+            )));
+        }
         return Err(GgError::Other("No hunks found to split".to_string()));
     }
 

--- a/docs/src/commands/split.md
+++ b/docs/src/commands/split.md
@@ -1,6 +1,6 @@
 # `gg split`
 
-Split a commit in the stack into two commits. The selected files/hunks become a new commit inserted **before** the original in the stack, while the remaining changes stay in the original commit.
+Split a commit in the stack into two commits. The selected hunks become a new commit inserted **before** the original in the stack, while the remaining changes stay in the original commit.
 
 ```bash
 gg split [OPTIONS] [FILES...]
@@ -11,16 +11,15 @@ gg split [OPTIONS] [FILES...]
 - `-c, --commit <TARGET>`: Target commit — position (1-indexed), short SHA, or GG-ID. Defaults to the current commit (HEAD).
 - `-m, --message <MESSAGE>`: Commit message for the new (first) commit. Skips the editor prompt.
 - `--no-edit`: Keep the original message for the remainder commit without prompting.
-- `-i, --interactive`: Select individual hunks interactively. Auto-enabled for single-file commits.
 - `--no-tui`: Disable TUI, use sequential prompt instead (legacy `git add -p` style).
-- `FILES...`: Files to include in the new commit. If omitted, opens an interactive file selector (or hunk selector in interactive mode).
+- `FILES...`: Files to include in the new commit. When provided, all hunks for the specified files are automatically selected (no interactive prompt).
 
 ## How It Works
 
 When you split commit **K** into two:
 
-1. **New commit (K')** — Contains only the selected files/hunks. Inserted **before** K in the stack. Gets a new GG-ID.
-2. **Remainder (K'')** — Contains the remaining files/hunks. Stays in K's original position. Keeps the original GG-ID (preserving PR association).
+1. **New commit (K')** — Contains only the selected hunks. Inserted **before** K in the stack. Gets a new GG-ID.
+2. **Remainder (K'')** — Contains the remaining hunks. Stays in K's original position. Keeps the original GG-ID (preserving PR association).
 
 All descendant commits are automatically rebased onto the remainder.
 
@@ -33,16 +32,18 @@ BEFORE                    AFTER
                              1: "Init project"
 ```
 
-## File-Level Splitting
+## Splitting
 
-### Interactive file selection
+### Interactive hunk selection
 
 ```bash
-# Split the current commit — opens a checkbox selector
+# Split the current commit — opens the TUI for hunk selection
 gg split
 ```
 
 ### Split with explicit files
+
+When files are specified, all hunks for those files are automatically selected (no interactive prompt):
 
 ```bash
 # Move auth files to a new commit before the current one
@@ -65,23 +66,9 @@ gg split -c c-abc1234 src/config.rs
 gg split -c 2 -m "Extract helpers" --no-edit helpers.rs utils.rs
 ```
 
-## Hunk-Level Splitting (`-i`)
-
-When you need finer control than whole files, use interactive hunk mode:
-
-```bash
-# Force hunk mode for any commit
-gg split -i
-
-# Hunk mode on specific files
-gg split -i src/auth.rs
-```
-
-**Note:** Single-file commits automatically enter hunk mode since file-level splitting wouldn't make sense.
-
 ### TUI Mode (Default)
 
-When run interactively with a TTY, `gg split -i` opens a two-panel TUI for hunk selection:
+When run interactively with a TTY, `gg split` opens a two-panel TUI for hunk selection:
 
 ```
 ┌── Files (1/3 width) ──┬── Diff (2/3 width) ──────────────┐
@@ -143,7 +130,7 @@ The `-m` flag still works and bypasses the TUI input for the new commit. The `--
 Use `--no-tui` to fall back to the legacy `git add -p` style sequential prompt:
 
 ```bash
-gg split -i --no-tui
+gg split --no-tui
 ```
 
 This mode is automatically used when no TTY is available (e.g., in CI pipelines or when piping).

--- a/docs/src/mcp-server.md
+++ b/docs/src/mcp-server.md
@@ -191,7 +191,7 @@ Split a commit into two by moving specified files to a new commit.
 - `message` (string, optional): Message for the new (first) commit.
 - `no_edit` (boolean, optional): Don't prompt for the remainder commit message.
 
-**Notes:** File-level only (no hunk selection via MCP). The new commit is inserted *before* the original.
+**Notes:** Auto-selects all hunks for the specified files. The new commit is inserted *before* the original.
 
 ### `stack_reorder`
 

--- a/skills/gg/SKILL.md
+++ b/skills/gg/SKILL.md
@@ -126,8 +126,7 @@ gg land -a -c --json
 - Navigate: `gg mv`, `gg first`, `gg last`, `gg prev`, `gg next`
 - Amend current commit: `gg sc` / `gg sc -a`
 - Auto-distribute staged hunks: `gg absorb -s`
-- Split a commit into two (file-level): `gg split -c 3 file1.rs file2.rs`
-- Split a commit into two (hunk-level): `gg split -i` — opens a two-panel TUI for hunk selection (files on the left, colored diff on the right), followed by inline commit message inputs for both the new and remainder commits. Use `--no-tui` to fall back to sequential `git add -p` style prompts. The `-m` flag bypasses the TUI message input for the new commit. The `--no-edit` flag skips the remainder message input.
+- Split a commit into two: `gg split` — opens a two-panel TUI for hunk selection (files on the left, colored diff on the right), followed by inline commit message inputs for both the new and remainder commits. Use `--no-tui` to fall back to sequential `git add -p` style prompts. The `-m` flag bypasses the TUI message input for the new commit. The `--no-edit` flag skips the remainder message input. Specify files directly to auto-select all their hunks: `gg split -c 3 file1.rs file2.rs`.
 - Drop commits from stack: `gg drop <position|sha|gg-id>... --force` (alias: `gg abandon`)
 - Reorder/drop stack (TUI): `gg reorder` (or `gg arrange`) — opens interactive TUI for visual reordering and dropping commits. Press `d` to mark a commit for dropping. Use `--no-tui` to fall back to text editor (delete lines to drop).
 - Reorder stack (direct): `gg reorder -o "3,1,2"`
@@ -222,7 +221,7 @@ The `gg-mcp` binary exposes git-gud as an MCP server (stdio transport). Set `GG_
 - `stack_squash` / `stack_absorb` — amend commits
 - `stack_reconcile` — fix out-of-sync remote branches
 - `stack_drop` — remove commits from the stack (always uses `--force`; agent confirms with user)
-- `stack_split` — split a commit by moving specified files to a new commit (file-level only, no hunk selection)
+- `stack_split` — split a commit by moving specified files to a new commit (auto-selects all hunks for the specified files)
 - `stack_reorder` — reorder commits with explicit order string (no TUI)
 
 ### Navigation tools

--- a/skills/gg/reference.md
+++ b/skills/gg/reference.md
@@ -136,9 +136,8 @@ Split a commit into two. Selected files/hunks become a new commit inserted befor
 - `-c, --commit <TARGET>` — target commit (position, SHA, or GG-ID; default: current)
 - `-m, --message <MSG>` — message for the new commit
 - `--no-edit` — keep original message for remainder, don't prompt
-- `-i, --interactive` — select individual hunks interactively with TUI. Auto-enabled for single-file commits. After selecting hunks, inline text inputs appear for both the new commit message (pre-filled with `Split from: <original title>`) and the remainder commit message (pre-filled with the original commit message). Press Enter to confirm each, Esc to go back to the previous step. The `--no-edit` flag skips the remainder message input.
-- `--no-tui` — disable TUI, use sequential prompt instead (legacy `git add -p` style)
-- `FILES...` — files for the new commit (interactive selector if omitted)
+- `--no-tui` — disable TUI, use sequential prompt instead (`git add -p` style)
+- `FILES...` — files for the new commit (auto-selects all hunks for specified files; opens interactive TUI if omitted). After selecting hunks, inline text inputs appear for both the new commit message (pre-filled with `Split from: <original title>`) and the remainder commit message (pre-filled with the original commit message). Press Enter to confirm each, Esc to go back to the previous step. The `--no-edit` flag skips the remainder message input.
 
 #### `gg rebase [TARGET]`
 Rebase current stack onto base or explicit target.
@@ -536,7 +535,7 @@ Split a commit by moving specified files to a new commit.
   - `files` (string[], required) — files to include in the new commit
   - `message` (string, optional) — message for the new commit
   - `no_edit` (bool, default false) — skip prompt for remainder commit message
-- **Notes:** File-level only (`--no-tui` implicit). Hunk-level selection not available via MCP.
+- **Notes:** Auto-selects all hunks for the specified files (`--no-tui` implicit).
 - **Returns:** Result of the split operation
 
 #### `stack_reorder`


### PR DESCRIPTION
## Summary
- Remove the `-i`/`--interactive` flag from `gg split` — hunk-level splitting is now always the default
- When `FILES...` args are provided, all hunks for those files are auto-selected without interactive prompting
- Delete the legacy file-level dialoguer checkbox flow (`select_files_interactive`, `build_partial_tree`) as the TUI is a strict superset
- Update docs, help text, and tests accordingly

## Test plan
- [x] `cargo check` — compiles with zero warnings
- [x] `cargo test split` — all 64 split tests pass
- [ ] Manual: `gg split` opens TUI hunk selector (previously required `-i`)
- [ ] Manual: `gg split src/file.rs` auto-selects all hunks for that file
- [ ] Manual: `gg split --no-tui` falls back to sequential prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)