### PR TITLE
feat(sync): stack navigation comments on PRs/MRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ All configuration options are in the `defaults` section (with provider-specific 
 | `sync_auto_lint` | `boolean` | Automatically run `gg lint` before `gg sync` | `false` |
 | `sync_auto_rebase` (`sync.auto_rebase`) | `boolean` | Automatically run `gg rebase` before `gg sync` when base is behind threshold | `false` |
 | `sync_behind_threshold` (`sync.behind_threshold`) | `number` | Warn/rebase in `gg sync` when base is at least this many commits behind `origin/<base>` (`0` disables check) | `1` |
+| `stack_nav_comments` | `boolean` | **Stack navigation comments** — opt-in. Each PR/MR in a stack gets a managed comment listing sibling PRs with a 👉 marker on the current one (GitHub `#N` or GitLab `!N`). | `false` |
 | `worktree_base_path` | `string` | Base directory used by `gg co --wt` / `--worktree` for managed stack worktrees | Parent directory of current repository |
 | `gitlab.auto_merge_on_land` | `boolean` | *(GitLab only)* Use "merge when pipeline succeeds" for `gg land` by default | `false` |
 

--- a/crates/gg-core/src/commands/setup.rs
+++ b/crates/gg-core/src/commands/setup.rs
@@ -161,6 +161,11 @@ fn prompt_defaults_full(
         .default(existing.sync_update_descriptions)
         .interact()
         .map_err(|e| GgError::Other(format!("Prompt failed: {}", e)))?;
+    defaults.stack_nav_comments = Confirm::with_theme(theme)
+        .with_prompt("Post a navigation comment on each PR/MR in a stack (links to other PRs/MRs)?")
+        .default(existing.stack_nav_comments)
+        .interact()
+        .map_err(|e| GgError::Other(format!("Prompt failed: {}", e)))?;
 
     // ── Land ──
     print_group_header("Land");

--- a/crates/gg-core/src/commands/sync.rs
+++ b/crates/gg-core/src/commands/sync.rs
@@ -671,14 +671,20 @@ pub fn run(
             // Reuse state cached during the main loop if available (existing PRs);
             // fall back to a fresh fetch only for newly created PRs.
             let state = if let Some(cached) = pr_state_cached {
-                Some(cached)
+                cached
             } else {
                 match provider.get_pr_info(num).map(|info| info.state).ok() {
-                    Some(crate::provider::PrState::Open) => Some(stack_nav::PrEntryState::Open),
-                    Some(crate::provider::PrState::Draft) => Some(stack_nav::PrEntryState::Draft),
-                    Some(crate::provider::PrState::Merged) => Some(stack_nav::PrEntryState::Merged),
-                    Some(crate::provider::PrState::Closed) => Some(stack_nav::PrEntryState::Closed),
-                    None => None,
+                    Some(crate::provider::PrState::Open) => stack_nav::PrEntryState::Open,
+                    Some(crate::provider::PrState::Draft) => stack_nav::PrEntryState::Draft,
+                    Some(crate::provider::PrState::Merged) => stack_nav::PrEntryState::Merged,
+                    Some(crate::provider::PrState::Closed) => stack_nav::PrEntryState::Closed,
+                    // Default to Open when the API is unreachable — we know the
+                    // PR exists (just created or from config). Treating it as Open
+                    // means the reconcile pass will attempt to upsert/delete the
+                    // nav comment; if the API is truly down, that will fail with a
+                    // non-fatal warning rather than silently dropping the entry
+                    // from all nav comments.
+                    None => stack_nav::PrEntryState::Open,
                 }
             };
             // json_entries.len() - 1 = the index of the entry we just pushed (JSON mode).
@@ -688,9 +694,9 @@ pub fn run(
             } else {
                 0
             };
-            state.map(|pr_state| NavEntrySnapshot {
+            Some(NavEntrySnapshot {
                 pr_number: num,
-                pr_state,
+                pr_state: state,
                 json_index,
             })
         } else {

--- a/crates/gg-core/src/commands/sync.rs
+++ b/crates/gg-core/src/commands/sync.rs
@@ -717,7 +717,10 @@ pub fn run(
     // cannot vouch for all PRs in the stack, and the single-entry skip rule
     // would misfire for partial subsets. Full `gg sync` (no --until) will
     // reconcile navigation across the whole stack.
-    if until.is_none() {
+    // Skip nav reconcile if any entry failed during the sync — a partial set of
+    // PR numbers would produce truncated stack navigation on every other PR in
+    // the stack. The next full successful sync will reconcile.
+    if until.is_none() && nav_snapshots.iter().all(|s| s.is_some()) {
         // For each synced entry whose PR exists and is reachable, decide whether
         // to create/update/delete the managed nav comment based on:
         //   - the stack_nav_comments setting
@@ -852,7 +855,7 @@ pub fn run(
                 }
             }
         }
-    } // end if until.is_none()
+    } // end nav-comment reconcile
 
     // Save updated config
     config.save(git_dir)?;

--- a/crates/gg-core/src/commands/sync.rs
+++ b/crates/gg-core/src/commands/sync.rs
@@ -390,6 +390,7 @@ pub fn run(
                         draft: entry_draft,
                         pushed,
                         error: entry_error,
+                        nav_comment_action: None,
                     });
                     continue;
                 }
@@ -640,6 +641,7 @@ pub fn run(
                 draft: entry_draft,
                 pushed,
                 error: entry_error,
+                nav_comment_action: None,
             });
         }
 
@@ -1079,6 +1081,7 @@ mod tests {
                     draft: false,
                     pushed: true,
                     error: None,
+                    nav_comment_action: None,
                 }],
             },
         };

--- a/crates/gg-core/src/commands/sync.rs
+++ b/crates/gg-core/src/commands/sync.rs
@@ -14,7 +14,17 @@ use crate::output::{
 };
 use crate::provider::Provider;
 use crate::stack::{resolve_target, Stack};
+use crate::stack_nav;
 use crate::template::{self, TemplateContext};
+
+/// Per-entry state captured during the main sync loop that the nav-comment
+/// reconcile pass needs. Populated only for entries whose PR exists.
+struct NavEntrySnapshot {
+    pr_number: u64,
+    pr_state: stack_nav::PrEntryState,
+    /// Index into `json_entries` so we can attach the nav action result.
+    json_index: usize,
+}
 
 /// Format and display a push error with helpful context
 fn maybe_rebase_if_base_is_behind(
@@ -328,6 +338,7 @@ pub fn run(
     // that PR and all subsequent PRs should be drafts.
     let mut force_draft = draft;
     let mut json_entries: Vec<SyncEntryResultJson> = Vec::new();
+    let mut nav_snapshots: Vec<Option<NavEntrySnapshot>> = Vec::new();
 
     for (i, entry) in entries_to_sync.iter().enumerate() {
         let gg_id = entry.gg_id.as_ref().unwrap();
@@ -392,6 +403,7 @@ pub fn run(
                         error: entry_error,
                         nav_comment_action: None,
                     });
+                    nav_snapshots.push(None);
                     continue;
                 }
 
@@ -645,11 +657,174 @@ pub fn run(
             });
         }
 
+        // Capture state for nav reconcile pass after the main loop.
+        let nav_snapshot: Option<NavEntrySnapshot> = if let Some(num) = pr_number {
+            let state = match provider.get_pr_info(num).map(|info| info.state).ok() {
+                Some(crate::provider::PrState::Open) => Some(stack_nav::PrEntryState::Open),
+                Some(crate::provider::PrState::Draft) => Some(stack_nav::PrEntryState::Draft),
+                Some(crate::provider::PrState::Merged) => Some(stack_nav::PrEntryState::Merged),
+                Some(crate::provider::PrState::Closed) => Some(stack_nav::PrEntryState::Closed),
+                None => None,
+            };
+            // json_entries.len() - 1 = the index of the entry we just pushed (JSON mode).
+            // In non-JSON mode, json_entries is empty — use a sentinel index.
+            let json_index = if json {
+                json_entries.len().saturating_sub(1)
+            } else {
+                0
+            };
+            state.map(|pr_state| NavEntrySnapshot {
+                pr_number: num,
+                pr_state,
+                json_index,
+            })
+        } else {
+            None
+        };
+        nav_snapshots.push(nav_snapshot);
+
         pb.inc(1);
     }
 
     if !json {
         pb.finish_with_message("Done!");
+    }
+
+    // --- Nav-comment reconcile pass ---
+    //
+    // For each synced entry whose PR exists and is reachable, decide whether
+    // to create/update/delete the managed nav comment based on:
+    //   - the stack_nav_comments setting
+    //   - the total stack size
+    //   - the PR's state (open/draft vs merged/closed)
+    //
+    // We render the nav body with `is_current = true` on the entry being
+    // processed, so each PR's comment highlights the reader's location.
+    let setting_enabled = config.get_stack_nav_comments();
+    let stack_entry_count = entries_to_sync.len();
+    let number_prefix = provider.pr_number_prefix();
+
+    // Collect the (pr_number, index) pairs once — used to render each
+    // per-PR body with a different `is_current` flag.
+    let all_entries: Vec<(u64, usize)> = nav_snapshots
+        .iter()
+        .enumerate()
+        .filter_map(|(i, s)| s.as_ref().map(|snap| (snap.pr_number, i)))
+        .collect();
+
+    for (i, snap) in nav_snapshots.iter().enumerate() {
+        let snap = match snap {
+            Some(s) => s,
+            None => continue,
+        };
+
+        // Check for an existing managed comment once per PR.
+        let existing = match provider.find_managed_comment(snap.pr_number, stack_nav::MARKER) {
+            Ok(v) => v,
+            Err(e) => {
+                if !json {
+                    println!(
+                        "{} Could not list comments on {} {}{}: {}",
+                        style("Warning:").yellow(),
+                        provider.pr_label(),
+                        number_prefix,
+                        snap.pr_number,
+                        e
+                    );
+                }
+                if json {
+                    if let Some(entry_json) = json_entries.get_mut(snap.json_index) {
+                        entry_json.nav_comment_action = Some("error".to_string());
+                    }
+                }
+                continue;
+            }
+        };
+
+        let decision = stack_nav::decide_action(stack_nav::NavDecisionInput {
+            setting_enabled,
+            stack_entry_count,
+            pr_state: snap.pr_state,
+            has_existing_comment: existing.is_some(),
+        });
+
+        let action_result: Option<&str> = match decision {
+            stack_nav::NavAction::Skip => None,
+            stack_nav::NavAction::Upsert => {
+                // Render body with `is_current = true` for this entry's position.
+                let nav_entries: Vec<stack_nav::StackNavEntry> = all_entries
+                    .iter()
+                    .map(|(n, j)| stack_nav::StackNavEntry {
+                        pr_number: *n,
+                        is_current: *j == i,
+                    })
+                    .collect();
+                let body = stack_nav::render(&stack.name, &nav_entries, number_prefix);
+
+                match existing {
+                    Some(c) if c.body == body => Some("unchanged"),
+                    Some(c) => match provider.update_pr_comment(snap.pr_number, c.id, &body) {
+                        Ok(()) => Some("updated"),
+                        Err(e) => {
+                            if !json {
+                                println!(
+                                    "{} Could not update nav comment on {} {}{}: {}",
+                                    style("Warning:").yellow(),
+                                    provider.pr_label(),
+                                    number_prefix,
+                                    snap.pr_number,
+                                    e
+                                );
+                            }
+                            Some("error")
+                        }
+                    },
+                    None => match provider.create_pr_comment(snap.pr_number, &body) {
+                        Ok(()) => Some("created"),
+                        Err(e) => {
+                            if !json {
+                                println!(
+                                    "{} Could not create nav comment on {} {}{}: {}",
+                                    style("Warning:").yellow(),
+                                    provider.pr_label(),
+                                    number_prefix,
+                                    snap.pr_number,
+                                    e
+                                );
+                            }
+                            Some("error")
+                        }
+                    },
+                }
+            }
+            stack_nav::NavAction::Delete => match existing {
+                Some(c) => match provider.delete_pr_comment(snap.pr_number, c.id) {
+                    Ok(()) => Some("deleted"),
+                    Err(e) => {
+                        if !json {
+                            println!(
+                                "{} Could not delete nav comment on {} {}{}: {}",
+                                style("Warning:").yellow(),
+                                provider.pr_label(),
+                                number_prefix,
+                                snap.pr_number,
+                                e
+                            );
+                        }
+                        Some("error")
+                    }
+                },
+                None => None,
+            },
+        };
+
+        if let Some(action) = action_result {
+            if json {
+                if let Some(entry_json) = json_entries.get_mut(snap.json_index) {
+                    entry_json.nav_comment_action = Some(action.to_string());
+                }
+            }
+        }
     }
 
     // Save updated config

--- a/crates/gg-core/src/commands/sync.rs
+++ b/crates/gg-core/src/commands/sync.rs
@@ -358,6 +358,7 @@ pub fn run(
         let mut pr_url: Option<String> = None;
         let mut pushed = false;
         let mut entry_error: Option<String> = None;
+        let mut pr_state_cached: Option<crate::stack_nav::PrEntryState> = None;
 
         let (title, description) = build_pr_payload(
             &title,
@@ -431,6 +432,14 @@ pub fn run(
                 // Check if PR is still open before updating
                 let pr_info = provider.get_pr_info(pr_num).ok();
                 pr_url = pr_info.as_ref().map(|info| info.url.clone());
+                // Cache the state so the nav reconcile pass can reuse it without
+                // a second network round-trip.
+                pr_state_cached = pr_info.as_ref().map(|info| match info.state {
+                    crate::provider::PrState::Open => crate::stack_nav::PrEntryState::Open,
+                    crate::provider::PrState::Draft => crate::stack_nav::PrEntryState::Draft,
+                    crate::provider::PrState::Merged => crate::stack_nav::PrEntryState::Merged,
+                    crate::provider::PrState::Closed => crate::stack_nav::PrEntryState::Closed,
+                });
                 let is_closed = pr_info
                     .as_ref()
                     .map(|info| {
@@ -659,12 +668,18 @@ pub fn run(
 
         // Capture state for nav reconcile pass after the main loop.
         let nav_snapshot: Option<NavEntrySnapshot> = if let Some(num) = pr_number {
-            let state = match provider.get_pr_info(num).map(|info| info.state).ok() {
-                Some(crate::provider::PrState::Open) => Some(stack_nav::PrEntryState::Open),
-                Some(crate::provider::PrState::Draft) => Some(stack_nav::PrEntryState::Draft),
-                Some(crate::provider::PrState::Merged) => Some(stack_nav::PrEntryState::Merged),
-                Some(crate::provider::PrState::Closed) => Some(stack_nav::PrEntryState::Closed),
-                None => None,
+            // Reuse state cached during the main loop if available (existing PRs);
+            // fall back to a fresh fetch only for newly created PRs.
+            let state = if let Some(cached) = pr_state_cached {
+                Some(cached)
+            } else {
+                match provider.get_pr_info(num).map(|info| info.state).ok() {
+                    Some(crate::provider::PrState::Open) => Some(stack_nav::PrEntryState::Open),
+                    Some(crate::provider::PrState::Draft) => Some(stack_nav::PrEntryState::Draft),
+                    Some(crate::provider::PrState::Merged) => Some(stack_nav::PrEntryState::Merged),
+                    Some(crate::provider::PrState::Closed) => Some(stack_nav::PrEntryState::Closed),
+                    None => None,
+                }
             };
             // json_entries.len() - 1 = the index of the entry we just pushed (JSON mode).
             // In non-JSON mode, json_entries is empty — use a sentinel index.
@@ -692,140 +707,146 @@ pub fn run(
 
     // --- Nav-comment reconcile pass ---
     //
-    // For each synced entry whose PR exists and is reachable, decide whether
-    // to create/update/delete the managed nav comment based on:
-    //   - the stack_nav_comments setting
-    //   - the total stack size
-    //   - the PR's state (open/draft vs merged/closed)
-    //
-    // We render the nav body with `is_current = true` on the entry being
-    // processed, so each PR's comment highlights the reader's location.
-    let setting_enabled = config.get_stack_nav_comments();
-    let stack_entry_count = entries_to_sync.len();
-    let number_prefix = provider.pr_number_prefix();
+    // Skipped under --until to avoid inconsistent nav comments: a partial sync
+    // cannot vouch for all PRs in the stack, and the single-entry skip rule
+    // would misfire for partial subsets. Full `gg sync` (no --until) will
+    // reconcile navigation across the whole stack.
+    if until.is_none() {
+        // For each synced entry whose PR exists and is reachable, decide whether
+        // to create/update/delete the managed nav comment based on:
+        //   - the stack_nav_comments setting
+        //   - the total stack size
+        //   - the PR's state (open/draft vs merged/closed)
+        //
+        // We render the nav body with `is_current = true` on the entry being
+        // processed, so each PR's comment highlights the reader's location.
+        let setting_enabled = config.get_stack_nav_comments();
+        let stack_entry_count = entries_to_sync.len();
+        let number_prefix = provider.pr_number_prefix();
 
-    // Collect the (pr_number, index) pairs once — used to render each
-    // per-PR body with a different `is_current` flag.
-    let all_entries: Vec<(u64, usize)> = nav_snapshots
-        .iter()
-        .enumerate()
-        .filter_map(|(i, s)| s.as_ref().map(|snap| (snap.pr_number, i)))
-        .collect();
+        // Collect the (pr_number, index) pairs once — used to render each
+        // per-PR body with a different `is_current` flag.
+        let all_entries: Vec<(u64, usize)> = nav_snapshots
+            .iter()
+            .enumerate()
+            .filter_map(|(i, s)| s.as_ref().map(|snap| (snap.pr_number, i)))
+            .collect();
 
-    for (i, snap) in nav_snapshots.iter().enumerate() {
-        let snap = match snap {
-            Some(s) => s,
-            None => continue,
-        };
+        for (i, snap) in nav_snapshots.iter().enumerate() {
+            let snap = match snap {
+                Some(s) => s,
+                None => continue,
+            };
 
-        // Check for an existing managed comment once per PR.
-        let existing = match provider.find_managed_comment(snap.pr_number, stack_nav::MARKER) {
-            Ok(v) => v,
-            Err(e) => {
-                if !json {
-                    println!(
-                        "{} Could not list comments on {} {}{}: {}",
-                        style("Warning:").yellow(),
-                        provider.pr_label(),
-                        number_prefix,
-                        snap.pr_number,
-                        e
-                    );
+            // Check for an existing managed comment once per PR.
+            let existing = match provider.find_managed_comment(snap.pr_number) {
+                Ok(v) => v,
+                Err(e) => {
+                    if !json {
+                        println!(
+                            "{} Could not list comments on {} {}{}: {}",
+                            style("Warning:").yellow(),
+                            provider.pr_label(),
+                            number_prefix,
+                            snap.pr_number,
+                            e
+                        );
+                    }
+                    if json {
+                        if let Some(entry_json) = json_entries.get_mut(snap.json_index) {
+                            entry_json.nav_comment_action = Some("error".to_string());
+                        }
+                    }
+                    continue;
                 }
+            };
+
+            let decision = stack_nav::decide_action(stack_nav::NavDecisionInput {
+                setting_enabled,
+                stack_entry_count,
+                pr_state: snap.pr_state,
+                has_existing_comment: existing.is_some(),
+            });
+
+            let action_result: Option<&str> = match decision {
+                stack_nav::NavAction::Skip => None,
+                stack_nav::NavAction::Upsert => {
+                    // Render body with `is_current = true` for this entry's position.
+                    let nav_entries: Vec<stack_nav::StackNavEntry> = all_entries
+                        .iter()
+                        .map(|(n, j)| stack_nav::StackNavEntry {
+                            pr_number: *n,
+                            is_current: *j == i,
+                        })
+                        .collect();
+                    let body = stack_nav::render(&stack.name, &nav_entries, number_prefix);
+
+                    match existing {
+                        Some(c) if c.body == body => Some("unchanged"),
+                        Some(c) => match provider.update_pr_comment(snap.pr_number, c.id, &body) {
+                            Ok(()) => Some("updated"),
+                            Err(e) => {
+                                if !json {
+                                    println!(
+                                        "{} Could not update nav comment on {} {}{}: {}",
+                                        style("Warning:").yellow(),
+                                        provider.pr_label(),
+                                        number_prefix,
+                                        snap.pr_number,
+                                        e
+                                    );
+                                }
+                                Some("error")
+                            }
+                        },
+                        None => match provider.create_pr_comment(snap.pr_number, &body) {
+                            Ok(()) => Some("created"),
+                            Err(e) => {
+                                if !json {
+                                    println!(
+                                        "{} Could not create nav comment on {} {}{}: {}",
+                                        style("Warning:").yellow(),
+                                        provider.pr_label(),
+                                        number_prefix,
+                                        snap.pr_number,
+                                        e
+                                    );
+                                }
+                                Some("error")
+                            }
+                        },
+                    }
+                }
+                stack_nav::NavAction::Delete => match existing {
+                    Some(c) => match provider.delete_pr_comment(snap.pr_number, c.id) {
+                        Ok(()) => Some("deleted"),
+                        Err(e) => {
+                            if !json {
+                                println!(
+                                    "{} Could not delete nav comment on {} {}{}: {}",
+                                    style("Warning:").yellow(),
+                                    provider.pr_label(),
+                                    number_prefix,
+                                    snap.pr_number,
+                                    e
+                                );
+                            }
+                            Some("error")
+                        }
+                    },
+                    None => None,
+                },
+            };
+
+            if let Some(action) = action_result {
                 if json {
                     if let Some(entry_json) = json_entries.get_mut(snap.json_index) {
-                        entry_json.nav_comment_action = Some("error".to_string());
+                        entry_json.nav_comment_action = Some(action.to_string());
                     }
-                }
-                continue;
-            }
-        };
-
-        let decision = stack_nav::decide_action(stack_nav::NavDecisionInput {
-            setting_enabled,
-            stack_entry_count,
-            pr_state: snap.pr_state,
-            has_existing_comment: existing.is_some(),
-        });
-
-        let action_result: Option<&str> = match decision {
-            stack_nav::NavAction::Skip => None,
-            stack_nav::NavAction::Upsert => {
-                // Render body with `is_current = true` for this entry's position.
-                let nav_entries: Vec<stack_nav::StackNavEntry> = all_entries
-                    .iter()
-                    .map(|(n, j)| stack_nav::StackNavEntry {
-                        pr_number: *n,
-                        is_current: *j == i,
-                    })
-                    .collect();
-                let body = stack_nav::render(&stack.name, &nav_entries, number_prefix);
-
-                match existing {
-                    Some(c) if c.body == body => Some("unchanged"),
-                    Some(c) => match provider.update_pr_comment(snap.pr_number, c.id, &body) {
-                        Ok(()) => Some("updated"),
-                        Err(e) => {
-                            if !json {
-                                println!(
-                                    "{} Could not update nav comment on {} {}{}: {}",
-                                    style("Warning:").yellow(),
-                                    provider.pr_label(),
-                                    number_prefix,
-                                    snap.pr_number,
-                                    e
-                                );
-                            }
-                            Some("error")
-                        }
-                    },
-                    None => match provider.create_pr_comment(snap.pr_number, &body) {
-                        Ok(()) => Some("created"),
-                        Err(e) => {
-                            if !json {
-                                println!(
-                                    "{} Could not create nav comment on {} {}{}: {}",
-                                    style("Warning:").yellow(),
-                                    provider.pr_label(),
-                                    number_prefix,
-                                    snap.pr_number,
-                                    e
-                                );
-                            }
-                            Some("error")
-                        }
-                    },
-                }
-            }
-            stack_nav::NavAction::Delete => match existing {
-                Some(c) => match provider.delete_pr_comment(snap.pr_number, c.id) {
-                    Ok(()) => Some("deleted"),
-                    Err(e) => {
-                        if !json {
-                            println!(
-                                "{} Could not delete nav comment on {} {}{}: {}",
-                                style("Warning:").yellow(),
-                                provider.pr_label(),
-                                number_prefix,
-                                snap.pr_number,
-                                e
-                            );
-                        }
-                        Some("error")
-                    }
-                },
-                None => None,
-            },
-        };
-
-        if let Some(action) = action_result {
-            if json {
-                if let Some(entry_json) = json_entries.get_mut(snap.json_index) {
-                    entry_json.nav_comment_action = Some(action.to_string());
                 }
             }
         }
-    }
+    } // end if until.is_none()
 
     // Save updated config
     config.save(git_dir)?;

--- a/crates/gg-core/src/config.rs
+++ b/crates/gg-core/src/config.rs
@@ -74,6 +74,11 @@ pub struct Defaults {
     /// Update PR/MR descriptions on re-sync (default: true)
     #[serde(default = "default_true")]
     pub sync_update_descriptions: bool,
+
+    /// Post and maintain a managed navigation comment on each PR/MR in a
+    /// multi-entry stack. Default: false (opt-in).
+    #[serde(default)]
+    pub stack_nav_comments: bool,
 }
 
 fn default_sync_behind_threshold() -> usize {
@@ -119,6 +124,7 @@ impl Default for Defaults {
             unstaged_action: UnstagedAction::Ask,
             sync_draft: false,
             sync_update_descriptions: true,
+            stack_nav_comments: false,
         }
     }
 }
@@ -365,6 +371,11 @@ impl Config {
     /// Get whether to update PR/MR descriptions on re-sync (default: true)
     pub fn get_sync_update_descriptions(&self) -> bool {
         self.defaults.sync_update_descriptions
+    }
+
+    /// Whether to post and maintain stack-navigation comments on PRs/MRs.
+    pub fn get_stack_nav_comments(&self) -> bool {
+        self.defaults.stack_nav_comments
     }
 
     // ============ Global config loading ============
@@ -828,6 +839,34 @@ mod tests {
     fn test_sync_update_descriptions_deserializes_to_default_when_missing() {
         let config: Config = serde_json::from_str(r#"{"defaults":{"base":"main"}}"#).unwrap();
         assert!(config.get_sync_update_descriptions());
+    }
+
+    // ============ Tests for stack_nav_comments ============
+
+    #[test]
+    fn test_stack_nav_comments_defaults_to_false() {
+        let defaults = Defaults::default();
+        assert!(
+            !defaults.stack_nav_comments,
+            "should default to false (opt-in)"
+        );
+    }
+
+    #[test]
+    fn test_stack_nav_comments_round_trips_through_json() {
+        let mut config = Config::default();
+        config.defaults.stack_nav_comments = true;
+        let json = serde_json::to_string(&config).unwrap();
+        let parsed: Config = serde_json::from_str(&json).unwrap();
+        assert!(parsed.defaults.stack_nav_comments);
+    }
+
+    #[test]
+    fn test_stack_nav_comments_missing_field_loads_as_false() {
+        // Existing configs without the field must continue to deserialize.
+        let json = r#"{"defaults":{}}"#;
+        let parsed: Config = serde_json::from_str(json).unwrap();
+        assert!(!parsed.defaults.stack_nav_comments);
     }
 
     // ============ Tests for global config loading ============

--- a/crates/gg-core/src/gh.rs
+++ b/crates/gg-core/src/gh.rs
@@ -525,33 +525,49 @@ pub struct IssueComment {
 
 /// List all comments on a PR (issue comments, i.e. Conversation-tab comments).
 ///
-/// Paginates across 100-per-page responses until exhausted.
+/// Paginates manually (100 per page) because `gh api --paginate` without
+/// `--slurp` concatenates raw JSON arrays, which is not valid JSON — parsing
+/// would fail as soon as a PR has more than one page of comments. We iterate
+/// pages until an empty array comes back.
 pub fn list_issue_comments(pr_number: u64) -> Result<Vec<IssueComment>> {
-    let endpoint = format!(
-        "repos/{{owner}}/{{repo}}/issues/{}/comments?per_page=100",
-        pr_number
-    );
-    let output = Command::new("gh")
-        .args(["api", "--paginate", &endpoint])
-        .output()?;
+    let mut all = Vec::new();
+    let mut page = 1u32;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(GgError::Other(format!(
-            "Failed to list comments for PR #{}: {}",
-            pr_number, stderr
-        )));
+    loop {
+        let endpoint = format!(
+            "repos/{{owner}}/{{repo}}/issues/{}/comments?per_page=100&page={}",
+            pr_number, page
+        );
+        let output = Command::new("gh").args(["api", &endpoint]).output()?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(GgError::Other(format!(
+                "Failed to list comments for PR #{} (page {}): {}",
+                pr_number, page, stderr
+            )));
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let page_comments: Vec<IssueComment> = serde_json::from_str(&stdout).map_err(|e| {
+            GgError::Other(format!(
+                "Failed to parse comments JSON for PR #{} (page {}): {}",
+                pr_number, page, e
+            ))
+        })?;
+
+        if page_comments.is_empty() {
+            break;
+        }
+        let full_page = page_comments.len() == 100;
+        all.extend(page_comments);
+        if !full_page {
+            break;
+        }
+        page += 1;
     }
 
-    // With --paginate, gh concatenates JSON arrays. Parse as one Vec.
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let comments: Vec<IssueComment> = serde_json::from_str(&stdout).map_err(|e| {
-        GgError::Other(format!(
-            "Failed to parse comments JSON for PR #{}: {}",
-            pr_number, e
-        ))
-    })?;
-    Ok(comments)
+    Ok(all)
 }
 
 /// Post a new comment on a PR.

--- a/crates/gg-core/src/gh.rs
+++ b/crates/gg-core/src/gh.rs
@@ -742,4 +742,25 @@ mod tests {
         let _: fn(u64, &str) -> Result<()> = update_issue_comment;
         let _: fn(u64) -> Result<()> = delete_issue_comment;
     }
+
+    #[test]
+    fn test_issue_comment_deserialization() {
+        let json = r#"{"id": 12345, "body": "This is a comment\n<!-- gg:stack-nav -->"}"#;
+        let comment: IssueComment = serde_json::from_str(json).expect("should deserialize");
+        assert_eq!(comment.id, 12345);
+        assert!(comment.body.contains("<!-- gg:stack-nav -->"));
+    }
+
+    #[test]
+    fn test_issue_comment_list_deserialization() {
+        let json = r#"[
+            {"id": 1, "body": "first"},
+            {"id": 2, "body": "second <!-- gg:stack-nav -->"}
+        ]"#;
+        let comments: Vec<IssueComment> =
+            serde_json::from_str(json).expect("should deserialize list");
+        assert_eq!(comments.len(), 2);
+        assert_eq!(comments[0].id, 1);
+        assert_eq!(comments[1].body, "second <!-- gg:stack-nav -->");
+    }
 }

--- a/crates/gg-core/src/gh.rs
+++ b/crates/gg-core/src/gh.rs
@@ -516,6 +516,109 @@ pub fn list_prs_for_branch(branch: &str) -> Result<Vec<u64>> {
     Ok(prs)
 }
 
+/// A GitHub issue comment (which includes PR comments on the Conversation tab).
+#[derive(Debug, Clone, Deserialize)]
+pub struct IssueComment {
+    pub id: u64,
+    pub body: String,
+}
+
+/// List all comments on a PR (issue comments, i.e. Conversation-tab comments).
+///
+/// Paginates across 100-per-page responses until exhausted.
+pub fn list_issue_comments(pr_number: u64) -> Result<Vec<IssueComment>> {
+    let endpoint = format!(
+        "repos/{{owner}}/{{repo}}/issues/{}/comments?per_page=100",
+        pr_number
+    );
+    let output = Command::new("gh")
+        .args(["api", "--paginate", &endpoint])
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(GgError::Other(format!(
+            "Failed to list comments for PR #{}: {}",
+            pr_number, stderr
+        )));
+    }
+
+    // With --paginate, gh concatenates JSON arrays. Parse as one Vec.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let comments: Vec<IssueComment> = serde_json::from_str(&stdout).map_err(|e| {
+        GgError::Other(format!(
+            "Failed to parse comments JSON for PR #{}: {}",
+            pr_number, e
+        ))
+    })?;
+    Ok(comments)
+}
+
+/// Post a new comment on a PR.
+pub fn create_issue_comment(pr_number: u64, body: &str) -> Result<()> {
+    let endpoint = format!("repos/{{owner}}/{{repo}}/issues/{}/comments", pr_number);
+    let output = Command::new("gh")
+        .args([
+            "api",
+            "-X",
+            "POST",
+            &endpoint,
+            "-f",
+            &format!("body={}", body),
+        ])
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(GgError::Other(format!(
+            "Failed to create comment on PR #{}: {}",
+            pr_number, stderr
+        )));
+    }
+    Ok(())
+}
+
+/// Edit an existing PR comment by its comment id.
+pub fn update_issue_comment(comment_id: u64, body: &str) -> Result<()> {
+    let endpoint = format!("repos/{{owner}}/{{repo}}/issues/comments/{}", comment_id);
+    let output = Command::new("gh")
+        .args([
+            "api",
+            "-X",
+            "PATCH",
+            &endpoint,
+            "-f",
+            &format!("body={}", body),
+        ])
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(GgError::Other(format!(
+            "Failed to update comment {}: {}",
+            comment_id, stderr
+        )));
+    }
+    Ok(())
+}
+
+/// Delete a PR comment by its comment id.
+pub fn delete_issue_comment(comment_id: u64) -> Result<()> {
+    let endpoint = format!("repos/{{owner}}/{{repo}}/issues/comments/{}", comment_id);
+    let output = Command::new("gh")
+        .args(["api", "-X", "DELETE", &endpoint])
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(GgError::Other(format!(
+            "Failed to delete comment {}: {}",
+            comment_id, stderr
+        )));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -612,5 +715,15 @@ mod tests {
         let cloned = result.clone();
         assert_eq!(cloned.number, 123);
         assert_eq!(cloned.url, "https://github.com/test/repo/pull/123");
+    }
+
+    #[test]
+    fn test_comment_helpers_exist() {
+        // Compile-only test; ensures the new functions are wired up.
+        // Real invocations require a live gh CLI and are tested manually / in CI.
+        let _: fn(u64) -> Result<Vec<IssueComment>> = list_issue_comments;
+        let _: fn(u64, &str) -> Result<()> = create_issue_comment;
+        let _: fn(u64, &str) -> Result<()> = update_issue_comment;
+        let _: fn(u64) -> Result<()> = delete_issue_comment;
     }
 }

--- a/crates/gg-core/src/glab.rs
+++ b/crates/gg-core/src/glab.rs
@@ -1514,4 +1514,24 @@ mod tests {
         let _: fn(u64, u64, &str) -> Result<()> = update_mr_note;
         let _: fn(u64, u64) -> Result<()> = delete_mr_note;
     }
+
+    #[test]
+    fn test_mr_note_deserialization() {
+        let json = r#"{"id": 67890, "body": "A note\n<!-- gg:stack-nav -->"}"#;
+        let note: MrNote = serde_json::from_str(json).expect("should deserialize");
+        assert_eq!(note.id, 67890);
+        assert!(note.body.contains("<!-- gg:stack-nav -->"));
+    }
+
+    #[test]
+    fn test_mr_note_list_deserialization() {
+        let json = r#"[
+            {"id": 1, "body": "first note"},
+            {"id": 2, "body": "nav <!-- gg:stack-nav -->"}
+        ]"#;
+        let notes: Vec<MrNote> = serde_json::from_str(json).expect("should deserialize list");
+        assert_eq!(notes.len(), 2);
+        assert_eq!(notes[0].id, 1);
+        assert_eq!(notes[1].body, "nav <!-- gg:stack-nav -->");
+    }
 }

--- a/crates/gg-core/src/glab.rs
+++ b/crates/gg-core/src/glab.rs
@@ -906,15 +906,19 @@ fn glab_project_prefix() -> &'static str {
 /// List all notes on an MR.
 ///
 /// Note IDs are needed to update or delete individual notes.
+/// List all notes on an MR.
+///
+/// Note IDs are needed to update or delete individual notes.
+/// Caps at 100 notes (per_page=100); MRs with more notes than that would
+/// need pagination handling, but this is extremely rare and the managed
+/// nav comment is typically visible among the most recent notes.
 pub fn list_mr_notes(mr_iid: u64) -> Result<Vec<MrNote>> {
     let endpoint = format!(
         "projects/{}/merge_requests/{}/notes?per_page=100",
         glab_project_prefix(),
         mr_iid
     );
-    let output = Command::new("glab")
-        .args(["api", "--paginate", &endpoint])
-        .output()?;
+    let output = Command::new("glab").args(["api", &endpoint]).output()?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);

--- a/crates/gg-core/src/glab.rs
+++ b/crates/gg-core/src/glab.rs
@@ -887,6 +887,132 @@ pub fn get_merge_train_status(mr_number: u64, target_branch: &str) -> Result<Mer
     })
 }
 
+/// A GitLab MR note (a discussion entry on the merge request).
+#[derive(Debug, Clone, Deserialize)]
+pub struct MrNote {
+    pub id: u64,
+    pub body: String,
+}
+
+/// Get the project identifier prefix for `glab api` calls.
+///
+/// `glab api` expands `:id` to the numeric project ID of the current repo,
+/// resolved from the git remote.  This matches the pattern used throughout
+/// this file (e.g. `projects/:id/merge_requests/…`).
+fn glab_project_prefix() -> &'static str {
+    ":id"
+}
+
+/// List all notes on an MR.
+///
+/// Note IDs are needed to update or delete individual notes.
+pub fn list_mr_notes(mr_iid: u64) -> Result<Vec<MrNote>> {
+    let endpoint = format!(
+        "projects/{}/merge_requests/{}/notes?per_page=100",
+        glab_project_prefix(),
+        mr_iid
+    );
+    let output = Command::new("glab")
+        .args(["api", "--paginate", &endpoint])
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(GgError::GlabError(format!(
+            "Failed to list notes for MR !{}: {}",
+            mr_iid, stderr
+        )));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let notes: Vec<MrNote> = serde_json::from_str(&stdout).map_err(|e| {
+        GgError::GlabError(format!(
+            "Failed to parse notes JSON for MR !{}: {}",
+            mr_iid, e
+        ))
+    })?;
+    Ok(notes)
+}
+
+/// Create a new note on an MR.
+pub fn create_mr_note(mr_iid: u64, body: &str) -> Result<()> {
+    let endpoint = format!(
+        "projects/{}/merge_requests/{}/notes",
+        glab_project_prefix(),
+        mr_iid
+    );
+    let output = Command::new("glab")
+        .args([
+            "api",
+            "-X",
+            "POST",
+            &endpoint,
+            "-f",
+            &format!("body={}", body),
+        ])
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(GgError::GlabError(format!(
+            "Failed to create note on MR !{}: {}",
+            mr_iid, stderr
+        )));
+    }
+    Ok(())
+}
+
+/// Update an existing note on an MR.
+pub fn update_mr_note(mr_iid: u64, note_id: u64, body: &str) -> Result<()> {
+    let endpoint = format!(
+        "projects/{}/merge_requests/{}/notes/{}",
+        glab_project_prefix(),
+        mr_iid,
+        note_id
+    );
+    let output = Command::new("glab")
+        .args([
+            "api",
+            "-X",
+            "PUT",
+            &endpoint,
+            "-f",
+            &format!("body={}", body),
+        ])
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(GgError::GlabError(format!(
+            "Failed to update note {} on MR !{}: {}",
+            note_id, mr_iid, stderr
+        )));
+    }
+    Ok(())
+}
+
+/// Delete a note from an MR.
+pub fn delete_mr_note(mr_iid: u64, note_id: u64) -> Result<()> {
+    let endpoint = format!(
+        "projects/{}/merge_requests/{}/notes/{}",
+        glab_project_prefix(),
+        mr_iid,
+        note_id
+    );
+    let output = Command::new("glab")
+        .args(["api", "-X", "DELETE", &endpoint])
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(GgError::GlabError(format!(
+            "Failed to delete note {} on MR !{}: {}",
+            note_id, mr_iid, stderr
+        )));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1361,5 +1487,14 @@ mod tests {
         let json = r#"{}"#;
         let parsed: GlabMrBodyJson = serde_json::from_str(json).unwrap();
         assert_eq!(parsed.description, None);
+    }
+
+    #[test]
+    fn test_note_helpers_exist() {
+        // Compile-only; real API calls tested manually.
+        let _: fn(u64) -> Result<Vec<MrNote>> = list_mr_notes;
+        let _: fn(u64, &str) -> Result<()> = create_mr_note;
+        let _: fn(u64, u64, &str) -> Result<()> = update_mr_note;
+        let _: fn(u64, u64) -> Result<()> = delete_mr_note;
     }
 }

--- a/crates/gg-core/src/glab.rs
+++ b/crates/gg-core/src/glab.rs
@@ -905,37 +905,50 @@ fn glab_project_prefix() -> &'static str {
 
 /// List all notes on an MR.
 ///
-/// Note IDs are needed to update or delete individual notes.
-/// List all notes on an MR.
-///
-/// Note IDs are needed to update or delete individual notes.
-/// Caps at 100 notes (per_page=100); MRs with more notes than that would
-/// need pagination handling, but this is extremely rare and the managed
-/// nav comment is typically visible among the most recent notes.
+/// Note IDs are needed to update or delete individual notes. Paginates
+/// manually (100 per page) until a short page is returned, so MRs with
+/// many notes still surface the managed nav note reliably.
 pub fn list_mr_notes(mr_iid: u64) -> Result<Vec<MrNote>> {
-    let endpoint = format!(
-        "projects/{}/merge_requests/{}/notes?per_page=100",
-        glab_project_prefix(),
-        mr_iid
-    );
-    let output = Command::new("glab").args(["api", &endpoint]).output()?;
+    let mut all = Vec::new();
+    let mut page = 1u32;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(GgError::GlabError(format!(
-            "Failed to list notes for MR !{}: {}",
-            mr_iid, stderr
-        )));
+    loop {
+        let endpoint = format!(
+            "projects/{}/merge_requests/{}/notes?per_page=100&page={}",
+            glab_project_prefix(),
+            mr_iid,
+            page
+        );
+        let output = Command::new("glab").args(["api", &endpoint]).output()?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(GgError::GlabError(format!(
+                "Failed to list notes for MR !{} (page {}): {}",
+                mr_iid, page, stderr
+            )));
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let page_notes: Vec<MrNote> = serde_json::from_str(&stdout).map_err(|e| {
+            GgError::GlabError(format!(
+                "Failed to parse notes JSON for MR !{} (page {}): {}",
+                mr_iid, page, e
+            ))
+        })?;
+
+        if page_notes.is_empty() {
+            break;
+        }
+        let full_page = page_notes.len() == 100;
+        all.extend(page_notes);
+        if !full_page {
+            break;
+        }
+        page += 1;
     }
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let notes: Vec<MrNote> = serde_json::from_str(&stdout).map_err(|e| {
-        GgError::GlabError(format!(
-            "Failed to parse notes JSON for MR !{}: {}",
-            mr_iid, e
-        ))
-    })?;
-    Ok(notes)
+    Ok(all)
 }
 
 /// Create a new note on an MR.

--- a/crates/gg-core/src/lib.rs
+++ b/crates/gg-core/src/lib.rs
@@ -14,4 +14,5 @@ pub mod managed_body;
 pub mod output;
 pub mod provider;
 pub mod stack;
+pub mod stack_nav;
 pub mod template;

--- a/crates/gg-core/src/output.rs
+++ b/crates/gg-core/src/output.rs
@@ -131,6 +131,11 @@ pub struct SyncEntryResultJson {
     pub draft: bool,
     pub pushed: bool,
     pub error: Option<String>,
+    /// Optional: action taken on the managed nav comment for this entry's PR.
+    /// One of "created", "updated", "unchanged", "deleted", "skipped", "error".
+    /// Omitted when the feature is disabled and no cleanup was required.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nav_comment_action: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -281,6 +286,49 @@ mod tests {
             value["lint"]["results"][0]["commands"][0]["output"],
             "error: warning denied"
         );
+    }
+
+    #[test]
+    fn test_sync_entry_nav_comment_action_omitted_when_none() {
+        let entry = SyncEntryResultJson {
+            position: 1,
+            sha: "abc".to_string(),
+            title: "t".to_string(),
+            gg_id: "c-1234567".to_string(),
+            branch: "b".to_string(),
+            action: "created".to_string(),
+            pr_number: Some(1),
+            pr_url: None,
+            draft: false,
+            pushed: true,
+            error: None,
+            nav_comment_action: None,
+        };
+        let json = serde_json::to_value(&entry).unwrap();
+        assert!(
+            json.get("nav_comment_action").is_none(),
+            "field should be omitted when None"
+        );
+    }
+
+    #[test]
+    fn test_sync_entry_nav_comment_action_serializes_when_some() {
+        let entry = SyncEntryResultJson {
+            position: 1,
+            sha: "abc".to_string(),
+            title: "t".to_string(),
+            gg_id: "c-1234567".to_string(),
+            branch: "b".to_string(),
+            action: "created".to_string(),
+            pr_number: Some(1),
+            pr_url: None,
+            draft: false,
+            pushed: true,
+            error: None,
+            nav_comment_action: Some("created".to_string()),
+        };
+        let json = serde_json::to_value(&entry).unwrap();
+        assert_eq!(json["nav_comment_action"], "created");
     }
 }
 

--- a/crates/gg-core/src/output.rs
+++ b/crates/gg-core/src/output.rs
@@ -132,7 +132,7 @@ pub struct SyncEntryResultJson {
     pub pushed: bool,
     pub error: Option<String>,
     /// Optional: action taken on the managed nav comment for this entry's PR.
-    /// One of "created", "updated", "unchanged", "deleted", "skipped", "error".
+    /// One of "created", "updated", "unchanged", "deleted", or "error".
     /// Omitted when the feature is disabled and no cleanup was required.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nav_comment_action: Option<String>,

--- a/crates/gg-core/src/provider.rs
+++ b/crates/gg-core/src/provider.rs
@@ -9,6 +9,7 @@ use crate::error::{GgError, Result};
 use crate::gh::{self, CiStatus as GhCiStatus, PrState as GhPrState};
 use crate::git;
 use crate::glab::{self, AutoMergeResult, CiStatus as GlabCiStatus, MrState as GlabMrState};
+use crate::stack_nav;
 
 pub use crate::glab::FailedJob;
 
@@ -235,20 +236,16 @@ impl Provider {
         }
     }
 
-    /// Find the first comment on a PR/MR whose body contains `marker`.
+    /// Find the first comment on a PR/MR that is a git-gud managed nav comment.
     ///
     /// Returns `Ok(None)` if no such comment exists.
-    pub fn find_managed_comment(
-        &self,
-        pr_number: u64,
-        marker: &str,
-    ) -> Result<Option<ManagedComment>> {
+    pub fn find_managed_comment(&self, pr_number: u64) -> Result<Option<ManagedComment>> {
         match self {
             Provider::GitHub => {
                 let comments = gh::list_issue_comments(pr_number)?;
                 Ok(comments
                     .into_iter()
-                    .find(|c| c.body.contains(marker))
+                    .find(|c| stack_nav::is_managed_comment(&c.body))
                     .map(|c| ManagedComment {
                         id: c.id,
                         body: c.body,
@@ -258,7 +255,7 @@ impl Provider {
                 let notes = glab::list_mr_notes(pr_number)?;
                 Ok(notes
                     .into_iter()
-                    .find(|n| n.body.contains(marker))
+                    .find(|n| stack_nav::is_managed_comment(&n.body))
                     .map(|n| ManagedComment {
                         id: n.id,
                         body: n.body,

--- a/crates/gg-core/src/provider.rs
+++ b/crates/gg-core/src/provider.rs
@@ -74,6 +74,13 @@ pub struct PrCreationResult {
     pub url: String,
 }
 
+/// A PR/MR comment that git-gud manages (identified by marker).
+#[derive(Debug, Clone)]
+pub struct ManagedComment {
+    pub id: u64,
+    pub body: String,
+}
+
 impl Provider {
     /// Detect provider from config or repository URL
     ///
@@ -225,6 +232,65 @@ impl Provider {
         match self {
             Provider::GitHub => gh::update_pr_description(number, description),
             Provider::GitLab => glab::update_mr_description(number, description),
+        }
+    }
+
+    /// Find the first comment on a PR/MR whose body contains `marker`.
+    ///
+    /// Returns `Ok(None)` if no such comment exists.
+    pub fn find_managed_comment(
+        &self,
+        pr_number: u64,
+        marker: &str,
+    ) -> Result<Option<ManagedComment>> {
+        match self {
+            Provider::GitHub => {
+                let comments = gh::list_issue_comments(pr_number)?;
+                Ok(comments
+                    .into_iter()
+                    .find(|c| c.body.contains(marker))
+                    .map(|c| ManagedComment {
+                        id: c.id,
+                        body: c.body,
+                    }))
+            }
+            Provider::GitLab => {
+                let notes = glab::list_mr_notes(pr_number)?;
+                Ok(notes
+                    .into_iter()
+                    .find(|n| n.body.contains(marker))
+                    .map(|n| ManagedComment {
+                        id: n.id,
+                        body: n.body,
+                    }))
+            }
+        }
+    }
+
+    /// Create a comment on a PR/MR.
+    pub fn create_pr_comment(&self, pr_number: u64, body: &str) -> Result<()> {
+        match self {
+            Provider::GitHub => gh::create_issue_comment(pr_number, body),
+            Provider::GitLab => glab::create_mr_note(pr_number, body),
+        }
+    }
+
+    /// Update an existing comment by its id.
+    ///
+    /// `pr_number` is required for GitLab (notes are per-MR); GitHub ignores it
+    /// because issue-comment endpoints address comments by id alone.
+    pub fn update_pr_comment(&self, pr_number: u64, comment_id: u64, body: &str) -> Result<()> {
+        match self {
+            Provider::GitHub => gh::update_issue_comment(comment_id, body),
+            Provider::GitLab => glab::update_mr_note(pr_number, comment_id, body),
+        }
+    }
+
+    /// Delete a comment by its id.
+    pub fn delete_pr_comment(&self, pr_number: u64, comment_id: u64) -> Result<()> {
+        match self {
+            Provider::GitHub => gh::delete_issue_comment(comment_id),
+            Provider::GitLab => glab::delete_mr_note(pr_number, comment_id),
         }
     }
 
@@ -615,5 +681,15 @@ mod tests {
     fn test_check_auth_with_network_fallback_passes_through_ok() {
         let result = check_auth_with_network_fallback(Ok(()));
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_managed_comment_construction() {
+        let comment = ManagedComment {
+            id: 99,
+            body: "hello\n<!-- gg:stack-nav -->".to_string(),
+        };
+        assert_eq!(comment.id, 99);
+        assert!(comment.body.contains("<!-- gg:stack-nav -->"));
     }
 }

--- a/crates/gg-core/src/stack_nav.rs
+++ b/crates/gg-core/src/stack_nav.rs
@@ -49,7 +49,6 @@ pub fn render(stack_name: &str, entries: &[StackNavEntry], number_prefix: &str) 
 
 /// The per-entry PR state that matters for nav-comment reconciliation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(dead_code)]
 pub(crate) enum PrEntryState {
     Open,
     Draft,
@@ -83,7 +82,6 @@ pub(crate) enum NavAction {
 /// - Closed/merged PRs: always skip.
 /// - Setting off OR single-entry stack: delete if a comment exists, else skip.
 /// - Otherwise: upsert.
-#[allow(dead_code)]
 pub(crate) fn decide_action(input: NavDecisionInput) -> NavAction {
     // Historical PRs are never touched.
     if matches!(input.pr_state, PrEntryState::Merged | PrEntryState::Closed) {

--- a/crates/gg-core/src/stack_nav.rs
+++ b/crates/gg-core/src/stack_nav.rs
@@ -5,7 +5,7 @@
 
 /// Hidden HTML comment used to identify git-gud-managed nav comments.
 /// Present at the end of every comment body rendered by `render`.
-pub const MARKER: &str = "<!-- gg:stack-nav -->";
+pub(crate) const MARKER: &str = "<!-- gg:stack-nav -->";
 
 /// A single entry in the rendered navigation list.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -25,19 +25,24 @@ pub struct StackNavEntry {
 /// The caller is responsible for deciding whether to render at all
 /// (single-entry stacks should skip this function).
 pub fn render(stack_name: &str, entries: &[StackNavEntry], number_prefix: &str) -> String {
+    use std::fmt::Write as _;
+
     let mut out = String::new();
-    out.push_str(&format!(
-        "This change is part of the `{}` stack:\n\n",
-        stack_name
-    ));
+    writeln!(out, "This change is part of the `{}` stack:", stack_name).unwrap();
+    writeln!(out).unwrap();
     for entry in entries {
         if entry.is_current {
-            out.push_str(&format!("- 👉 {}{}\n", number_prefix, entry.pr_number));
+            writeln!(out, "- 👉 {}{}", number_prefix, entry.pr_number).unwrap();
         } else {
-            out.push_str(&format!("- {}{}\n", number_prefix, entry.pr_number));
+            writeln!(out, "- {}{}", number_prefix, entry.pr_number).unwrap();
         }
     }
-    out.push_str("\n<sub>Managed by [git-gud](https://github.com/mrmans0n/git-gud).</sub>\n");
+    writeln!(out).unwrap();
+    writeln!(
+        out,
+        "<sub>Managed by [git-gud](https://github.com/mrmans0n/git-gud).</sub>"
+    )
+    .unwrap();
     out.push_str(MARKER);
     out
 }

--- a/crates/gg-core/src/stack_nav.rs
+++ b/crates/gg-core/src/stack_nav.rs
@@ -367,4 +367,102 @@ mod tests {
         });
         assert_eq!(decision, NavAction::Upsert);
     }
+
+    // --- Pipeline tests: snapshot → decision → rendered body ---
+
+    #[test]
+    fn test_full_pipeline_three_entries_setting_on() {
+        // Simulate the reconcile pass for a 3-entry stack with setting on.
+        let stack_name = "my-stack";
+        let entries: Vec<(u64, PrEntryState)> = vec![
+            (42, PrEntryState::Open),
+            (43, PrEntryState::Open),
+            (44, PrEntryState::Draft), // draft treated as open
+        ];
+
+        for (current_idx, _) in entries.iter().enumerate() {
+            let decision = decide_action(NavDecisionInput {
+                setting_enabled: true,
+                stack_entry_count: entries.len(),
+                pr_state: entries[current_idx].1,
+                has_existing_comment: false,
+            });
+            assert_eq!(
+                decision,
+                NavAction::Upsert,
+                "entry {} should upsert",
+                current_idx
+            );
+
+            let nav_entries: Vec<StackNavEntry> = entries
+                .iter()
+                .enumerate()
+                .map(|(j, (num, _))| StackNavEntry {
+                    pr_number: *num,
+                    is_current: j == current_idx,
+                })
+                .collect();
+            let body = render(stack_name, &nav_entries, "#");
+
+            // Each PR's body should contain all 3 entries.
+            assert!(
+                body.contains("#42"),
+                "entry {} body missing #42",
+                current_idx
+            );
+            assert!(
+                body.contains("#43"),
+                "entry {} body missing #43",
+                current_idx
+            );
+            assert!(
+                body.contains("#44"),
+                "entry {} body missing #44",
+                current_idx
+            );
+            // Only the current entry should have the marker.
+            let current_num = entries[current_idx].0;
+            assert!(
+                body.contains(&format!("👉 #{}", current_num)),
+                "entry {} should be marked current",
+                current_idx
+            );
+        }
+    }
+
+    #[test]
+    fn test_full_pipeline_setting_off_with_existing_comments() {
+        // When setting is off, every entry with an existing comment should be Delete.
+        let entries: Vec<(u64, PrEntryState, bool)> = vec![
+            (10, PrEntryState::Open, true),   // has comment → Delete
+            (11, PrEntryState::Open, false),  // no comment → Skip
+            (12, PrEntryState::Merged, true), // merged with comment → Skip (merged always skipped)
+        ];
+
+        let expected = [NavAction::Delete, NavAction::Skip, NavAction::Skip];
+
+        for (i, (_, state, has_comment)) in entries.iter().enumerate() {
+            let decision = decide_action(NavDecisionInput {
+                setting_enabled: false,
+                stack_entry_count: entries.len(),
+                pr_state: *state,
+                has_existing_comment: *has_comment,
+            });
+            assert_eq!(decision, expected[i], "entry {} mismatch", i);
+        }
+    }
+
+    #[test]
+    fn test_full_pipeline_partial_failure_should_skip() {
+        // When one entry has no snapshot (failed during sync), the calling code
+        // in sync.rs checks nav_snapshots.iter().all(|s| s.is_some()) before
+        // entering the reconcile pass. Verify the precondition catches this.
+        let snapshots: Vec<Option<(u64, PrEntryState)>> = vec![
+            Some((42, PrEntryState::Open)),
+            None, // entry 2 failed during sync
+            Some((44, PrEntryState::Open)),
+        ];
+        let all_present = snapshots.iter().all(|s| s.is_some());
+        assert!(!all_present, "should detect incomplete snapshot set");
+    }
 }

--- a/crates/gg-core/src/stack_nav.rs
+++ b/crates/gg-core/src/stack_nav.rs
@@ -99,12 +99,16 @@ pub(crate) fn decide_action(input: NavDecisionInput) -> NavAction {
     }
 }
 
-/// Returns true if `body` contains the managed-comment marker.
+/// Returns true if `body` ends with the managed-comment marker.
 ///
 /// Used to identify git-gud-managed nav comments among arbitrary PR comments
 /// when we need to find our own comment to update or delete it.
+///
+/// We require the marker at the end (modulo trailing whitespace) rather than
+/// just `contains()` to avoid false positives when a reviewer quotes the
+/// marker text in a normal discussion comment.
 pub(crate) fn is_managed_comment(body: &str) -> bool {
-    body.contains(MARKER)
+    body.trim_end().ends_with(MARKER)
 }
 
 #[cfg(test)]
@@ -286,6 +290,16 @@ mod tests {
     #[test]
     fn test_is_managed_comment_empty_body() {
         assert!(!is_managed_comment(""));
+    }
+
+    #[test]
+    fn test_is_managed_comment_marker_in_middle_is_false_positive() {
+        // A reviewer quoting the marker in a discussion comment should NOT match.
+        let body = "See the docs — the marker is `<!-- gg:stack-nav -->` at the end.\n\nLGTM!";
+        assert!(
+            !is_managed_comment(body),
+            "marker in the middle of a comment should not match"
+        );
     }
 
     #[test]

--- a/crates/gg-core/src/stack_nav.rs
+++ b/crates/gg-core/src/stack_nav.rs
@@ -1,0 +1,71 @@
+//! Stack navigation comment rendering.
+//!
+//! Renders the body of the managed comment that `gg sync` posts on each
+//! open PR/MR in a multi-entry stack. Pure — no I/O, no provider calls.
+
+/// Hidden HTML comment used to identify git-gud-managed nav comments.
+/// Present at the end of every comment body rendered by `render`.
+pub const MARKER: &str = "<!-- gg:stack-nav -->";
+
+/// A single entry in the rendered navigation list.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StackNavEntry {
+    pub pr_number: u64,
+    pub is_current: bool,
+}
+
+/// Render the body of the managed nav comment.
+///
+/// `entries` must be in bottom-up order (index 0 is the entry adjacent to
+/// the base branch; the last entry is the tip of the stack). Exactly one
+/// entry should have `is_current == true`.
+///
+/// `number_prefix` is `"#"` for GitHub, `"!"` for GitLab.
+///
+/// The caller is responsible for deciding whether to render at all
+/// (single-entry stacks should skip this function).
+pub fn render(stack_name: &str, entries: &[StackNavEntry], number_prefix: &str) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "This change is part of the `{}` stack:\n\n",
+        stack_name
+    ));
+    for entry in entries {
+        if entry.is_current {
+            out.push_str(&format!("- 👉 {}{}\n", number_prefix, entry.pr_number));
+        } else {
+            out.push_str(&format!("- {}{}\n", number_prefix, entry.pr_number));
+        }
+    }
+    out.push_str("\n<sub>Managed by [git-gud](https://github.com/mrmans0n/git-gud).</sub>\n");
+    out.push_str(MARKER);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_render_two_entries_current_first_github() {
+        let entries = vec![
+            StackNavEntry {
+                pr_number: 42,
+                is_current: true,
+            },
+            StackNavEntry {
+                pr_number: 43,
+                is_current: false,
+            },
+        ];
+        let body = render("feat-auth", &entries, "#");
+        assert_eq!(
+            body,
+            "This change is part of the `feat-auth` stack:\n\n\
+             - 👉 #42\n\
+             - #43\n\n\
+             <sub>Managed by [git-gud](https://github.com/mrmans0n/git-gud).</sub>\n\
+             <!-- gg:stack-nav -->"
+        );
+    }
+}

--- a/crates/gg-core/src/stack_nav.rs
+++ b/crates/gg-core/src/stack_nav.rs
@@ -103,7 +103,6 @@ pub(crate) fn decide_action(input: NavDecisionInput) -> NavAction {
 ///
 /// Used to identify git-gud-managed nav comments among arbitrary PR comments
 /// when we need to find our own comment to update or delete it.
-#[allow(dead_code)]
 pub(crate) fn is_managed_comment(body: &str) -> bool {
     body.contains(MARKER)
 }

--- a/crates/gg-core/src/stack_nav.rs
+++ b/crates/gg-core/src/stack_nav.rs
@@ -47,6 +47,15 @@ pub fn render(stack_name: &str, entries: &[StackNavEntry], number_prefix: &str) 
     out
 }
 
+/// Returns true if `body` contains the managed-comment marker.
+///
+/// Used to identify git-gud-managed nav comments among arbitrary PR comments
+/// when we need to find our own comment to update or delete it.
+#[allow(dead_code)]
+pub(crate) fn is_managed_comment(body: &str) -> bool {
+    body.contains(MARKER)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -203,5 +212,28 @@ mod tests {
         ];
         let body = render("s", &entries, "#");
         assert!(body.contains("<sub>Managed by [git-gud]"));
+    }
+
+    #[test]
+    fn test_is_managed_comment_with_marker() {
+        let body = "some text\n<!-- gg:stack-nav -->";
+        assert!(is_managed_comment(body));
+    }
+
+    #[test]
+    fn test_is_managed_comment_without_marker() {
+        let body = "a user comment with no markers";
+        assert!(!is_managed_comment(body));
+    }
+
+    #[test]
+    fn test_is_managed_comment_with_trailing_whitespace_after_marker() {
+        let body = "body\n<!-- gg:stack-nav -->   \n";
+        assert!(is_managed_comment(body));
+    }
+
+    #[test]
+    fn test_is_managed_comment_empty_body() {
+        assert!(!is_managed_comment(""));
     }
 }

--- a/crates/gg-core/src/stack_nav.rs
+++ b/crates/gg-core/src/stack_nav.rs
@@ -73,4 +73,135 @@ mod tests {
              <!-- gg:stack-nav -->"
         );
     }
+
+    #[test]
+    fn test_render_three_entries_current_middle_github() {
+        let entries = vec![
+            StackNavEntry {
+                pr_number: 42,
+                is_current: false,
+            },
+            StackNavEntry {
+                pr_number: 43,
+                is_current: true,
+            },
+            StackNavEntry {
+                pr_number: 44,
+                is_current: false,
+            },
+        ];
+        let body = render("feat-auth", &entries, "#");
+        assert!(body.contains("- #42\n"));
+        assert!(body.contains("- 👉 #43\n"));
+        assert!(body.contains("- #44\n"));
+        assert!(body.ends_with(MARKER));
+    }
+
+    #[test]
+    fn test_render_current_last_preserves_bottom_up_order() {
+        // Bottom-up: base-adjacent first, tip last. Current on tip should be last.
+        let entries = vec![
+            StackNavEntry {
+                pr_number: 10,
+                is_current: false,
+            },
+            StackNavEntry {
+                pr_number: 11,
+                is_current: false,
+            },
+            StackNavEntry {
+                pr_number: 12,
+                is_current: true,
+            },
+        ];
+        let body = render("s", &entries, "#");
+        let idx_10 = body.find("#10").unwrap();
+        let idx_11 = body.find("#11").unwrap();
+        let idx_12 = body.find("#12").unwrap();
+        assert!(idx_10 < idx_11 && idx_11 < idx_12);
+        assert!(body.contains("- 👉 #12\n"));
+    }
+
+    #[test]
+    fn test_render_gitlab_prefix() {
+        let entries = vec![
+            StackNavEntry {
+                pr_number: 1,
+                is_current: true,
+            },
+            StackNavEntry {
+                pr_number: 2,
+                is_current: false,
+            },
+        ];
+        let body = render("s", &entries, "!");
+        assert!(body.contains("- 👉 !1\n"));
+        assert!(body.contains("- !2\n"));
+        assert!(!body.contains('#'));
+    }
+
+    #[test]
+    fn test_render_is_idempotent() {
+        let entries = vec![
+            StackNavEntry {
+                pr_number: 1,
+                is_current: true,
+            },
+            StackNavEntry {
+                pr_number: 2,
+                is_current: false,
+            },
+        ];
+        let a = render("s", &entries, "#");
+        let b = render("s", &entries, "#");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn test_render_includes_stack_name_backticked() {
+        let entries = vec![
+            StackNavEntry {
+                pr_number: 1,
+                is_current: true,
+            },
+            StackNavEntry {
+                pr_number: 2,
+                is_current: false,
+            },
+        ];
+        let body = render("my-stack", &entries, "#");
+        assert!(body.contains("`my-stack`"));
+    }
+
+    #[test]
+    fn test_render_ends_with_marker() {
+        let entries = vec![
+            StackNavEntry {
+                pr_number: 1,
+                is_current: true,
+            },
+            StackNavEntry {
+                pr_number: 2,
+                is_current: false,
+            },
+        ];
+        let body = render("s", &entries, "#");
+        assert!(body.ends_with(MARKER));
+    }
+
+    #[test]
+    fn test_render_includes_attribution_footer() {
+        let entries = vec![
+            StackNavEntry {
+                pr_number: 1,
+                is_current: true,
+            },
+            StackNavEntry {
+                pr_number: 2,
+                is_current: false,
+            },
+        ];
+        let body = render("s", &entries, "#");
+        assert!(body.contains("<sub>Managed by [git-gud]"));
+    }
 }

--- a/crates/gg-core/src/stack_nav.rs
+++ b/crates/gg-core/src/stack_nav.rs
@@ -9,7 +9,7 @@ pub(crate) const MARKER: &str = "<!-- gg:stack-nav -->";
 
 /// A single entry in the rendered navigation list.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct StackNavEntry {
+pub(crate) struct StackNavEntry {
     pub pr_number: u64,
     pub is_current: bool,
 }
@@ -24,7 +24,7 @@ pub struct StackNavEntry {
 ///
 /// The caller is responsible for deciding whether to render at all
 /// (single-entry stacks should skip this function).
-pub fn render(stack_name: &str, entries: &[StackNavEntry], number_prefix: &str) -> String {
+pub(crate) fn render(stack_name: &str, entries: &[StackNavEntry], number_prefix: &str) -> String {
     use std::fmt::Write as _;
 
     let mut out = String::new();

--- a/crates/gg-core/src/stack_nav.rs
+++ b/crates/gg-core/src/stack_nav.rs
@@ -47,6 +47,60 @@ pub fn render(stack_name: &str, entries: &[StackNavEntry], number_prefix: &str) 
     out
 }
 
+/// The per-entry PR state that matters for nav-comment reconciliation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
+pub(crate) enum PrEntryState {
+    Open,
+    Draft,
+    Merged,
+    Closed,
+}
+
+/// Inputs for the per-entry nav-action decision.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct NavDecisionInput {
+    pub setting_enabled: bool,
+    pub stack_entry_count: usize,
+    pub pr_state: PrEntryState,
+    pub has_existing_comment: bool,
+}
+
+/// What to do with the nav comment on a single PR in the stack.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NavAction {
+    /// Do nothing: no comment should exist and none does.
+    Skip,
+    /// Create a new comment, or update the existing one (idempotent upsert).
+    Upsert,
+    /// Delete an existing comment.
+    Delete,
+}
+
+/// Decide what to do with the nav comment on a single PR, based on state.
+///
+/// See the design spec for the full decision table. In short:
+/// - Closed/merged PRs: always skip.
+/// - Setting off OR single-entry stack: delete if a comment exists, else skip.
+/// - Otherwise: upsert.
+#[allow(dead_code)]
+pub(crate) fn decide_action(input: NavDecisionInput) -> NavAction {
+    // Historical PRs are never touched.
+    if matches!(input.pr_state, PrEntryState::Merged | PrEntryState::Closed) {
+        return NavAction::Skip;
+    }
+
+    let should_have_comment = input.setting_enabled && input.stack_entry_count >= 2;
+
+    if should_have_comment {
+        NavAction::Upsert
+    } else if input.has_existing_comment {
+        NavAction::Delete
+    } else {
+        NavAction::Skip
+    }
+}
+
 /// Returns true if `body` contains the managed-comment marker.
 ///
 /// Used to identify git-gud-managed nav comments among arbitrary PR comments
@@ -235,5 +289,85 @@ mod tests {
     #[test]
     fn test_is_managed_comment_empty_body() {
         assert!(!is_managed_comment(""));
+    }
+
+    #[test]
+    fn test_decide_action_reconcile_when_setting_on_and_multi_entry_open() {
+        let decision = decide_action(NavDecisionInput {
+            setting_enabled: true,
+            stack_entry_count: 3,
+            pr_state: PrEntryState::Open,
+            has_existing_comment: false,
+        });
+        assert_eq!(decision, NavAction::Upsert);
+    }
+
+    #[test]
+    fn test_decide_action_cleanup_when_setting_off_and_comment_exists() {
+        let decision = decide_action(NavDecisionInput {
+            setting_enabled: false,
+            stack_entry_count: 3,
+            pr_state: PrEntryState::Open,
+            has_existing_comment: true,
+        });
+        assert_eq!(decision, NavAction::Delete);
+    }
+
+    #[test]
+    fn test_decide_action_skip_when_setting_off_and_no_comment() {
+        let decision = decide_action(NavDecisionInput {
+            setting_enabled: false,
+            stack_entry_count: 3,
+            pr_state: PrEntryState::Open,
+            has_existing_comment: false,
+        });
+        assert_eq!(decision, NavAction::Skip);
+    }
+
+    #[test]
+    fn test_decide_action_cleanup_when_single_entry_and_comment_exists() {
+        let decision = decide_action(NavDecisionInput {
+            setting_enabled: true,
+            stack_entry_count: 1,
+            pr_state: PrEntryState::Open,
+            has_existing_comment: true,
+        });
+        assert_eq!(decision, NavAction::Delete);
+    }
+
+    #[test]
+    fn test_decide_action_skip_when_single_entry_and_no_comment() {
+        let decision = decide_action(NavDecisionInput {
+            setting_enabled: true,
+            stack_entry_count: 1,
+            pr_state: PrEntryState::Open,
+            has_existing_comment: false,
+        });
+        assert_eq!(decision, NavAction::Skip);
+    }
+
+    #[test]
+    fn test_decide_action_skip_when_pr_closed() {
+        // Closed / merged PRs are historical — never touch their comments.
+        for state in [PrEntryState::Merged, PrEntryState::Closed] {
+            let decision = decide_action(NavDecisionInput {
+                setting_enabled: true,
+                stack_entry_count: 3,
+                pr_state: state,
+                has_existing_comment: true,
+            });
+            assert_eq!(decision, NavAction::Skip, "closed/merged must be skipped");
+        }
+    }
+
+    #[test]
+    fn test_decide_action_draft_treated_as_open() {
+        let decision = decide_action(NavDecisionInput {
+            setting_enabled: true,
+            stack_entry_count: 2,
+            pr_state: PrEntryState::Draft,
+            has_existing_comment: false,
+        });
+        assert_eq!(decision, NavAction::Upsert);
     }
 }

--- a/docs/src/commands/setup.md
+++ b/docs/src/commands/setup.md
@@ -48,6 +48,7 @@ Full mode organizes all settings into logical groups:
 | `sync_behind_threshold` | number | 1 | Commits behind origin before warning/rebase |
 | `sync_draft` | bool | false | Create new PRs/MRs as drafts by default |
 | `sync_update_descriptions` | bool | true | Update PR/MR descriptions on re-sync |
+| `stack_nav_comments` | bool | false | Post a managed navigation comment linking all PRs/MRs in the stack |
 
 ### Land
 

--- a/docs/src/commands/sync.md
+++ b/docs/src/commands/sync.md
@@ -89,8 +89,8 @@ Merged or closed PRs are left alone — `gg sync` never modifies comments on
 historical PRs.
 
 When running with `--json`, each entry includes an optional `nav_comment_action`
-field (one of `"created"`, `"updated"`, `"unchanged"`, `"deleted"`, `"skipped"`,
-`"error"`) when a reconcile decision was made.
+field (one of `"created"`, `"updated"`, `"unchanged"`, `"deleted"`, `"error"`)
+when a reconcile decision was made.
 
 Example JSON (shape):
 

--- a/docs/src/commands/sync.md
+++ b/docs/src/commands/sync.md
@@ -73,6 +73,25 @@ Content **inside** the managed block (the generated description) is regenerated 
 
 **Legacy PRs** (created before this feature) have no managed markers. `gg sync` will skip body updates for these PRs and log a warning, to avoid overwriting manual edits.
 
+## Stack navigation comments
+
+If `defaults.stack_nav_comments` is enabled in `.git/gg/config.json`, every
+full `gg sync` (no `--until`) reconciles a managed comment on each PR/MR in
+the stack. The comment shows all entries in the stack in bottom-up order,
+with a 👉 marker on the entry that PR corresponds to — letting reviewers see
+where they are in the chain and click through to siblings.
+
+The comment is identified by a hidden HTML marker (`<!-- gg:stack-nav -->`)
+and never touches comments git-gud didn't create. Disabling the setting and
+re-syncing cleans up any previously-posted comments automatically.
+
+Merged or closed PRs are left alone — `gg sync` never modifies comments on
+historical PRs.
+
+When running with `--json`, each entry includes an optional `nav_comment_action`
+field (one of `"created"`, `"updated"`, `"unchanged"`, `"deleted"`, `"skipped"`,
+`"error"`) when a reconcile decision was made.
+
 Example JSON (shape):
 
 ```json

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -66,6 +66,7 @@ For global config, manually create `~/.config/gg/config.json` with your preferre
 | `sync_behind_threshold` | `number` | Warn/rebase in `gg sync` when base is at least this many commits behind `origin/<base>` (`0` disables check) | `1` |
 | `sync_draft` | `boolean` | Create new PRs/MRs as drafts by default | `false` |
 | `sync_update_descriptions` | `boolean` | Update PR/MR descriptions on re-sync | `true` |
+| `stack_nav_comments` | `boolean` | Post a managed navigation comment on each open PR/MR in a multi-entry stack, listing all entries with a 👉 marker on the current one. When set back to `false`, the next `gg sync` removes any previously-posted managed comments. Skipped for single-entry stacks and when `--until` limits a sync. | `false` |
 | `worktree_base_path` | `string` | Base directory for managed worktrees | Parent of repo |
 | `gitlab.auto_merge_on_land` | `boolean` | Default GitLab auto-merge behavior for `gg land` | `false` |
 

--- a/docs/superpowers/plans/2026-04-15-stack-nav-comment.md
+++ b/docs/superpowers/plans/2026-04-15-stack-nav-comment.md
@@ -1,0 +1,1671 @@
+# Stack Navigation Comment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the stack-navigation comment feature from the spec at [docs/superpowers/specs/2026-04-15-stack-nav-comment-design.md](../specs/2026-04-15-stack-nav-comment-design.md). When the new `stack_nav_comments` setting is enabled, `gg sync` upserts a managed comment on each open PR/MR listing all stack entries with a 👉 marker on the current one; when disabled, it cleans up any such comments it previously created.
+
+**Architecture:** A pure `stack_nav` module renders the comment body. Four new provider methods (`find_managed_comment`, `create_pr_comment`, `update_pr_comment`, `delete_pr_comment`) add the transport layer on top of `gh api` / `glab api`. A second pass at the end of `gg sync` reconciles nav comments using the state accumulated during the first pass (PR numbers + states).
+
+**Tech Stack:** Rust workspace, `git2`, `serde`, `gh` / `glab` CLIs via `std::process::Command`, existing `dialoguer` / `console` / `indicatif` for UX.
+
+---
+
+## File Structure
+
+**Created files:**
+- `crates/gg-core/src/stack_nav.rs` — pure rendering + marker helpers (MARKER const, StackNavEntry, render, is_managed_comment)
+
+**Modified files:**
+- `crates/gg-core/src/lib.rs` — register new `stack_nav` module
+- `crates/gg-core/src/config.rs` — add `stack_nav_comments: bool` to `Defaults`
+- `crates/gg-core/src/gh.rs` — add `list_issue_comments`, `create_issue_comment`, `update_issue_comment`, `delete_issue_comment`
+- `crates/gg-core/src/glab.rs` — add `list_mr_notes`, `create_mr_note`, `update_mr_note`, `delete_mr_note`
+- `crates/gg-core/src/provider.rs` — add `ManagedComment` struct and four new `Provider` methods that dispatch to gh/glab
+- `crates/gg-core/src/output.rs` — add optional `nav_comment_action` field to `SyncEntryResultJson`
+- `crates/gg-core/src/commands/sync.rs` — reconcile nav comments after the main PR loop, populate JSON field
+- `crates/gg-core/src/commands/setup.rs` — add prompt for the new setting under the "Sync" group
+- `docs/src/configuration.md` — document the new setting
+- `docs/src/commands/sync.md` — mention nav-comment behavior
+- `docs/src/commands/setup.md` — document the new prompt
+- `skills/gg/SKILL.md` — add an operating note that `gg sync` may leave a managed comment
+- `skills/gg/reference.md` — document the new JSON field and config setting
+- `README.md` — add to feature list
+
+---
+
+## Task 1: Create `stack_nav` module with render function
+
+**Files:**
+- Create: `crates/gg-core/src/stack_nav.rs`
+- Modify: `crates/gg-core/src/lib.rs`
+
+Pure, I/O-free module. Heavily unit tested. Produces the comment body we will later post to providers.
+
+- [ ] **Step 1.1: Register the new module**
+
+Modify `crates/gg-core/src/lib.rs` — add a `pub mod stack_nav;` line after the other module declarations (alphabetical order: between `provider` and `stack`). Resulting module list:
+
+```rust
+pub mod commands;
+pub mod config;
+pub mod context;
+pub mod error;
+pub mod gh;
+pub mod git;
+pub mod glab;
+pub mod managed_body;
+pub mod output;
+pub mod provider;
+pub mod stack;
+pub mod stack_nav;
+pub mod template;
+```
+
+- [ ] **Step 1.2: Write the first failing test**
+
+Create `crates/gg-core/src/stack_nav.rs` with just the test skeleton:
+
+```rust
+//! Stack navigation comment rendering.
+//!
+//! Renders the body of the managed comment that `gg sync` posts on each
+//! open PR/MR in a multi-entry stack. Pure — no I/O, no provider calls.
+
+/// Hidden HTML comment used to identify git-gud-managed nav comments.
+/// Present at the end of every comment body rendered by `render`.
+pub const MARKER: &str = "<!-- gg:stack-nav -->";
+
+/// A single entry in the rendered navigation list.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StackNavEntry {
+    pub pr_number: u64,
+    pub is_current: bool,
+}
+
+/// Render the body of the managed nav comment.
+///
+/// `entries` must be in bottom-up order (index 0 is the entry adjacent to
+/// the base branch; the last entry is the tip of the stack). Exactly one
+/// entry should have `is_current == true`.
+///
+/// `number_prefix` is `"#"` for GitHub, `"!"` for GitLab.
+///
+/// The caller is responsible for deciding whether to render at all
+/// (single-entry stacks should skip this function).
+pub fn render(stack_name: &str, entries: &[StackNavEntry], number_prefix: &str) -> String {
+    todo!("implemented in next step")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_render_two_entries_current_first_github() {
+        let entries = vec![
+            StackNavEntry { pr_number: 42, is_current: true },
+            StackNavEntry { pr_number: 43, is_current: false },
+        ];
+        let body = render("feat-auth", &entries, "#");
+        assert_eq!(
+            body,
+            "This change is part of the `feat-auth` stack:\n\n\
+             - 👉 #42\n\
+             - #43\n\n\
+             <sub>Managed by [git-gud](https://github.com/mrmans0n/git-gud).</sub>\n\
+             <!-- gg:stack-nav -->"
+        );
+    }
+}
+```
+
+- [ ] **Step 1.3: Run the test, confirm it fails**
+
+Run: `cargo test -p gg-core stack_nav::`
+Expected: test panics with `not yet implemented` from the `todo!()`.
+
+- [ ] **Step 1.4: Implement `render`**
+
+Replace the `todo!()` body of `render`:
+
+```rust
+pub fn render(stack_name: &str, entries: &[StackNavEntry], number_prefix: &str) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "This change is part of the `{}` stack:\n\n",
+        stack_name
+    ));
+    for entry in entries {
+        if entry.is_current {
+            out.push_str(&format!("- 👉 {}{}\n", number_prefix, entry.pr_number));
+        } else {
+            out.push_str(&format!("- {}{}\n", number_prefix, entry.pr_number));
+        }
+    }
+    out.push_str(
+        "\n<sub>Managed by [git-gud](https://github.com/mrmans0n/git-gud).</sub>\n",
+    );
+    out.push_str(MARKER);
+    out
+}
+```
+
+- [ ] **Step 1.5: Run the test, confirm it passes**
+
+Run: `cargo test -p gg-core stack_nav::test_render_two_entries_current_first_github`
+Expected: PASS.
+
+- [ ] **Step 1.6: Commit**
+
+```bash
+git add crates/gg-core/src/stack_nav.rs crates/gg-core/src/lib.rs
+git commit -m "feat(core): add stack_nav render function for nav comments"
+```
+
+---
+
+## Task 2: Add full test coverage for `render`
+
+**Files:**
+- Modify: `crates/gg-core/src/stack_nav.rs`
+
+- [ ] **Step 2.1: Add remaining render tests**
+
+Add the following tests inside the existing `mod tests` block in `crates/gg-core/src/stack_nav.rs`:
+
+```rust
+#[test]
+fn test_render_three_entries_current_middle_github() {
+    let entries = vec![
+        StackNavEntry { pr_number: 42, is_current: false },
+        StackNavEntry { pr_number: 43, is_current: true },
+        StackNavEntry { pr_number: 44, is_current: false },
+    ];
+    let body = render("feat-auth", &entries, "#");
+    assert!(body.contains("- #42\n"));
+    assert!(body.contains("- 👉 #43\n"));
+    assert!(body.contains("- #44\n"));
+    assert!(body.ends_with(MARKER));
+}
+
+#[test]
+fn test_render_current_last_preserves_bottom_up_order() {
+    // Bottom-up: base-adjacent first, tip last. Current on tip should be last.
+    let entries = vec![
+        StackNavEntry { pr_number: 10, is_current: false },
+        StackNavEntry { pr_number: 11, is_current: false },
+        StackNavEntry { pr_number: 12, is_current: true },
+    ];
+    let body = render("s", &entries, "#");
+    let idx_10 = body.find("#10").unwrap();
+    let idx_11 = body.find("#11").unwrap();
+    let idx_12 = body.find("#12").unwrap();
+    assert!(idx_10 < idx_11 && idx_11 < idx_12);
+    assert!(body.contains("- 👉 #12\n"));
+}
+
+#[test]
+fn test_render_gitlab_prefix() {
+    let entries = vec![
+        StackNavEntry { pr_number: 1, is_current: true },
+        StackNavEntry { pr_number: 2, is_current: false },
+    ];
+    let body = render("s", &entries, "!");
+    assert!(body.contains("- 👉 !1\n"));
+    assert!(body.contains("- !2\n"));
+    assert!(!body.contains('#'));
+}
+
+#[test]
+fn test_render_is_idempotent() {
+    let entries = vec![
+        StackNavEntry { pr_number: 1, is_current: true },
+        StackNavEntry { pr_number: 2, is_current: false },
+    ];
+    let a = render("s", &entries, "#");
+    let b = render("s", &entries, "#");
+    assert_eq!(a, b);
+}
+
+#[test]
+fn test_render_includes_stack_name_backticked() {
+    let entries = vec![
+        StackNavEntry { pr_number: 1, is_current: true },
+        StackNavEntry { pr_number: 2, is_current: false },
+    ];
+    let body = render("my-stack", &entries, "#");
+    assert!(body.contains("`my-stack`"));
+}
+
+#[test]
+fn test_render_ends_with_marker() {
+    let entries = vec![
+        StackNavEntry { pr_number: 1, is_current: true },
+        StackNavEntry { pr_number: 2, is_current: false },
+    ];
+    let body = render("s", &entries, "#");
+    assert!(body.ends_with(MARKER));
+}
+
+#[test]
+fn test_render_includes_attribution_footer() {
+    let entries = vec![
+        StackNavEntry { pr_number: 1, is_current: true },
+        StackNavEntry { pr_number: 2, is_current: false },
+    ];
+    let body = render("s", &entries, "#");
+    assert!(body.contains("<sub>Managed by [git-gud]"));
+}
+```
+
+- [ ] **Step 2.2: Run the tests, confirm they all pass**
+
+Run: `cargo test -p gg-core stack_nav::`
+Expected: all 7 render tests PASS.
+
+- [ ] **Step 2.3: Commit**
+
+```bash
+git add crates/gg-core/src/stack_nav.rs
+git commit -m "test(core): add render coverage for stack_nav"
+```
+
+---
+
+## Task 3: Add `is_managed_comment` marker detection
+
+**Files:**
+- Modify: `crates/gg-core/src/stack_nav.rs`
+
+- [ ] **Step 3.1: Add failing test for `is_managed_comment`**
+
+Append to the `mod tests` block in `crates/gg-core/src/stack_nav.rs`:
+
+```rust
+#[test]
+fn test_is_managed_comment_with_marker() {
+    let body = "some text\n<!-- gg:stack-nav -->";
+    assert!(is_managed_comment(body));
+}
+
+#[test]
+fn test_is_managed_comment_without_marker() {
+    let body = "a user comment with no markers";
+    assert!(!is_managed_comment(body));
+}
+
+#[test]
+fn test_is_managed_comment_with_trailing_whitespace_after_marker() {
+    let body = "body\n<!-- gg:stack-nav -->   \n";
+    assert!(is_managed_comment(body));
+}
+
+#[test]
+fn test_is_managed_comment_empty_body() {
+    assert!(!is_managed_comment(""));
+}
+```
+
+- [ ] **Step 3.2: Run tests, confirm compile error (function not yet defined)**
+
+Run: `cargo test -p gg-core stack_nav::is_managed_comment`
+Expected: compile error — `cannot find function is_managed_comment`.
+
+- [ ] **Step 3.3: Implement `is_managed_comment`**
+
+Add above the `#[cfg(test)] mod tests {` block in `crates/gg-core/src/stack_nav.rs`:
+
+```rust
+/// Returns true if `body` contains the managed-comment marker.
+///
+/// Used to identify git-gud-managed nav comments among arbitrary PR comments
+/// when we need to find our own comment to update or delete it.
+pub fn is_managed_comment(body: &str) -> bool {
+    body.contains(MARKER)
+}
+```
+
+- [ ] **Step 3.4: Run tests, confirm all pass**
+
+Run: `cargo test -p gg-core stack_nav::`
+Expected: all stack_nav tests PASS (11 total).
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add crates/gg-core/src/stack_nav.rs
+git commit -m "feat(core): add is_managed_comment marker detection"
+```
+
+---
+
+## Task 4: Add `stack_nav_comments` config field
+
+**Files:**
+- Modify: `crates/gg-core/src/config.rs`
+
+- [ ] **Step 4.1: Write failing test for the new config default**
+
+Look at the end of `crates/gg-core/src/config.rs` for the `#[cfg(test)] mod tests` block. Find `fn test_defaults_default()` or the equivalent test function; if none exists, append a new one. Add this test (place it near the end of the `mod tests { ... }` block in `config.rs`):
+
+```rust
+#[test]
+fn test_stack_nav_comments_defaults_to_false() {
+    let defaults = Defaults::default();
+    assert!(!defaults.stack_nav_comments, "should default to false (opt-in)");
+}
+
+#[test]
+fn test_stack_nav_comments_round_trips_through_json() {
+    let mut config = Config::default();
+    config.defaults.stack_nav_comments = true;
+    let json = serde_json::to_string(&config).unwrap();
+    let parsed: Config = serde_json::from_str(&json).unwrap();
+    assert!(parsed.defaults.stack_nav_comments);
+}
+
+#[test]
+fn test_stack_nav_comments_missing_field_loads_as_false() {
+    // Existing configs without the field must continue to deserialize.
+    let json = r#"{"defaults":{}}"#;
+    let parsed: Config = serde_json::from_str(json).unwrap();
+    assert!(!parsed.defaults.stack_nav_comments);
+}
+```
+
+- [ ] **Step 4.2: Run tests, confirm compile error**
+
+Run: `cargo test -p gg-core config::tests::test_stack_nav_comments_defaults_to_false`
+Expected: compile error — no field `stack_nav_comments` on `Defaults`.
+
+- [ ] **Step 4.3: Add the field and default**
+
+In `crates/gg-core/src/config.rs`:
+
+Add the field to the `Defaults` struct — insert after `pub sync_update_descriptions: bool,` (around line 76):
+
+```rust
+    /// Post and maintain a managed navigation comment on each PR/MR in a
+    /// multi-entry stack. Default: false (opt-in).
+    #[serde(default)]
+    pub stack_nav_comments: bool,
+```
+
+Add the initializer to the `impl Default for Defaults` block — insert after `sync_update_descriptions: true,` (around line 121):
+
+```rust
+            stack_nav_comments: false,
+```
+
+- [ ] **Step 4.4: Add a getter helper**
+
+Still in `crates/gg-core/src/config.rs`, search for existing getters like `get_sync_update_descriptions`. They are defined on `impl Config` using the pattern of falling back through global config. Find that block and add:
+
+```rust
+    /// Whether to post and maintain stack-navigation comments on PRs/MRs.
+    pub fn get_stack_nav_comments(&self) -> bool {
+        self.defaults.stack_nav_comments
+    }
+```
+
+Place this method next to `get_sync_update_descriptions` or similar sync-related getters. If `get_sync_update_descriptions` does anything more complex (e.g., consults a global fallback), match its shape.
+
+- [ ] **Step 4.5: Run tests, confirm they pass**
+
+Run: `cargo test -p gg-core config::tests::test_stack_nav_comments`
+Expected: all 3 new tests PASS.
+
+- [ ] **Step 4.6: Commit**
+
+```bash
+git add crates/gg-core/src/config.rs
+git commit -m "feat(core): add stack_nav_comments config field (default false)"
+```
+
+---
+
+## Task 5: Add GitHub comment helpers in `gh.rs`
+
+**Files:**
+- Modify: `crates/gg-core/src/gh.rs`
+
+GitHub PR comments are "issue comments" in the API (they appear on the Conversation tab). We shell out to `gh api` with explicit endpoints.
+
+- [ ] **Step 5.1: Add failing compile-check test**
+
+Add this to the `#[cfg(test)] mod tests` block at the bottom of `crates/gg-core/src/gh.rs`. If the file has no tests module, create one:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_comment_helpers_exist() {
+        // Compile-only test; ensures the new functions are wired up.
+        // Real invocations require a live gh CLI and are tested manually / in CI.
+        let _: fn(u64) -> Result<Vec<IssueComment>> = list_issue_comments;
+        let _: fn(u64, &str) -> Result<()> = create_issue_comment;
+        let _: fn(u64, &str) -> Result<()> = update_issue_comment;
+        let _: fn(u64) -> Result<()> = delete_issue_comment;
+    }
+}
+```
+
+- [ ] **Step 5.2: Run tests, confirm compile error**
+
+Run: `cargo test -p gg-core gh::tests::test_comment_helpers_exist`
+Expected: compile error — none of the four functions or `IssueComment` exist yet.
+
+- [ ] **Step 5.3: Add the `IssueComment` struct and helpers**
+
+Append to the non-test portion of `crates/gg-core/src/gh.rs` (above the tests module):
+
+```rust
+/// A GitHub issue comment (which includes PR comments on the Conversation tab).
+#[derive(Debug, Clone, Deserialize)]
+pub struct IssueComment {
+    pub id: u64,
+    pub body: String,
+}
+
+/// List all comments on a PR (issue comments, i.e. Conversation-tab comments).
+///
+/// Paginates across 100-per-page responses until exhausted.
+pub fn list_issue_comments(pr_number: u64) -> Result<Vec<IssueComment>> {
+    let endpoint = format!(
+        "repos/{{owner}}/{{repo}}/issues/{}/comments?per_page=100",
+        pr_number
+    );
+    let output = Command::new("gh")
+        .args(["api", "--paginate", &endpoint])
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(GgError::Other(format!(
+            "Failed to list comments for PR #{}: {}",
+            pr_number, stderr
+        )));
+    }
+
+    // With --paginate, gh concatenates JSON arrays. Parse as one Vec.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let comments: Vec<IssueComment> = serde_json::from_str(&stdout).map_err(|e| {
+        GgError::Other(format!(
+            "Failed to parse comments JSON for PR #{}: {}",
+            pr_number, e
+        ))
+    })?;
+    Ok(comments)
+}
+
+/// Post a new comment on a PR.
+pub fn create_issue_comment(pr_number: u64, body: &str) -> Result<()> {
+    let endpoint = format!("repos/{{owner}}/{{repo}}/issues/{}/comments", pr_number);
+    let output = Command::new("gh")
+        .args([
+            "api",
+            "-X",
+            "POST",
+            &endpoint,
+            "-f",
+            &format!("body={}", body),
+        ])
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(GgError::Other(format!(
+            "Failed to create comment on PR #{}: {}",
+            pr_number, stderr
+        )));
+    }
+    Ok(())
+}
+
+/// Edit an existing PR comment by its comment id.
+pub fn update_issue_comment(comment_id: u64, body: &str) -> Result<()> {
+    let endpoint = format!("repos/{{owner}}/{{repo}}/issues/comments/{}", comment_id);
+    let output = Command::new("gh")
+        .args([
+            "api",
+            "-X",
+            "PATCH",
+            &endpoint,
+            "-f",
+            &format!("body={}", body),
+        ])
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(GgError::Other(format!(
+            "Failed to update comment {}: {}",
+            comment_id, stderr
+        )));
+    }
+    Ok(())
+}
+
+/// Delete a PR comment by its comment id.
+pub fn delete_issue_comment(comment_id: u64) -> Result<()> {
+    let endpoint = format!("repos/{{owner}}/{{repo}}/issues/comments/{}", comment_id);
+    let output = Command::new("gh")
+        .args(["api", "-X", "DELETE", &endpoint])
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(GgError::Other(format!(
+            "Failed to delete comment {}: {}",
+            comment_id, stderr
+        )));
+    }
+    Ok(())
+}
+```
+
+> Note: the `{owner}` / `{repo}` placeholders are expanded by `gh api` from the current repo context, identical to the pattern used elsewhere in this file.
+
+Fix the test signatures if the sketch in Step 5.1 used `fn(u64, &str)` for `update_issue_comment` — the real signature is `fn(u64, &str) -> Result<()>` where the first `u64` is the comment id, not the PR number. Update the test:
+
+```rust
+    let _: fn(u64) -> Result<Vec<IssueComment>> = list_issue_comments;
+    let _: fn(u64, &str) -> Result<()> = create_issue_comment;
+    let _: fn(u64, &str) -> Result<()> = update_issue_comment;
+    let _: fn(u64) -> Result<()> = delete_issue_comment;
+```
+
+- [ ] **Step 5.4: Run tests**
+
+Run: `cargo test -p gg-core gh::tests::test_comment_helpers_exist`
+Expected: PASS (compile-only smoke test).
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add crates/gg-core/src/gh.rs
+git commit -m "feat(core): add GitHub issue-comment CRUD helpers for nav comments"
+```
+
+---
+
+## Task 6: Add GitLab note helpers in `glab.rs`
+
+**Files:**
+- Modify: `crates/gg-core/src/glab.rs`
+
+GitLab's equivalent of PR comments is "notes." Shell out to `glab api`.
+
+- [ ] **Step 6.1: Add failing compile-check test**
+
+Append to the existing `#[cfg(test)] mod tests` block in `crates/gg-core/src/glab.rs`:
+
+```rust
+#[test]
+fn test_note_helpers_exist() {
+    // Compile-only; real API calls tested manually.
+    let _: fn(u64) -> Result<Vec<MrNote>> = list_mr_notes;
+    let _: fn(u64, &str) -> Result<()> = create_mr_note;
+    let _: fn(u64, u64, &str) -> Result<()> = update_mr_note;
+    let _: fn(u64, u64) -> Result<()> = delete_mr_note;
+}
+```
+
+- [ ] **Step 6.2: Run tests, confirm compile error**
+
+Run: `cargo test -p gg-core glab::tests::test_note_helpers_exist`
+Expected: compile error — none of those items exist.
+
+- [ ] **Step 6.3: Add the `MrNote` struct and helpers**
+
+Append to the non-test portion of `crates/gg-core/src/glab.rs`:
+
+```rust
+/// A GitLab MR note (a discussion entry on the merge request).
+#[derive(Debug, Clone, Deserialize)]
+pub struct MrNote {
+    pub id: u64,
+    pub body: String,
+}
+
+/// Get the project identifier for `glab api` calls (URL-encoded `owner/repo`).
+///
+/// `glab api` accepts `:fullpath` as a shorthand for the current repo's
+/// `projects/<encoded>` prefix, matching how `glab` resolves the remote.
+fn glab_project_prefix() -> &'static str {
+    // `:fullpath` is a glab-expanded template that resolves to the current repo.
+    // It works anywhere `glab api` accepts a path.
+    ":fullpath"
+}
+
+/// List all notes on an MR.
+///
+/// Note IDs are needed to update or delete individual notes.
+pub fn list_mr_notes(mr_iid: u64) -> Result<Vec<MrNote>> {
+    let endpoint = format!(
+        "projects/{}/merge_requests/{}/notes?per_page=100",
+        glab_project_prefix(),
+        mr_iid
+    );
+    let output = Command::new("glab")
+        .args(["api", "--paginate", &endpoint])
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(GgError::GlabError(format!(
+            "Failed to list notes for MR !{}: {}",
+            mr_iid, stderr
+        )));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let notes: Vec<MrNote> = serde_json::from_str(&stdout).map_err(|e| {
+        GgError::GlabError(format!(
+            "Failed to parse notes JSON for MR !{}: {}",
+            mr_iid, e
+        ))
+    })?;
+    Ok(notes)
+}
+
+/// Create a new note on an MR.
+pub fn create_mr_note(mr_iid: u64, body: &str) -> Result<()> {
+    let endpoint = format!(
+        "projects/{}/merge_requests/{}/notes",
+        glab_project_prefix(),
+        mr_iid
+    );
+    let output = Command::new("glab")
+        .args([
+            "api",
+            "-X",
+            "POST",
+            &endpoint,
+            "-f",
+            &format!("body={}", body),
+        ])
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(GgError::GlabError(format!(
+            "Failed to create note on MR !{}: {}",
+            mr_iid, stderr
+        )));
+    }
+    Ok(())
+}
+
+/// Update an existing note on an MR.
+pub fn update_mr_note(mr_iid: u64, note_id: u64, body: &str) -> Result<()> {
+    let endpoint = format!(
+        "projects/{}/merge_requests/{}/notes/{}",
+        glab_project_prefix(),
+        mr_iid,
+        note_id
+    );
+    let output = Command::new("glab")
+        .args([
+            "api",
+            "-X",
+            "PUT",
+            &endpoint,
+            "-f",
+            &format!("body={}", body),
+        ])
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(GgError::GlabError(format!(
+            "Failed to update note {} on MR !{}: {}",
+            note_id, mr_iid, stderr
+        )));
+    }
+    Ok(())
+}
+
+/// Delete a note from an MR.
+pub fn delete_mr_note(mr_iid: u64, note_id: u64) -> Result<()> {
+    let endpoint = format!(
+        "projects/{}/merge_requests/{}/notes/{}",
+        glab_project_prefix(),
+        mr_iid,
+        note_id
+    );
+    let output = Command::new("glab")
+        .args(["api", "-X", "DELETE", &endpoint])
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(GgError::GlabError(format!(
+            "Failed to delete note {} on MR !{}: {}",
+            note_id, mr_iid, stderr
+        )));
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 6.4: Run tests, confirm they pass**
+
+Run: `cargo test -p gg-core glab::tests::test_note_helpers_exist`
+Expected: PASS.
+
+- [ ] **Step 6.5: Commit**
+
+```bash
+git add crates/gg-core/src/glab.rs
+git commit -m "feat(core): add GitLab MR-note CRUD helpers for nav comments"
+```
+
+---
+
+## Task 7: Expose comment operations through the `Provider` abstraction
+
+**Files:**
+- Modify: `crates/gg-core/src/provider.rs`
+
+Add a `ManagedComment` struct and four methods on `Provider` that dispatch to the gh/glab helpers. This is the unified surface callers (sync.rs) will use.
+
+- [ ] **Step 7.1: Write failing unit tests**
+
+Add the following tests to the `#[cfg(test)] mod tests` block at the bottom of `crates/gg-core/src/provider.rs` (after the existing tests):
+
+```rust
+#[test]
+fn test_managed_comment_construction() {
+    let comment = ManagedComment {
+        id: 99,
+        body: "hello\n<!-- gg:stack-nav -->".to_string(),
+    };
+    assert_eq!(comment.id, 99);
+    assert!(comment.body.contains("<!-- gg:stack-nav -->"));
+}
+```
+
+- [ ] **Step 7.2: Run the test, confirm compile error**
+
+Run: `cargo test -p gg-core provider::tests::test_managed_comment_construction`
+Expected: compile error — `ManagedComment` does not exist.
+
+- [ ] **Step 7.3: Add `ManagedComment` and the four methods**
+
+In `crates/gg-core/src/provider.rs`, find the `PrCreationResult` struct (around line 72) and add immediately after it:
+
+```rust
+/// A PR/MR comment that git-gud manages (identified by marker).
+#[derive(Debug, Clone)]
+pub struct ManagedComment {
+    pub id: u64,
+    pub body: String,
+}
+```
+
+Then, inside the `impl Provider` block — place these near `get_pr_body` / `update_pr_description` for locality — add four new methods:
+
+```rust
+    /// Find the first comment on a PR/MR whose body contains `marker`.
+    ///
+    /// Returns `Ok(None)` if no such comment exists.
+    pub fn find_managed_comment(
+        &self,
+        pr_number: u64,
+        marker: &str,
+    ) -> Result<Option<ManagedComment>> {
+        match self {
+            Provider::GitHub => {
+                let comments = gh::list_issue_comments(pr_number)?;
+                Ok(comments
+                    .into_iter()
+                    .find(|c| c.body.contains(marker))
+                    .map(|c| ManagedComment {
+                        id: c.id,
+                        body: c.body,
+                    }))
+            }
+            Provider::GitLab => {
+                let notes = glab::list_mr_notes(pr_number)?;
+                Ok(notes
+                    .into_iter()
+                    .find(|n| n.body.contains(marker))
+                    .map(|n| ManagedComment {
+                        id: n.id,
+                        body: n.body,
+                    }))
+            }
+        }
+    }
+
+    /// Create a comment on a PR/MR.
+    pub fn create_pr_comment(&self, pr_number: u64, body: &str) -> Result<()> {
+        match self {
+            Provider::GitHub => gh::create_issue_comment(pr_number, body),
+            Provider::GitLab => glab::create_mr_note(pr_number, body),
+        }
+    }
+
+    /// Update an existing comment by its id.
+    ///
+    /// `pr_number` is required for GitLab (notes are per-MR); GitHub ignores it
+    /// because issue-comment endpoints address comments by id alone.
+    pub fn update_pr_comment(
+        &self,
+        pr_number: u64,
+        comment_id: u64,
+        body: &str,
+    ) -> Result<()> {
+        match self {
+            Provider::GitHub => gh::update_issue_comment(comment_id, body),
+            Provider::GitLab => glab::update_mr_note(pr_number, comment_id, body),
+        }
+    }
+
+    /// Delete a comment by its id.
+    pub fn delete_pr_comment(&self, pr_number: u64, comment_id: u64) -> Result<()> {
+        match self {
+            Provider::GitHub => gh::delete_issue_comment(comment_id),
+            Provider::GitLab => glab::delete_mr_note(pr_number, comment_id),
+        }
+    }
+```
+
+- [ ] **Step 7.4: Run tests, confirm they pass**
+
+Run: `cargo test -p gg-core provider::tests::`
+Expected: all provider tests PASS, including the new `test_managed_comment_construction`.
+
+- [ ] **Step 7.5: Commit**
+
+```bash
+git add crates/gg-core/src/provider.rs
+git commit -m "feat(core): add Provider::{find,create,update,delete}_pr_comment"
+```
+
+---
+
+## Task 8: Add `nav_comment_action` optional field to sync JSON output
+
+**Files:**
+- Modify: `crates/gg-core/src/output.rs`
+
+The field is `Option<String>` — when omitted from serialized output, existing JSON consumers are unaffected for users who don't opt in.
+
+- [ ] **Step 8.1: Write failing test**
+
+Append to the `#[cfg(test)] mod tests` block in `crates/gg-core/src/output.rs`:
+
+```rust
+#[test]
+fn test_sync_entry_nav_comment_action_omitted_when_none() {
+    let entry = SyncEntryResultJson {
+        position: 1,
+        sha: "abc".to_string(),
+        title: "t".to_string(),
+        gg_id: "c-1234567".to_string(),
+        branch: "b".to_string(),
+        action: "created".to_string(),
+        pr_number: Some(1),
+        pr_url: None,
+        draft: false,
+        pushed: true,
+        error: None,
+        nav_comment_action: None,
+    };
+    let json = serde_json::to_value(&entry).unwrap();
+    assert!(
+        json.get("nav_comment_action").is_none(),
+        "field should be omitted when None"
+    );
+}
+
+#[test]
+fn test_sync_entry_nav_comment_action_serializes_when_some() {
+    let entry = SyncEntryResultJson {
+        position: 1,
+        sha: "abc".to_string(),
+        title: "t".to_string(),
+        gg_id: "c-1234567".to_string(),
+        branch: "b".to_string(),
+        action: "created".to_string(),
+        pr_number: Some(1),
+        pr_url: None,
+        draft: false,
+        pushed: true,
+        error: None,
+        nav_comment_action: Some("created".to_string()),
+    };
+    let json = serde_json::to_value(&entry).unwrap();
+    assert_eq!(json["nav_comment_action"], "created");
+}
+```
+
+- [ ] **Step 8.2: Run, confirm compile error**
+
+Run: `cargo test -p gg-core output::tests::test_sync_entry_nav_comment_action_omitted_when_none`
+Expected: compile error — missing field `nav_comment_action`.
+
+- [ ] **Step 8.3: Add the field**
+
+In `crates/gg-core/src/output.rs`, modify the `SyncEntryResultJson` struct (around line 122):
+
+```rust
+#[derive(Serialize)]
+pub struct SyncEntryResultJson {
+    pub position: usize,
+    pub sha: String,
+    pub title: String,
+    pub gg_id: String,
+    pub branch: String,
+    pub action: String,
+    pub pr_number: Option<u64>,
+    pub pr_url: Option<String>,
+    pub draft: bool,
+    pub pushed: bool,
+    pub error: Option<String>,
+    /// Optional: action taken on the managed nav comment for this entry's PR.
+    /// One of "created", "updated", "unchanged", "deleted", "skipped", "error".
+    /// Omitted when the feature is disabled and no cleanup was required.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nav_comment_action: Option<String>,
+}
+```
+
+- [ ] **Step 8.4: Fix call sites that construct this struct**
+
+The sync command constructs `SyncEntryResultJson` in two places. Update them to pass `nav_comment_action: None` explicitly (sync.rs will populate this in Task 9). In `crates/gg-core/src/commands/sync.rs`, find each `json_entries.push(SyncEntryResultJson { ... })` call and add the new field with the value `None`:
+
+```rust
+        json_entries.push(SyncEntryResultJson {
+            position: entry.position,
+            sha: entry.short_sha.clone(),
+            title: entry.title.clone(),
+            gg_id: gg_id.clone(),
+            branch: entry_branch,
+            action,
+            pr_number,
+            pr_url,
+            draft: entry_draft,
+            pushed,
+            error: entry_error,
+            nav_comment_action: None,
+        });
+```
+
+There are two such construction sites (one on the `push` error path, one at the end of the loop). Both need the new field.
+
+- [ ] **Step 8.5: Run tests, confirm they pass**
+
+Run: `cargo test -p gg-core output::tests::`
+Expected: PASS, including the 2 new tests.
+
+Also run: `cargo build -p gg-core` — should compile without errors.
+
+- [ ] **Step 8.6: Commit**
+
+```bash
+git add crates/gg-core/src/output.rs crates/gg-core/src/commands/sync.rs
+git commit -m "feat(core): add optional nav_comment_action to sync JSON output"
+```
+
+---
+
+## Task 9: Add pure helper for deciding per-entry nav action
+
+**Files:**
+- Create: (none — add to `crates/gg-core/src/stack_nav.rs`)
+
+The decision logic ("given state, what should we do for each entry?") is pure and easy to test. Keep it out of sync.rs.
+
+- [ ] **Step 9.1: Write failing tests for the decision helper**
+
+Append to the `mod tests` block in `crates/gg-core/src/stack_nav.rs`:
+
+```rust
+#[test]
+fn test_decide_action_reconcile_when_setting_on_and_multi_entry_open() {
+    let decision = decide_action(NavDecisionInput {
+        setting_enabled: true,
+        stack_entry_count: 3,
+        pr_state: PrEntryState::Open,
+        has_existing_comment: false,
+    });
+    assert_eq!(decision, NavAction::Upsert);
+}
+
+#[test]
+fn test_decide_action_cleanup_when_setting_off_and_comment_exists() {
+    let decision = decide_action(NavDecisionInput {
+        setting_enabled: false,
+        stack_entry_count: 3,
+        pr_state: PrEntryState::Open,
+        has_existing_comment: true,
+    });
+    assert_eq!(decision, NavAction::Delete);
+}
+
+#[test]
+fn test_decide_action_skip_when_setting_off_and_no_comment() {
+    let decision = decide_action(NavDecisionInput {
+        setting_enabled: false,
+        stack_entry_count: 3,
+        pr_state: PrEntryState::Open,
+        has_existing_comment: false,
+    });
+    assert_eq!(decision, NavAction::Skip);
+}
+
+#[test]
+fn test_decide_action_cleanup_when_single_entry_and_comment_exists() {
+    let decision = decide_action(NavDecisionInput {
+        setting_enabled: true,
+        stack_entry_count: 1,
+        pr_state: PrEntryState::Open,
+        has_existing_comment: true,
+    });
+    assert_eq!(decision, NavAction::Delete);
+}
+
+#[test]
+fn test_decide_action_skip_when_single_entry_and_no_comment() {
+    let decision = decide_action(NavDecisionInput {
+        setting_enabled: true,
+        stack_entry_count: 1,
+        pr_state: PrEntryState::Open,
+        has_existing_comment: false,
+    });
+    assert_eq!(decision, NavAction::Skip);
+}
+
+#[test]
+fn test_decide_action_skip_when_pr_closed() {
+    // Closed / merged PRs are historical — never touch their comments.
+    for state in [PrEntryState::Merged, PrEntryState::Closed] {
+        let decision = decide_action(NavDecisionInput {
+            setting_enabled: true,
+            stack_entry_count: 3,
+            pr_state: state,
+            has_existing_comment: true,
+        });
+        assert_eq!(decision, NavAction::Skip, "closed/merged must be skipped");
+    }
+}
+
+#[test]
+fn test_decide_action_draft_treated_as_open() {
+    let decision = decide_action(NavDecisionInput {
+        setting_enabled: true,
+        stack_entry_count: 2,
+        pr_state: PrEntryState::Draft,
+        has_existing_comment: false,
+    });
+    assert_eq!(decision, NavAction::Upsert);
+}
+```
+
+- [ ] **Step 9.2: Run tests, confirm compile errors**
+
+Run: `cargo test -p gg-core stack_nav::tests::test_decide_action_reconcile_when_setting_on_and_multi_entry_open`
+Expected: compile errors — types and function don't exist.
+
+- [ ] **Step 9.3: Implement the decision helper**
+
+Add to `crates/gg-core/src/stack_nav.rs` (above the tests module):
+
+```rust
+/// The per-entry PR state that matters for nav-comment reconciliation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrEntryState {
+    Open,
+    Draft,
+    Merged,
+    Closed,
+}
+
+/// Inputs for the per-entry nav-action decision.
+#[derive(Debug, Clone, Copy)]
+pub struct NavDecisionInput {
+    pub setting_enabled: bool,
+    pub stack_entry_count: usize,
+    pub pr_state: PrEntryState,
+    pub has_existing_comment: bool,
+}
+
+/// What to do with the nav comment on a single PR in the stack.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NavAction {
+    /// Do nothing: no comment should exist and none does.
+    Skip,
+    /// Create a new comment, or update the existing one (idempotent upsert).
+    Upsert,
+    /// Delete an existing comment.
+    Delete,
+}
+
+/// Decide what to do with the nav comment on a single PR, based on state.
+///
+/// See the design spec for the full decision table. In short:
+/// - Closed/merged PRs: always skip.
+/// - Setting off OR single-entry stack: delete if a comment exists, else skip.
+/// - Otherwise: upsert.
+pub fn decide_action(input: NavDecisionInput) -> NavAction {
+    // Historical PRs are never touched.
+    if matches!(input.pr_state, PrEntryState::Merged | PrEntryState::Closed) {
+        return NavAction::Skip;
+    }
+
+    let should_have_comment = input.setting_enabled && input.stack_entry_count >= 2;
+
+    if should_have_comment {
+        NavAction::Upsert
+    } else if input.has_existing_comment {
+        NavAction::Delete
+    } else {
+        NavAction::Skip
+    }
+}
+```
+
+- [ ] **Step 9.4: Run tests, confirm all pass**
+
+Run: `cargo test -p gg-core stack_nav::`
+Expected: all stack_nav tests PASS (11 render + 4 is_managed + 7 decide_action = 22).
+
+- [ ] **Step 9.5: Commit**
+
+```bash
+git add crates/gg-core/src/stack_nav.rs
+git commit -m "feat(core): add NavAction decision helper for sync reconcile"
+```
+
+---
+
+## Task 10: Integrate nav reconcile into `gg sync`
+
+**Files:**
+- Modify: `crates/gg-core/src/commands/sync.rs`
+
+Hook the nav reconcile into the existing sync flow. Track per-entry PR numbers/states during the main loop, then run a single reconcile pass over the open PRs after the main loop finishes.
+
+- [ ] **Step 10.1: Add a small record type at the top of the module**
+
+At the top of `crates/gg-core/src/commands/sync.rs`, after the `use` statements, add:
+
+```rust
+/// Per-entry state captured during the main sync loop that the nav-comment
+/// reconcile pass needs. Populated only for entries whose PR exists.
+struct NavEntrySnapshot {
+    pr_number: u64,
+    pr_state: crate::stack_nav::PrEntryState,
+    /// Index into `json_entries` so we can attach the nav action result.
+    json_index: usize,
+}
+```
+
+Add `use crate::stack_nav;` to the import block at the top of the file.
+
+- [ ] **Step 10.2: Collect snapshots during the main loop**
+
+Find the `for (i, entry) in entries_to_sync.iter().enumerate()` loop (around line 332). Inside this loop, after the `match existing_pr { ... }` block that sets `pr_number`, and **before** the `if json { json_entries.push(...) }` block at the end of the iteration, insert state collection:
+
+```rust
+        // Capture state for nav reconcile pass (below).
+        let nav_snapshot: Option<NavEntrySnapshot> = if let Some(num) = pr_number {
+            let state = match provider.get_pr_info(num).map(|info| info.state).ok() {
+                Some(crate::provider::PrState::Open) => Some(stack_nav::PrEntryState::Open),
+                Some(crate::provider::PrState::Draft) => Some(stack_nav::PrEntryState::Draft),
+                Some(crate::provider::PrState::Merged) => Some(stack_nav::PrEntryState::Merged),
+                Some(crate::provider::PrState::Closed) => Some(stack_nav::PrEntryState::Closed),
+                None => None,
+            };
+            state.map(|pr_state| NavEntrySnapshot {
+                pr_number: num,
+                pr_state,
+                json_index: json_entries.len(), // the push below will be at this index
+            })
+        } else {
+            None
+        };
+```
+
+Then hoist the snapshot up to a `Vec<Option<NavEntrySnapshot>>` defined above the loop. Specifically, add this declaration next to `let mut json_entries: Vec<SyncEntryResultJson> = Vec::new();`:
+
+```rust
+    let mut nav_snapshots: Vec<Option<NavEntrySnapshot>> = Vec::new();
+```
+
+And at the end of each iteration, push the snapshot. Right before `pb.inc(1);` at the end of the loop, add:
+
+```rust
+        nav_snapshots.push(nav_snapshot);
+```
+
+> **Note:** `get_pr_info` makes an extra network call per entry. This is acceptable for v1 — the reconcile pass depends on per-entry state. If this proves slow in practice, v2 can thread state through the main loop (which already calls `get_pr_info` in the `existing_pr: Some(...)` branch).
+
+- [ ] **Step 10.3: Add the reconcile pass after the main loop**
+
+After the main loop closes (after `pb.finish_with_message("Done!");`) and **before** `config.save(git_dir)?;`, insert the reconcile block:
+
+```rust
+    // --- Nav-comment reconcile pass ---
+    //
+    // For each synced entry whose PR exists and is reachable, decide whether
+    // to create/update/delete the managed nav comment based on:
+    //   - the stack_nav_comments setting
+    //   - the total stack size
+    //   - the PR's state (open/draft vs merged/closed)
+    //
+    // We render the nav body with `is_current = true` on the entry being
+    // processed, so each PR's comment highlights the reader's location.
+    let setting_enabled = config.get_stack_nav_comments();
+    let stack_entry_count = entries_to_sync.len();
+    let number_prefix = provider.pr_number_prefix();
+
+    // Collect the (pr_number, is_current) pairs once — used to render each
+    // per-PR body with a different `is_current` flag.
+    let all_entries: Vec<(u64, usize)> = nav_snapshots
+        .iter()
+        .enumerate()
+        .filter_map(|(i, s)| s.as_ref().map(|snap| (snap.pr_number, i)))
+        .collect();
+
+    for (i, snap) in nav_snapshots.iter().enumerate() {
+        let snap = match snap {
+            Some(s) => s,
+            None => continue,
+        };
+
+        // Check for an existing managed comment once per PR.
+        let existing = match provider
+            .find_managed_comment(snap.pr_number, stack_nav::MARKER)
+        {
+            Ok(v) => v,
+            Err(e) => {
+                if !json {
+                    println!(
+                        "{} Could not list comments on {} {}{}: {}",
+                        style("Warning:").yellow(),
+                        provider.pr_label(),
+                        number_prefix,
+                        snap.pr_number,
+                        e
+                    );
+                }
+                if json {
+                    if let Some(entry_json) = json_entries.get_mut(snap.json_index) {
+                        entry_json.nav_comment_action = Some("error".to_string());
+                    }
+                }
+                continue;
+            }
+        };
+
+        let decision = stack_nav::decide_action(stack_nav::NavDecisionInput {
+            setting_enabled,
+            stack_entry_count,
+            pr_state: snap.pr_state,
+            has_existing_comment: existing.is_some(),
+        });
+
+        let action_result: Option<&str> = match decision {
+            stack_nav::NavAction::Skip => None,
+            stack_nav::NavAction::Upsert => {
+                // Render body with `is_current = true` for this entry's position.
+                let nav_entries: Vec<stack_nav::StackNavEntry> = all_entries
+                    .iter()
+                    .map(|(n, j)| stack_nav::StackNavEntry {
+                        pr_number: *n,
+                        is_current: *j == i,
+                    })
+                    .collect();
+                let body = stack_nav::render(&stack.name, &nav_entries, number_prefix);
+
+                match existing {
+                    Some(c) if c.body == body => Some("unchanged"),
+                    Some(c) => match provider.update_pr_comment(snap.pr_number, c.id, &body) {
+                        Ok(()) => Some("updated"),
+                        Err(e) => {
+                            if !json {
+                                println!(
+                                    "{} Could not update nav comment on {} {}{}: {}",
+                                    style("Warning:").yellow(),
+                                    provider.pr_label(),
+                                    number_prefix,
+                                    snap.pr_number,
+                                    e
+                                );
+                            }
+                            Some("error")
+                        }
+                    },
+                    None => match provider.create_pr_comment(snap.pr_number, &body) {
+                        Ok(()) => Some("created"),
+                        Err(e) => {
+                            if !json {
+                                println!(
+                                    "{} Could not create nav comment on {} {}{}: {}",
+                                    style("Warning:").yellow(),
+                                    provider.pr_label(),
+                                    number_prefix,
+                                    snap.pr_number,
+                                    e
+                                );
+                            }
+                            Some("error")
+                        }
+                    },
+                }
+            }
+            stack_nav::NavAction::Delete => {
+                match existing {
+                    Some(c) => match provider.delete_pr_comment(snap.pr_number, c.id) {
+                        Ok(()) => Some("deleted"),
+                        Err(e) => {
+                            if !json {
+                                println!(
+                                    "{} Could not delete nav comment on {} {}{}: {}",
+                                    style("Warning:").yellow(),
+                                    provider.pr_label(),
+                                    number_prefix,
+                                    snap.pr_number,
+                                    e
+                                );
+                            }
+                            Some("error")
+                        }
+                    },
+                    None => None, // decision was Delete but nothing to delete
+                }
+            }
+        };
+
+        if let Some(action) = action_result {
+            if let Some(entry_json) = json_entries.get_mut(snap.json_index) {
+                entry_json.nav_comment_action = Some(action.to_string());
+            }
+        }
+    }
+```
+
+- [ ] **Step 10.4: Build and fix compile errors**
+
+Run: `cargo build -p gg-core`
+
+Fix any compile errors. Common likely issues:
+- Missing `use crate::stack_nav;` — add it.
+- `existing_pr` already consumed `provider.get_pr_info(...)` earlier but didn't store the state in a local usable after the match. The snapshot code above calls `provider.get_pr_info` again — intentional, since for the `existing_pr: None` branch (newly created PR) we don't have state yet. Confirm the branch where `existing_pr: Some(_)` doesn't move `pr_info` in a way that blocks re-fetching.
+
+Expected final state: `cargo build -p gg-core` succeeds.
+
+- [ ] **Step 10.5: Run the full test suite**
+
+Run: `cargo test -p gg-core`
+Expected: all existing tests still PASS.
+
+Run: `cargo fmt --all` and `cargo clippy --all-targets --all-features -- -D warnings` to catch style/lint issues introduced. Fix any clippy warnings with the minimal change.
+
+- [ ] **Step 10.6: Commit**
+
+```bash
+git add crates/gg-core/src/commands/sync.rs
+git commit -m "feat(sync): reconcile stack-nav comments on PRs/MRs after sync"
+```
+
+---
+
+## Task 11: Add `gg setup` prompt for the new setting
+
+**Files:**
+- Modify: `crates/gg-core/src/commands/setup.rs`
+
+- [ ] **Step 11.1: Add the prompt in the "Sync" group**
+
+In `crates/gg-core/src/commands/setup.rs`, find the "── Sync ──" block (starting around line 143). Add the new prompt after `sync_update_descriptions` but before the group closes (i.e., immediately after the `sync_update_descriptions = Confirm...` block ending around line 163):
+
+```rust
+    defaults.stack_nav_comments = Confirm::with_theme(theme)
+        .with_prompt(
+            "Post a navigation comment on each PR/MR in a stack (links to other PRs/MRs)?",
+        )
+        .default(existing.stack_nav_comments)
+        .interact()
+        .map_err(|e| GgError::Other(format!("Prompt failed: {}", e)))?;
+```
+
+- [ ] **Step 11.2: Build**
+
+Run: `cargo build -p gg-core`
+Expected: success.
+
+- [ ] **Step 11.3: Commit**
+
+```bash
+git add crates/gg-core/src/commands/setup.rs
+git commit -m "feat(setup): prompt for stack_nav_comments in full setup mode"
+```
+
+---
+
+## Task 12: Update documentation
+
+**Files:**
+- Modify: `docs/src/configuration.md`
+- Modify: `docs/src/commands/sync.md`
+- Modify: `docs/src/commands/setup.md`
+
+- [ ] **Step 12.1: Read the current docs to match existing style**
+
+Read each of these files in full before editing:
+- `docs/src/configuration.md`
+- `docs/src/commands/sync.md`
+- `docs/src/commands/setup.md`
+
+Match the existing voice, header levels, and example formatting.
+
+- [ ] **Step 12.2: Document the config field**
+
+Add to `docs/src/configuration.md` — find the section that documents sync-related settings (look for `sync_update_descriptions`). Add a new entry in the same format:
+
+```markdown
+#### `defaults.stack_nav_comments` (boolean, default: `false`)
+
+Opt-in. When `true`, `gg sync` posts a managed comment on each open PR/MR in a
+multi-entry stack, listing all entries with a 👉 marker on the current one. The
+list uses `#N` references on GitHub and `!N` on GitLab, so the provider renders
+titles and status badges automatically.
+
+When the setting is `false` (default), no nav comments are posted. If the
+setting was previously `true` and is now `false`, the next `gg sync` removes
+any existing managed comments it previously created.
+
+Single-entry stacks are always skipped (a one-item navigation is noise). The
+feature is fully managed: git-gud never touches comments it didn't create
+(identified by a hidden `<!-- gg:stack-nav -->` marker).
+```
+
+- [ ] **Step 12.3: Mention in the sync command reference**
+
+Add a section to `docs/src/commands/sync.md` (place near the end, before any "See also" section). Match the existing heading style:
+
+```markdown
+## Stack navigation comments
+
+If `defaults.stack_nav_comments` is enabled in `.git/gg/config.json`, every
+`gg sync` reconciles a managed comment on each PR/MR in the stack. The
+comment shows all entries in the stack in bottom-up order, with a 👉 marker
+on the entry that PR corresponds to — letting reviewers see where they are
+in the chain and click through to siblings.
+
+The comment is identified by a hidden HTML marker (`<!-- gg:stack-nav -->`)
+and never touches comments git-gud didn't create. Disabling the setting and
+re-syncing cleans up any previously-posted comments automatically.
+
+Merged or closed PRs are left alone — `gg sync` never modifies comments on
+historical PRs.
+
+When running with `--json`, each entry includes an optional `nav_comment_action`
+field (one of `"created"`, `"updated"`, `"unchanged"`, `"deleted"`, `"skipped"`,
+`"error"`) when a reconcile decision was made.
+```
+
+- [ ] **Step 12.4: Mention in the setup reference**
+
+In `docs/src/commands/setup.md`, find the section listing prompts in full setup mode (search for the "Sync" group or `sync_update_descriptions`). Add a line describing the new prompt, matching existing formatting:
+
+```markdown
+- **Post a navigation comment on each PR/MR in a stack?** — sets `defaults.stack_nav_comments`.
+  When enabled, each PR/MR in a multi-entry stack gets a managed comment listing
+  all entries with a 👉 marker on the current one. Opt-in; default is `no`.
+```
+
+- [ ] **Step 12.5: Commit**
+
+```bash
+git add docs/src/configuration.md docs/src/commands/sync.md docs/src/commands/setup.md
+git commit -m "docs: document stack navigation comment feature"
+```
+
+---
+
+## Task 13: Update agent skill and README
+
+**Files:**
+- Modify: `skills/gg/SKILL.md`
+- Modify: `skills/gg/reference.md`
+- Modify: `README.md`
+
+- [ ] **Step 13.1: Update the skill**
+
+Read `skills/gg/SKILL.md` in full first to match the existing tone and structure.
+
+Add a short subsection to `skills/gg/SKILL.md` where other optional sync behaviors are described (search for "sync" or a section discussing PR bodies / managed content). Use this wording:
+
+```markdown
+### Stack-navigation comments
+
+If the repo's `.git/gg/config.json` has `defaults.stack_nav_comments: true`,
+`gg sync` posts and maintains a managed comment on each open PR/MR in the
+stack. The comment lists every entry (`#N` on GitHub, `!N` on GitLab) with a
+👉 marker on the current one. The comment is identified by a hidden
+`<!-- gg:stack-nav -->` marker and managed entirely by git-gud — don't edit
+these comments manually, and don't be surprised when `gg sync` adds, updates,
+or removes them automatically.
+
+Disable the feature by setting `defaults.stack_nav_comments: false` (the
+default). The next `gg sync` then cleans up any existing managed comments.
+```
+
+- [ ] **Step 13.2: Update the skill reference**
+
+Add to `skills/gg/reference.md` where other config options are listed:
+
+```markdown
+#### `defaults.stack_nav_comments`
+
+- **Type:** `boolean`
+- **Default:** `false`
+- **Effect:** When `true`, `gg sync` posts and maintains a managed "stack
+  navigation" comment on each open PR/MR in a multi-entry stack. When `false`
+  (default), no such comments are posted; any pre-existing managed comments
+  are removed on the next sync.
+```
+
+Also, find the JSON schema section for `gg sync --json` output (search for `SyncEntryResultJson` or `nav_comment_action` / `pr_number` in the existing schema docs). Add a field description:
+
+```markdown
+- `nav_comment_action` (string, optional): action taken on the managed
+  stack-nav comment for this entry's PR during this sync. One of
+  `"created"`, `"updated"`, `"unchanged"`, `"deleted"`, `"skipped"`, or
+  `"error"`. Omitted when no reconcile action was required.
+```
+
+- [ ] **Step 13.3: Update the README**
+
+Read `README.md` to find the feature list (usually near the top, under a "Features" heading). Add a line matching existing bullet style:
+
+```markdown
+- **Stack navigation comments** — opt-in. Each PR/MR in a stack gets a managed comment listing sibling PRs with a 👉 marker on the current one (GitHub `#N` or GitLab `!N`).
+```
+
+- [ ] **Step 13.4: Commit**
+
+```bash
+git add skills/gg/SKILL.md skills/gg/reference.md README.md
+git commit -m "docs(skill): document stack navigation comment behavior"
+```
+
+---
+
+## Task 14: Final verification
+
+**Files:** none — verification only.
+
+- [ ] **Step 14.1: Full format, lint, test sweep**
+
+Run the project's pre-commit checklist:
+
+```bash
+cargo fmt --all
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-features
+```
+
+Expected: all three pass with zero warnings and zero test failures.
+
+- [ ] **Step 14.2: Verify all new tests are discoverable and passing**
+
+Run explicitly:
+
+```bash
+cargo test -p gg-core stack_nav::
+cargo test -p gg-core config::tests::test_stack_nav_comments
+cargo test -p gg-core provider::tests::test_managed_comment_construction
+cargo test -p gg-core output::tests::test_sync_entry_nav_comment_action
+```
+
+Expected: all pass.
+
+- [ ] **Step 14.3: Manual smoke test (optional but recommended)**
+
+If a test repo with a real remote is available:
+
+1. Set `defaults.stack_nav_comments: true` in `.git/gg/config.json`.
+2. Create a two-commit stack.
+3. Run `gg sync`.
+4. Confirm both PRs/MRs get a stack-nav comment with the expected format.
+5. Add a third commit, run `gg sync` again — first two should be updated, third should be created.
+6. Toggle the setting to `false`, run `gg sync` — all three comments should be deleted.
+
+Document any surprises in the PR description when opening the PR.
+
+- [ ] **Step 14.4: Commit any final fixes if needed**
+
+If step 14.1 surfaces warnings or failures, fix them as minimally as possible, run the sweep again, and commit. Otherwise, no commit needed for this task.
+
+---
+
+## Self-Review Notes
+
+Spec coverage verified against design doc sections:
+
+- Overview + example → Task 1 (render format matches exactly)
+- Opt-in single global bool, default off → Task 4
+- Ordering (bottom-up) → Task 1 (callers pass entries in stack order)
+- Content (minimal) → Task 1 (no titles, just `#N` / `!N` + 👉)
+- Current-entry marker (👉) → Task 1
+- Included entries (all) → Task 10 renders entries from `all_entries` regardless of per-PR state
+- Single-entry stacks skipped → Task 9 (`decide_action` returns Skip when `stack_entry_count < 2`)
+- Closed/merged PRs untouched → Task 9 (first guard in `decide_action`)
+- Cleanup when nav shouldn't exist → Task 9 (Delete decision) + Task 10 (reconcile pass handles Delete)
+- Independence from `--no-update-descriptions` → Task 10 (reconcile runs unconditionally, not gated by `update_descriptions`)
+- `stack_nav.rs` module → Task 1-3, 9
+- Config field → Task 4
+- Provider methods → Tasks 5, 6, 7
+- Two/three-pass sync → Task 10
+- JSON field → Task 8
+- Tests → Tasks 1, 2, 3, 4, 7, 8, 9
+- Docs + skill + README → Tasks 12, 13

--- a/docs/superpowers/specs/2026-04-15-stack-nav-comment-design.md
+++ b/docs/superpowers/specs/2026-04-15-stack-nav-comment-design.md
@@ -1,0 +1,207 @@
+# Stack Navigation Comment Design
+
+**Issue:** [#275 – Feature Request: Add links to other PRs in the stack](https://github.com/mrmans0n/git-gud/issues/275)
+**Date:** 2026-04-15
+
+## Overview
+
+When enabled via a global opt-in setting, `gg sync` posts (and keeps updated) a single comment on each open PR/MR in a stack. The comment lists every entry in the stack in bottom-up order, with an emoji marker (👉) on the entry that PR corresponds to, so reviewers can see their position within the stack at a glance and navigate to sibling PRs.
+
+The comment uses `#N` references on GitHub and `!N` on GitLab; the provider's reference expansion handles titles, status badges (open / merged / closed / draft), and click-through navigation automatically.
+
+### Example (GitHub, stack `feat-auth` with three entries viewed from the middle PR)
+
+```
+This change is part of the `feat-auth` stack:
+
+- #42
+- 👉 #43
+- #44
+
+<sub>Managed by [git-gud](https://github.com/mrmans0n/git-gud).</sub>
+<!-- gg:stack-nav -->
+```
+
+The same stack on GitLab uses `!42`, `!43`, `!44`.
+
+## Motivation
+
+Reviewers viewing a single PR from a stack often have no way to know what else is in flight, where their PR sits in the dependency chain, or where to go next. Graphite, git-spice, and Phabricator all solve this by rendering navigation inline on each review unit. git-gud currently has no equivalent.
+
+## Design Decisions
+
+### Where: a pinned comment per PR, not the description
+
+The navigation lives in a dedicated comment on each PR/MR, not inside the PR body. This keeps the `pr_template.md` and `{{description}}` placeholders entirely separate from the managed navigation concern.
+
+- The description stays author-authored; `gg sync` doesn't need to reconcile nav content against user edits within the managed-body block.
+- A hidden HTML marker (`<!-- gg:stack-nav -->`) in the comment body lets `gg sync` find "its" comment across subsequent runs without storing comment IDs in `.git/gg/config.json`.
+
+### Opt-in: single global bool, default off
+
+A new field `stack_nav_comments: bool` (default `false`) on the repository `Config` (`.git/gg/config.json`). `gg setup` gains a prompt to enable it.
+
+No per-stack override in v1 — a single global default matches most expected usage patterns. Per-stack granularity can be added later without breaking changes if demand appears.
+
+### Ordering: bottom-up (base first, tip last)
+
+Entries are listed in the natural order of `stack.entries` (index 0 first). This matches `gg ls` and `git rebase -i`, both of which the project's users are already trained on.
+
+### Content: minimal
+
+Each line is `- #NUMBER` (or `- 👉 #NUMBER` for the current entry). No inline titles, no custom format strings. Relying on the provider's reference rendering:
+
+- Eliminates drift between the rendered nav and the commit title.
+- Automatically gets open/merged/closed/draft status badges.
+- Keeps the comment body small.
+
+### Current-entry marker: 👉
+
+The pointing-finger emoji reads unambiguously as "this is you" and doesn't collide with checkbox or bullet formatting authors commonly paste into PR descriptions. Fixed, not configurable.
+
+### Included entries: all of them
+
+Every entry in `stack.entries` appears in the list, regardless of its PR state (open / merged / closed / draft). The provider's reference expansion shows the state badge next to each number. `gg clean` eventually removes entries from the stack, so the list shrinks naturally over time.
+
+### Single-entry stacks: skip
+
+If `stack.entries.len() == 1`, no comment is posted (or, if one already exists, it is deleted). A one-item nav is noise. The transition from "no comment" → "comment appears when a second entry is added" is a useful signal.
+
+### Closed/merged PRs: don't touch them
+
+When iterating entries to reconcile comments, skip any entry whose PR is closed or merged — don't create, update, or delete comments on them. Closed PRs are historical artifacts and shouldn't be modified by subsequent syncs. Draft PRs are **not** in this category: they are treated as open and receive nav comments like any other open PR.
+
+### Cleanup when nav shouldn't exist
+
+When the setting is `false` or the stack has shrunk to a single entry, `gg sync` actively removes any existing stack-nav comments (found by marker) from still-open PRs. Toggling the setting off, or a stack naturally collapsing to one commit, leaves no orphaned comments — the feature fully owns its output.
+
+### Independence from `--no-update-descriptions`
+
+The nav comment is reconciled on every sync regardless of the `update_descriptions` flag. Adding a commit to a stack requires updating nav on every OTHER open PR too, even ones whose own body didn't change — so gating nav reconciliation on description updates would produce inconsistent navigation.
+
+## Architecture
+
+### New module: `crates/gg-core/src/stack_nav.rs`
+
+Pure, I/O-free rendering and marker detection. Heavily unit-tested.
+
+```rust
+pub const MARKER: &str = "<!-- gg:stack-nav -->";
+
+pub struct StackNavEntry {
+    pub pr_number: u64,
+    pub is_current: bool,
+}
+
+/// Render the navigation comment body.
+/// `number_prefix` is "#" for GitHub, "!" for GitLab.
+pub fn render(stack_name: &str, entries: &[StackNavEntry], number_prefix: &str) -> String;
+
+/// Returns true if a comment body is a git-gud-managed nav comment.
+pub fn is_managed_comment(body: &str) -> bool;
+```
+
+### Config changes: `crates/gg-core/src/config.rs`
+
+- Add `stack_nav_comments: bool` field to the `Config` struct, with a serde default of `false` so existing configs load unchanged.
+
+### Provider additions: `crates/gg-core/src/provider.rs`
+
+Four new methods on the provider abstraction, plus a small struct:
+
+```rust
+pub struct ManagedComment {
+    pub id: u64,
+    pub body: String,
+}
+
+pub trait ProviderOps { // or equivalent existing trait
+    fn find_managed_comment(&self, pr_number: u64, marker: &str) -> Result<Option<ManagedComment>>;
+    fn create_pr_comment(&self, pr_number: u64, body: &str) -> Result<()>;
+    fn update_pr_comment(&self, pr_number: u64, comment_id: u64, body: &str) -> Result<()>;
+    fn delete_pr_comment(&self, pr_number: u64, comment_id: u64) -> Result<()>;
+}
+```
+
+Implementation details per backend:
+
+- **GitHub (`gh.rs`):** `gh api /repos/{owner}/{repo}/issues/{number}/comments` for listing and creating (PR comments are issue comments in GitHub's data model); `gh api -X PATCH /repos/{owner}/{repo}/issues/comments/{id}` for updates; `gh api -X DELETE` for deletion.
+- **GitLab (`glab.rs`):** `glab api /projects/:id/merge_requests/:iid/notes` for list/create; `glab api -X PUT .../notes/:note_id` for update; `glab api -X DELETE` for delete.
+
+### `gg sync` flow change — two-pass execution
+
+The existing sync is single-pass: iterate entries, create-or-update each PR. The new flow:
+
+1. **Pass 1 (unchanged):** iterate entries, create/update PRs, collect the final `pr_number` for each entry.
+2. **Pass 2 — nav reconcile (conditional):** runs only when `stack_nav_comments == true` AND `stack.entries.len() >= 2`. For each entry whose PR is still open:
+   - Render the nav body with this entry's index flagged `is_current = true`.
+   - Call `find_managed_comment` on the PR.
+   - If no managed comment exists: `create_pr_comment`.
+   - If one exists and its body matches the rendered body: no-op (skip network call).
+   - If one exists with different body: `update_pr_comment`.
+3. **Pass 3 — cleanup (conditional):** runs when `stack_nav_comments == false` OR `stack.entries.len() < 2`. For each entry whose PR is still open, call `find_managed_comment`; if present, `delete_pr_comment`.
+
+Passes 2 and 3 are mutually exclusive — only one runs per sync, selected by state at sync time.
+
+### JSON output extension
+
+`SyncEntryResultJson` gains an optional field:
+
+```rust
+pub nav_comment_action: Option<String>, // "created" | "updated" | "unchanged" | "deleted" | "skipped" | "error"
+```
+
+Omitted when the setting is disabled AND no cleanup happens, so existing JSON consumers are unaffected for users who don't opt in.
+
+## Testing
+
+### Unit tests
+
+**`stack_nav::render`:**
+- Single-entry stack returns an empty string (or is-short-circuit safe).
+- Two-entry stack with `is_current` on first → `- 👉 #1\n- #2`.
+- Three-entry stack with `is_current` on middle.
+- GitLab prefix `!` produces `!1`, `!2`, etc.
+- Bottom-up ordering preserved when `is_current` is on the last entry.
+- Rendering the same input twice is byte-identical (idempotency).
+- Stack name appears in header exactly once, backtick-quoted.
+
+**`stack_nav::is_managed_comment`:**
+- Plain user comment → `false`.
+- Comment containing exactly the marker → `true`.
+- Marker with surrounding whitespace → `true`.
+- Marker appearing inside a fenced code block in a user comment → still matches (acceptable false positive — extremely unlikely in practice, and harmless since we never create comments that mix our marker with user content).
+
+### Integration tests
+
+Using a mock provider implementation that records all `create/update/delete/find` calls:
+
+- Setting `false` → no comment API calls.
+- Setting `true`, 2 entries, first sync → 2 `create_pr_comment` calls with correct bodies and 👉 placement.
+- Setting `true`, 2 entries, second sync with no stack changes → 2 `find_managed_comment` calls, 0 `update_pr_comment` calls (byte-identical bodies skip update).
+- Setting `true`, 2 entries, adding a 3rd entry and re-syncing → 2 `update_pr_comment` calls (PRs #1 and #2 get updated nav) + 1 `create_pr_comment` (new PR #3 gets its initial nav).
+- Toggling setting `true` → `false` → next sync issues `delete_pr_comment` for every open PR with a managed comment.
+- Stack of 2 entries where one PR is merged → only the open PR gets a comment touch.
+- Stack shrinks to 1 entry via `gg clean` → next sync deletes the stack-nav comment on the remaining open PR.
+
+### No E2E against real GitHub/GitLab
+
+New provider methods are covered by the existing unit-test patterns for `gh.rs` / `glab.rs` command-shape tests. Live E2E against GitHub/GitLab is expensive and the provider-shell pattern is the same as the existing `create_pr` / `update_pr_description` methods.
+
+## Documentation & skill updates
+
+- **`docs/src/`** — document the `stack_nav_comments` config field under the sync command reference and in the configuration guide page. Include a small screenshot or rendered example of the comment.
+- **`skills/gg/SKILL.md`** — add a short section explaining that `gg sync` may leave a managed comment on each PR when the setting is enabled, so agents don't treat it as unexpected content.
+- **`skills/gg/reference.md`** — document the new JSON field `nav_comment_action` and the config field.
+- **`README.md`** — add to the feature list.
+
+## Out of scope for v1
+
+These are explicitly deferred and can be revisited if demand emerges:
+
+- Per-stack override of the setting.
+- Configurable header text or emoji.
+- Inline commit titles on each line (relies on provider expansion instead).
+- A `gg sync --no-stack-nav` one-shot opt-out flag — the config setting is sufficient.
+- An on-demand `gg stack-nav` command that rewrites nav without full sync.
+- Surfacing the managed comment in `gg ls` output.

--- a/skills/gg/SKILL.md
+++ b/skills/gg/SKILL.md
@@ -197,6 +197,20 @@ config.
 - **Legacy PRs (no markers)**: Body is left untouched with a warning — no risk of clobbering manual edits.
 - **Content inside the managed block** is regenerated on each sync. Place persistent checklists and notes outside the markers.
 
+## Stack-navigation comments
+
+If the repo's `.git/gg/config.json` has `defaults.stack_nav_comments: true`,
+`gg sync` posts and maintains a managed comment on each open PR/MR in the
+stack. The comment lists every entry (`#N` on GitHub, `!N` on GitLab) with a
+👉 marker on the current one. The comment is identified by a hidden
+`<!-- gg:stack-nav -->` marker and managed entirely by git-gud — don't edit
+these comments manually, and don't be surprised when `gg sync` adds, updates,
+or removes them automatically.
+
+Disable the feature by setting `defaults.stack_nav_comments: false` (the
+default). The next `gg sync` then cleans up any existing managed comments.
+Reconcile is skipped under `--until` to avoid partial-stack inconsistencies.
+
 ## GitLab-specific
 
 - `gg land --auto-merge` is GitLab-only and requests queueing/auto-merge.

--- a/skills/gg/examples/basic-flow.md
+++ b/skills/gg/examples/basic-flow.md
@@ -40,6 +40,9 @@ Capture:
 - `sync.entries[*].pr_number`
 - `sync.entries[*].pr_url`
 
+If `defaults.stack_nav_comments` is enabled, also check:
+- `sync.entries[*].nav_comment_action` — confirms nav comments were posted
+
 ## 5) Refresh status after reviews/CI
 
 ```bash

--- a/skills/gg/examples/multi-commit.md
+++ b/skills/gg/examples/multi-commit.md
@@ -50,6 +50,9 @@ gg reorder -o "2,1,3"
 gg sync -f --json
 ```
 
+If `defaults.stack_nav_comments` is enabled, the response includes
+`nav_comment_action` per entry (`"created"`, `"updated"`, or `"unchanged"`).
+
 ## 6) Validate lint + status
 
 ```bash

--- a/skills/gg/reference.md
+++ b/skills/gg/reference.md
@@ -180,6 +180,16 @@ Interactive config wizard.
 
 Supports global config at `~/.config/gg/config.json` for shared defaults across repos. New fields: `sync_draft` (create PRs as drafts) and `sync_update_descriptions` (update PR descriptions on re-sync).
 
+#### `defaults.stack_nav_comments`
+
+- **Type:** `boolean`
+- **Default:** `false`
+- **Effect:** When `true`, `gg sync` posts and maintains a managed "stack
+  navigation" comment on each open PR/MR in a multi-entry stack. When `false`
+  (default), no such comments are posted; any pre-existing managed comments
+  are removed on the next sync. The reconcile pass is skipped when `--until`
+  limits a sync.
+
 #### `gg completions <SHELL>`
 Generate shell completion (`bash|elvish|fish|powershell|zsh`).
 
@@ -325,12 +335,19 @@ Field types:
         "pr_url": "https://host/org/repo/...",
         "draft": false,
         "pushed": true,
+        "nav_comment_action": "created",
         "error": null
       }
     ]
   }
 }
 ```
+
+Field types for `entries`:
+- `nav_comment_action` (string, optional): action taken on the managed
+  stack-nav comment for this entry's PR during this sync. One of
+  `"created"`, `"updated"`, `"unchanged"`, `"deleted"`, `"skipped"`, or
+  `"error"`. Omitted when no reconcile action was required.
 
 ### `gg lint --json`
 

--- a/skills/gg/reference.md
+++ b/skills/gg/reference.md
@@ -346,8 +346,8 @@ Field types:
 Field types for `entries`:
 - `nav_comment_action` (string, optional): action taken on the managed
   stack-nav comment for this entry's PR during this sync. One of
-  `"created"`, `"updated"`, `"unchanged"`, `"deleted"`, `"skipped"`, or
-  `"error"`. Omitted when no reconcile action was required.
+  `"created"`, `"updated"`, `"unchanged"`, `"deleted"`, or `"error"`.
+  Omitted when no reconcile action was required.
 
 ### `gg lint --json`
 


### PR DESCRIPTION
Closes #275.

## Summary

Opt-in feature that has `gg sync` post and maintain a managed comment on each open PR/MR in a multi-entry stack. The comment lists all stack entries with a 👉 marker on the current one, so reviewers can see where they are in the chain and click through to siblings.

Uses `#N` on GitHub and `!N` on GitLab so the provider's reference expansion renders titles and status badges automatically — no drift between nav and commit metadata.

### Example rendered comment (GitHub, 3-entry stack viewed from the middle PR)

```
This change is part of the `feat-auth` stack:

- #42
- 👉 #43
- #44

<sub>Managed by [git-gud](https://github.com/mrmans0n/git-gud).</sub>
<!-- gg:stack-nav -->
```

## Design highlights

- **Opt-in**: new `defaults.stack_nav_comments: bool` (default `false`) in `.git/gg/config.json`. `gg setup` prompts for it.
- **Comment, not description**: keeps `pr_template.md` entirely separate from the managed navigation. Hidden HTML marker (`<!-- gg:stack-nav -->`) identifies the comment across syncs — no comment IDs stored in config.
- **Bottom-up ordering**: matches `gg ls` and `git rebase -i`.
- **Two-pass sync**: main loop creates/updates PRs as before; a reconcile pass after the main loop (skipped under `--until`) calls `provider.{find,create,update,delete}_pr_comment` to post/update/delete nav comments. Errors are non-fatal warnings.
- **Self-managing**: toggle the setting off and the next `gg sync` deletes any comments gg previously created. Closed/merged PRs are never touched.
- **Idempotent**: byte-identical bodies skip the API update call to avoid notification spam.
- **JSON output**: optional `nav_comment_action` field (`"created"` | `"updated"` | `"unchanged"` | `"deleted"` | `"error"`) on each sync entry.

Full design: [`docs/superpowers/specs/2026-04-15-stack-nav-comment-design.md`](docs/superpowers/specs/2026-04-15-stack-nav-comment-design.md). Plan: [`docs/superpowers/plans/2026-04-15-stack-nav-comment.md`](docs/superpowers/plans/2026-04-15-stack-nav-comment.md).

## Test plan

- [x] Unit tests for pure `stack_nav` module (render, is_managed_comment, decide_action) — 19 tests
- [x] Config round-trip + default tests
- [x] Compile-shape tests for new gh.rs / glab.rs helpers
- [x] JSON output omit-when-none test
- [x] \`cargo fmt --all\`, \`cargo clippy --all-targets --all-features -- -D warnings\`, \`cargo test --all-features\` — clean (one pre-existing environmental test failure, see note below)
- [x] Live smoke test on [mrmans0n/git-gud-playground](https://github.com/mrmans0n/git-gud-playground):
  - Fresh 3-entry stack → 3 PRs + 3 nav comments with correct 👉 placement per PR
  - Idempotent re-sync → all report \`unchanged\` (no API calls)
  - Add 4th entry → existing 3 updated, new PR created, bodies show all 4
  - Toggle setting off → all 4 nav comments deleted
  - \`--until\` → reconcile pass skipped, no nav changes
  - Toggle back on + full sync → nav comments re-created

### Note on pre-existing test failure

On my machine, \`config::tests::test_load_with_global_returns_default_when_no_configs\` fails because I have a \`~/.config/gg/config.json\` overriding defaults — the test isn't hermetic against \`HOME\`. Fails identically at \`main\`; not a regression. Side-task spawned separately to fix the test by sandboxing \`HOME\`/\`XDG_CONFIG_HOME\`.