### PR TITLE
feat(log): add gg log smartlog view + stack_log MCP tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,9 @@ gg clean
 | `gg ls` | List current stack commits with PR/MR status (shows `↓N` when base is behind `origin/<base>`) |
 | `gg ls --all` | List all stacks in the repository |
 | `gg ls --remote` | List remote stacks not checked out locally |
+| `gg log` | Smartlog tree view of the current stack, with PR/MR status, CI badges, and `<- HEAD` marker |
+| `gg log --json` | Machine-readable stack snapshot (same shape as `gg ls --json`, always refreshes PR/MR state) |
+| `gg log --refresh` | Refresh PR/MR state from the provider before rendering the tree |
 | `gg clean` | Remove merged stacks and their remote branches |
 
 ### Syncing

--- a/crates/gg-cli/src/main.rs
+++ b/crates/gg-cli/src/main.rs
@@ -387,9 +387,7 @@ fn main() {
             remote,
             json,
         }) => (gg_core::commands::ls::run(all, refresh, remote, json), json),
-        Some(Commands::Log { json, refresh }) => {
-            (gg_core::commands::log::run(json, refresh), json)
-        }
+        Some(Commands::Log { json, refresh }) => (gg_core::commands::log::run(json, refresh), json),
         Some(Commands::Sync {
             draft,
             json,

--- a/crates/gg-cli/src/main.rs
+++ b/crates/gg-cli/src/main.rs
@@ -57,6 +57,18 @@ enum Commands {
         json: bool,
     },
 
+    /// Show a smartlog-style view of the current stack
+    #[command(name = "log")]
+    Log {
+        /// Output structured JSON
+        #[arg(long)]
+        json: bool,
+
+        /// Refresh PR/MR status from remote
+        #[arg(short, long)]
+        refresh: bool,
+    },
+
     /// Sync stack with remote (push branches and create/update PRs/MRs)
     #[command(name = "sync", alias = "diff")]
     Sync {
@@ -375,6 +387,9 @@ fn main() {
             remote,
             json,
         }) => (gg_core::commands::ls::run(all, refresh, remote, json), json),
+        Some(Commands::Log { json, refresh }) => {
+            (gg_core::commands::log::run(json, refresh), json)
+        }
         Some(Commands::Sync {
             draft,
             json,

--- a/crates/gg-cli/tests/integration_tests.rs
+++ b/crates/gg-cli/tests/integration_tests.rs
@@ -8274,10 +8274,19 @@ fn test_gg_log_shows_stack_tree() {
     assert!(stdout.contains("Add A"), "commit title should appear");
     assert!(stdout.contains("Add B"), "commit title should appear");
     // Tree glyphs: non-last uses ├──, last uses └──
-    assert!(stdout.contains("├──"), "tree tee glyph should appear: {stdout}");
-    assert!(stdout.contains("└──"), "tree corner glyph should appear: {stdout}");
+    assert!(
+        stdout.contains("├──"),
+        "tree tee glyph should appear: {stdout}"
+    );
+    assert!(
+        stdout.contains("└──"),
+        "tree corner glyph should appear: {stdout}"
+    );
     // HEAD marker should appear on the currently-checked-out (latest) commit
-    assert!(stdout.contains("HEAD"), "HEAD marker should appear: {stdout}");
+    assert!(
+        stdout.contains("HEAD"),
+        "HEAD marker should appear: {stdout}"
+    );
 }
 
 #[test]
@@ -8354,7 +8363,10 @@ fn test_gg_log_empty_stack() {
     let (success, stdout, stderr) = run_gg(&repo_path, &["log"]);
     assert!(success, "gg log on empty stack should succeed: {}", stderr);
     assert!(stdout.contains("log-empty"), "stack name should appear");
-    assert!(stdout.contains("empty stack"), "empty-stack hint should appear: {stdout}");
+    assert!(
+        stdout.contains("empty stack"),
+        "empty-stack hint should appear: {stdout}"
+    );
 
     // JSON shape should still be valid with zero entries.
     let (success, stdout, stderr) = run_gg(&repo_path, &["log", "--json"]);

--- a/crates/gg-cli/tests/integration_tests.rs
+++ b/crates/gg-cli/tests/integration_tests.rs
@@ -8232,6 +8232,164 @@ fn test_land_admin_config_default() {
 }
 
 #[test]
+fn test_gg_log_help() {
+    let (_temp_dir, repo_path) = create_test_repo();
+    let (success, stdout, _stderr) = run_gg(&repo_path, &["log", "--help"]);
+
+    assert!(success, "gg log --help failed");
+    assert!(stdout.contains("smartlog"), "help should mention smartlog");
+    assert!(stdout.contains("--json"));
+    assert!(stdout.contains("--refresh"));
+}
+
+#[test]
+fn test_gg_log_shows_stack_tree() {
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .expect("Failed to write config");
+
+    let (success, _stdout, stderr) = run_gg(&repo_path, &["co", "log-tree"]);
+    assert!(success, "Failed to create stack: {}", stderr);
+
+    fs::write(repo_path.join("a.txt"), "a").expect("Failed to write file");
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "Add A"]);
+
+    fs::write(repo_path.join("b.txt"), "b").expect("Failed to write file");
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "Add B"]);
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["log"]);
+    assert!(success, "gg log failed: {}", stderr);
+
+    assert!(stdout.contains("log-tree"), "stack name should appear");
+    assert!(stdout.contains("[1]"), "position 1 should appear");
+    assert!(stdout.contains("[2]"), "position 2 should appear");
+    assert!(stdout.contains("Add A"), "commit title should appear");
+    assert!(stdout.contains("Add B"), "commit title should appear");
+    // Tree glyphs: non-last uses ├──, last uses └──
+    assert!(stdout.contains("├──"), "tree tee glyph should appear: {stdout}");
+    assert!(stdout.contains("└──"), "tree corner glyph should appear: {stdout}");
+    // HEAD marker should appear on the currently-checked-out (latest) commit
+    assert!(stdout.contains("HEAD"), "HEAD marker should appear: {stdout}");
+}
+
+#[test]
+fn test_gg_log_json_shape() {
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .expect("Failed to write config");
+
+    let (success, _stdout, stderr) = run_gg(&repo_path, &["co", "log-json"]);
+    assert!(success, "Failed to create stack: {}", stderr);
+
+    fs::write(repo_path.join("a.txt"), "a").expect("Failed to write file");
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "Add A\n\nGG-ID: c-abc1234"]);
+
+    fs::write(repo_path.join("b.txt"), "b").expect("Failed to write file");
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "Add B\n\nGG-ID: c-def5678"]);
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["log", "--json"]);
+    assert!(success, "gg log --json failed: {}", stderr);
+
+    let parsed: Value = serde_json::from_str(&stdout).expect("stdout must be valid JSON");
+    assert_eq!(parsed["version"], 1);
+    assert_eq!(parsed["log"]["stack"], "log-json");
+    let base = parsed["log"]["base"]
+        .as_str()
+        .expect("log.base must be a string");
+    assert!(
+        matches!(base, "main" | "master"),
+        "expected base 'main' or 'master', got '{base}'"
+    );
+
+    let entries = parsed["log"]["entries"]
+        .as_array()
+        .expect("entries must be an array");
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0]["position"], 1);
+    assert_eq!(entries[0]["title"], "Add A");
+    assert_eq!(entries[1]["position"], 2);
+    assert_eq!(entries[1]["title"], "Add B");
+
+    // Current position should be the last entry (HEAD sits at stack head by default).
+    let current = parsed["log"]["current_position"]
+        .as_u64()
+        .expect("current_position should be populated");
+    assert_eq!(current, 2);
+    assert_eq!(entries[1]["is_current"], true);
+    assert_eq!(entries[0]["is_current"], false);
+}
+
+#[test]
+fn test_gg_log_empty_stack() {
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .expect("Failed to write config");
+
+    let (success, _stdout, stderr) = run_gg(&repo_path, &["co", "log-empty"]);
+    assert!(success, "Failed to create stack: {}", stderr);
+
+    // No commits yet — stack is empty.
+    let (success, stdout, stderr) = run_gg(&repo_path, &["log"]);
+    assert!(success, "gg log on empty stack should succeed: {}", stderr);
+    assert!(stdout.contains("log-empty"), "stack name should appear");
+    assert!(stdout.contains("empty stack"), "empty-stack hint should appear: {stdout}");
+
+    // JSON shape should still be valid with zero entries.
+    let (success, stdout, stderr) = run_gg(&repo_path, &["log", "--json"]);
+    assert!(success, "gg log --json on empty stack failed: {}", stderr);
+
+    let parsed: Value = serde_json::from_str(&stdout).expect("stdout must be valid JSON");
+    assert_eq!(parsed["version"], 1);
+    assert_eq!(parsed["log"]["stack"], "log-empty");
+    let entries = parsed["log"]["entries"]
+        .as_array()
+        .expect("entries must be an array");
+    assert!(entries.is_empty(), "empty stack should have zero entries");
+}
+
+#[test]
+fn test_gg_log_not_on_stack() {
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    // Not on any stack branch — still on `main`.
+    let (success, stdout, stderr) = run_gg(&repo_path, &["log"]);
+    assert!(!success, "gg log off-stack should fail: stdout={stdout}");
+    assert!(
+        stderr.contains("Not on a stack"),
+        "stderr should explain we are not on a stack: {stderr}"
+    );
+
+    // JSON mode surfaces the same condition as a structured error on stdout.
+    let (success, stdout, _stderr) = run_gg(&repo_path, &["log", "--json"]);
+    assert!(!success, "gg log --json off-stack should fail");
+    let parsed: Value = serde_json::from_str(&stdout).expect("stdout must be valid JSON");
+    assert_eq!(parsed["version"], 1);
+    assert!(parsed["error"].is_string(), "error field must be string");
+}
+
+#[test]
 fn test_land_admin_config_enabled() {
     // Test that land_admin can be set to true in config
     let (_temp_dir, repo_path) = create_test_repo();

--- a/crates/gg-core/src/commands/log.rs
+++ b/crates/gg-core/src/commands/log.rs
@@ -1,0 +1,283 @@
+//! `gg log` - Smartlog-style view of the current stack
+//!
+//! Renders the current stack as a tree view (bottom-to-top), with PR/MR
+//! status, CI badges, and a HEAD marker. Stack-scoped — to see all stacks,
+//! use `gg ls --all` instead.
+
+use console::style;
+
+use crate::config::Config;
+use crate::error::Result;
+use crate::git;
+use crate::output::{print_json, LogJson, LogResponse, StackEntryJson, OUTPUT_VERSION};
+use crate::provider::{CiStatus, PrState, Provider};
+use crate::stack::Stack;
+
+/// Run the log command
+pub fn run(json: bool, refresh: bool) -> Result<()> {
+    let repo = git::open_repo()?;
+    let git_dir = repo.commondir();
+    let config = Config::load_with_global(git_dir)?;
+
+    let mut stack = Stack::load(&repo, &config)?;
+
+    if should_refresh_mr_info(refresh, json) {
+        if refresh {
+            let provider = Provider::detect(&repo)?;
+            if !json {
+                print!("Refreshing {} status... ", provider.pr_label());
+            }
+            stack.refresh_mr_info(&provider)?;
+            if !json {
+                println!("{}", style("done").green());
+            }
+        } else if let Ok(provider) = Provider::detect(&repo) {
+            stack.refresh_mr_info(&provider)?;
+        }
+    }
+
+    if json {
+        render_json(&stack);
+    } else {
+        render_text(&stack, &repo);
+    }
+
+    Ok(())
+}
+
+fn render_json(stack: &Stack) {
+    let current_pos_1based = stack.current_position.map(|p| p + 1);
+
+    let entries: Vec<StackEntryJson> = stack
+        .entries
+        .iter()
+        .map(|entry| {
+            let is_current = match current_pos_1based {
+                Some(p) => entry.position == p,
+                None => entry.position == stack.len(),
+            };
+
+            StackEntryJson {
+                position: entry.position,
+                sha: entry.short_sha.clone(),
+                title: entry.title.clone(),
+                gg_id: entry.gg_id.clone(),
+                gg_parent: entry.gg_parent.clone(),
+                pr_number: entry.mr_number,
+                pr_state: entry.mr_state.as_ref().map(pr_state_to_json),
+                approved: entry.approved,
+                ci_status: entry.ci_status.as_ref().map(ci_status_to_json),
+                is_current,
+                in_merge_train: entry.in_merge_train,
+                merge_train_position: entry.merge_train_position,
+            }
+        })
+        .collect();
+
+    print_json(&LogResponse {
+        version: OUTPUT_VERSION,
+        log: LogJson {
+            stack: stack.name.clone(),
+            base: stack.base.clone(),
+            current_position: current_pos_1based,
+            entries,
+        },
+    });
+}
+
+fn render_text(stack: &Stack, repo: &git2::Repository) {
+    println!(
+        "{} ({} commits, base: {})",
+        style(&stack.name).cyan().bold(),
+        stack.len(),
+        style(&stack.base).dim(),
+    );
+    println!();
+
+    if git::is_rebase_in_progress(repo) {
+        println!(
+            "{} {}",
+            style("⚠️").yellow(),
+            style("Rebase in progress. Run `gg continue` or `gg abort`")
+                .yellow()
+                .bold()
+        );
+        println!();
+    }
+
+    if stack.is_empty() {
+        println!(
+            "{}",
+            style("  (empty stack — use `git commit` to add changes)").dim()
+        );
+        return;
+    }
+
+    let provider = Provider::detect(repo).ok();
+    let pr_prefix = provider
+        .as_ref()
+        .map(|p| p.pr_number_prefix())
+        .unwrap_or("!");
+
+    let current_pos_0based = stack
+        .current_position
+        .unwrap_or(stack.len().saturating_sub(1));
+    let total = stack.len();
+
+    for (i, entry) in stack.entries.iter().enumerate() {
+        let is_current = i == current_pos_0based;
+        let glyph = glyph_for_position(i, total);
+        let line = format_entry_line(entry, is_current, pr_prefix);
+        println!("  {} {}", style(glyph).dim(), line);
+
+        if let Some(mr_num) = entry.mr_number {
+            let mut mr_line = format!("{}{}", pr_prefix, mr_num);
+
+            if entry.in_merge_train {
+                if let Some(pos) = entry.merge_train_position {
+                    mr_line.push_str(&format!(" [train pos {}]", pos));
+                } else {
+                    mr_line.push_str(" [train]");
+                }
+            }
+
+            let continuation = if i + 1 < total { "│" } else { " " };
+            println!("  {}     {}", style(continuation).dim(), style(&mr_line).blue());
+        }
+    }
+
+    println!();
+}
+
+/// Pick the tree glyph for an entry at index `i` out of `total`.
+///
+/// `├──` for all entries except the last (HEAD), which uses `└──`.
+fn glyph_for_position(i: usize, total: usize) -> &'static str {
+    if i + 1 == total {
+        "└──"
+    } else {
+        "├──"
+    }
+}
+
+/// Format a single entry's display line (without the leading tree glyph).
+fn format_entry_line(
+    entry: &crate::stack::StackEntry,
+    is_current: bool,
+    pr_prefix: &str,
+) -> String {
+    let position = format!("[{}]", entry.position);
+    let sha = &entry.short_sha;
+    let title = &entry.title;
+
+    let status = entry.status_display();
+    let status_styled = match &entry.mr_state {
+        Some(PrState::Merged) => style(&status).green(),
+        Some(PrState::Closed) => style(&status).red(),
+        Some(PrState::Draft) => style(&status).dim(),
+        Some(PrState::Open) if entry.approved => style(&status).green(),
+        Some(PrState::Open) => style(&status).yellow(),
+        None => style(&status).dim(),
+    };
+
+    let ci = match &entry.ci_status {
+        Some(CiStatus::Success) => style("✓").green().to_string(),
+        Some(CiStatus::Failed) => style("✗").red().to_string(),
+        Some(CiStatus::Running) => style("●").yellow().to_string(),
+        Some(CiStatus::Pending) => style("○").dim().to_string(),
+        _ => String::new(),
+    };
+
+    let train = if entry.in_merge_train { " 🚂" } else { "" };
+    let mr_display = entry
+        .mr_number
+        .map(|n| format!(" {}{}", pr_prefix, n))
+        .unwrap_or_default();
+    let head_marker = if is_current { " <- HEAD" } else { "" };
+
+    if is_current {
+        format!(
+            "{} {} {} {} {}{}{}{}",
+            style(&position).bold(),
+            style(sha).yellow().bold(),
+            style(title).bold(),
+            status_styled,
+            ci,
+            train,
+            style(&mr_display).blue(),
+            style(head_marker).cyan().bold(),
+        )
+    } else {
+        format!(
+            "{} {} {} {} {}{}{}",
+            style(&position).dim(),
+            style(sha).yellow(),
+            title,
+            status_styled,
+            ci,
+            train,
+            style(&mr_display).blue(),
+        )
+    }
+}
+
+fn pr_state_to_json(state: &PrState) -> String {
+    match state {
+        PrState::Open => "open".to_string(),
+        PrState::Merged => "merged".to_string(),
+        PrState::Closed => "closed".to_string(),
+        PrState::Draft => "draft".to_string(),
+    }
+}
+
+fn ci_status_to_json(status: &CiStatus) -> String {
+    match status {
+        CiStatus::Pending => "pending".to_string(),
+        CiStatus::Running => "running".to_string(),
+        CiStatus::Success => "success".to_string(),
+        CiStatus::Failed => "failed".to_string(),
+        CiStatus::Canceled => "canceled".to_string(),
+        CiStatus::Unknown => "unknown".to_string(),
+    }
+}
+
+fn should_refresh_mr_info(refresh: bool, json: bool) -> bool {
+    refresh || json
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn glyph_middle_entries_use_tee() {
+        assert_eq!(glyph_for_position(0, 3), "├──");
+        assert_eq!(glyph_for_position(1, 3), "├──");
+    }
+
+    #[test]
+    fn glyph_last_entry_uses_corner() {
+        assert_eq!(glyph_for_position(2, 3), "└──");
+    }
+
+    #[test]
+    fn glyph_single_entry_is_corner() {
+        // Single-entry stack: the lone entry is both first and last.
+        assert_eq!(glyph_for_position(0, 1), "└──");
+    }
+
+    #[test]
+    fn refresh_triggers_on_json_without_flag() {
+        assert!(should_refresh_mr_info(false, true));
+    }
+
+    #[test]
+    fn refresh_triggers_on_explicit_flag() {
+        assert!(should_refresh_mr_info(true, false));
+    }
+
+    #[test]
+    fn refresh_skipped_for_human_output_without_flag() {
+        assert!(!should_refresh_mr_info(false, false));
+    }
+}

--- a/crates/gg-core/src/commands/log.rs
+++ b/crates/gg-core/src/commands/log.rs
@@ -142,7 +142,11 @@ fn render_text(stack: &Stack, repo: &git2::Repository) {
             }
 
             let continuation = if i + 1 < total { "│" } else { " " };
-            println!("  {}     {}", style(continuation).dim(), style(&mr_line).blue());
+            println!(
+                "  {}     {}",
+                style(continuation).dim(),
+                style(&mr_line).blue()
+            );
         }
     }
 

--- a/crates/gg-core/src/commands/log.rs
+++ b/crates/gg-core/src/commands/log.rs
@@ -46,35 +46,37 @@ pub fn run(json: bool, refresh: bool) -> Result<()> {
 }
 
 fn render_json(stack: &Stack) {
+    print_json(&build_log_response(stack));
+}
+
+/// Build the JSON payload for `gg log --json`.
+///
+/// Pure function: no I/O, no formatting. When HEAD isn't mapped to a stack
+/// entry (e.g. detached HEAD), `current_position` is null and no entry is
+/// flagged as current — we do not fall back to marking the tail as HEAD.
+fn build_log_response(stack: &Stack) -> LogResponse {
     let current_pos_1based = stack.current_position.map(|p| p + 1);
 
     let entries: Vec<StackEntryJson> = stack
         .entries
         .iter()
-        .map(|entry| {
-            let is_current = match current_pos_1based {
-                Some(p) => entry.position == p,
-                None => entry.position == stack.len(),
-            };
-
-            StackEntryJson {
-                position: entry.position,
-                sha: entry.short_sha.clone(),
-                title: entry.title.clone(),
-                gg_id: entry.gg_id.clone(),
-                gg_parent: entry.gg_parent.clone(),
-                pr_number: entry.mr_number,
-                pr_state: entry.mr_state.as_ref().map(pr_state_to_json),
-                approved: entry.approved,
-                ci_status: entry.ci_status.as_ref().map(ci_status_to_json),
-                is_current,
-                in_merge_train: entry.in_merge_train,
-                merge_train_position: entry.merge_train_position,
-            }
+        .map(|entry| StackEntryJson {
+            position: entry.position,
+            sha: entry.short_sha.clone(),
+            title: entry.title.clone(),
+            gg_id: entry.gg_id.clone(),
+            gg_parent: entry.gg_parent.clone(),
+            pr_number: entry.mr_number,
+            pr_state: entry.mr_state.as_ref().map(pr_state_to_json),
+            approved: entry.approved,
+            ci_status: entry.ci_status.as_ref().map(ci_status_to_json),
+            is_current: current_pos_1based == Some(entry.position),
+            in_merge_train: entry.in_merge_train,
+            merge_train_position: entry.merge_train_position,
         })
         .collect();
 
-    print_json(&LogResponse {
+    LogResponse {
         version: OUTPUT_VERSION,
         log: LogJson {
             stack: stack.name.clone(),
@@ -82,7 +84,7 @@ fn render_json(stack: &Stack) {
             current_position: current_pos_1based,
             entries,
         },
-    });
+    }
 }
 
 fn render_text(stack: &Stack, repo: &git2::Repository) {
@@ -119,13 +121,12 @@ fn render_text(stack: &Stack, repo: &git2::Repository) {
         .map(|p| p.pr_number_prefix())
         .unwrap_or("!");
 
-    let current_pos_0based = stack
-        .current_position
-        .unwrap_or(stack.len().saturating_sub(1));
     let total = stack.len();
 
     for (i, entry) in stack.entries.iter().enumerate() {
-        let is_current = i == current_pos_0based;
+        // When HEAD isn't mapped to a stack entry (e.g. detached HEAD),
+        // no entry carries the `<- HEAD` marker.
+        let is_current = stack.current_position == Some(i);
         let glyph = glyph_for_position(i, total);
         let line = format_entry_line(entry, is_current, pr_prefix);
         println!("  {} {}", style(glyph).dim(), line);
@@ -252,6 +253,53 @@ fn should_refresh_mr_info(refresh: bool, json: bool) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::stack::StackEntry;
+
+    fn fake_entry(position: usize, title: &str) -> StackEntry {
+        StackEntry {
+            oid: git2::Oid::zero(),
+            short_sha: format!("sha{position}"),
+            title: title.to_string(),
+            gg_id: Some(format!("c-fake{position}")),
+            gg_parent: None,
+            mr_number: None,
+            mr_state: None,
+            approved: false,
+            ci_status: None,
+            position,
+            in_merge_train: false,
+            merge_train_position: None,
+        }
+    }
+
+    fn fake_stack(current_position: Option<usize>) -> Stack {
+        Stack {
+            name: "demo".to_string(),
+            username: "tester".to_string(),
+            base: "main".to_string(),
+            entries: vec![fake_entry(1, "first"), fake_entry(2, "second")],
+            current_position,
+        }
+    }
+
+    #[test]
+    fn json_marks_current_entry_when_head_maps_to_stack() {
+        let response = build_log_response(&fake_stack(Some(1)));
+        assert_eq!(response.log.current_position, Some(2));
+        assert!(!response.log.entries[0].is_current);
+        assert!(response.log.entries[1].is_current);
+    }
+
+    #[test]
+    fn json_flags_no_current_when_head_is_detached() {
+        // Regression: when HEAD is not part of the stack (detached HEAD onto an
+        // unrelated commit) current_position is None — the JSON must mirror
+        // that by reporting `current_position: null` AND `is_current: false`
+        // on every entry, not forcing the tail to be current.
+        let response = build_log_response(&fake_stack(None));
+        assert_eq!(response.log.current_position, None);
+        assert!(response.log.entries.iter().all(|e| !e.is_current));
+    }
 
     #[test]
     fn glyph_middle_entries_use_tee() {

--- a/crates/gg-core/src/commands/mod.rs
+++ b/crates/gg-core/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod completions;
 pub mod drop_cmd;
 pub mod land;
 pub mod lint;
+pub mod log;
 pub mod ls;
 pub mod nav;
 pub mod rebase;

--- a/crates/gg-core/src/output.rs
+++ b/crates/gg-core/src/output.rs
@@ -362,3 +362,17 @@ pub struct DroppedEntryJson {
     pub sha: String,
     pub title: String,
 }
+
+#[derive(Serialize)]
+pub struct LogResponse {
+    pub version: u32,
+    pub log: LogJson,
+}
+
+#[derive(Serialize)]
+pub struct LogJson {
+    pub stack: String,
+    pub base: String,
+    pub current_position: Option<usize>,
+    pub entries: Vec<StackEntryJson>,
+}

--- a/crates/gg-mcp/src/tools.rs
+++ b/crates/gg-mcp/src/tools.rs
@@ -457,10 +457,7 @@ impl GgMcpServer {
     #[tool(
         description = "Show a smartlog-style view of the current stack (positions, SHAs, titles, PR/MR status, HEAD marker). Stack-scoped — use stack_list_all for all stacks."
     )]
-    fn stack_log(
-        &self,
-        Parameters(params): Parameters<StackLogParams>,
-    ) -> Result<String, String> {
+    fn stack_log(&self, Parameters(params): Parameters<StackLogParams>) -> Result<String, String> {
         let repo = open_repo()?;
         let config = load_config(&repo)?;
         let mut stack = load_stack(&repo, &config)?;

--- a/crates/gg-mcp/src/tools.rs
+++ b/crates/gg-mcp/src/tools.rs
@@ -97,6 +97,14 @@ struct StackInfo {
 }
 
 #[derive(Debug, Serialize)]
+struct StackLogInfo {
+    stack: String,
+    base: String,
+    current_position: Option<usize>,
+    entries: Vec<StackEntryInfo>,
+}
+
+#[derive(Debug, Serialize)]
 struct StackSummary {
     name: String,
     base: String,
@@ -127,6 +135,13 @@ struct ConfigInfo {
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct StackListParams {
     /// Refresh PR/MR status from remote before listing
+    #[serde(default)]
+    pub refresh: bool,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct StackLogParams {
+    /// Refresh PR/MR status from remote before rendering
     #[serde(default)]
     pub refresh: bool,
 }
@@ -433,6 +448,39 @@ impl GgMcpServer {
 
         let info = build_stack_info(&stack, &repo);
         Ok(to_json(&info))
+    }
+
+    /// Render the current stack as a smartlog-style view.
+    /// Returns a stack-scoped view with positions, SHAs, titles, GG-IDs,
+    /// PR/MR state, CI status, and a flag marking the HEAD entry. Use
+    /// `stack_list_all` for cross-stack browsing.
+    #[tool(
+        description = "Show a smartlog-style view of the current stack (positions, SHAs, titles, PR/MR status, HEAD marker). Stack-scoped — use stack_list_all for all stacks."
+    )]
+    fn stack_log(
+        &self,
+        Parameters(params): Parameters<StackLogParams>,
+    ) -> Result<String, String> {
+        let repo = open_repo()?;
+        let config = load_config(&repo)?;
+        let mut stack = load_stack(&repo, &config)?;
+
+        if params.refresh {
+            let provider =
+                Provider::detect(&repo).map_err(|e| McpToolError::ProviderDetect(e.to_string()))?;
+            stack
+                .refresh_mr_info(&provider)
+                .map_err(McpToolError::ConfigLoad)?;
+        }
+
+        let info = build_stack_info(&stack, &repo);
+        let log_info = StackLogInfo {
+            stack: info.name,
+            base: info.base,
+            current_position: info.current_position,
+            entries: info.entries,
+        };
+        Ok(to_json(&log_info))
     }
 
     /// List all stacks in the repository with summary information.

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -15,6 +15,7 @@
 - [Command Reference](./commands/README.md)
   - [co (checkout)](./commands/co.md)
   - [ls](./commands/ls.md)
+  - [log](./commands/log.md)
   - [sync](./commands/sync.md)
   - [Navigation (mv / first / last / prev / next)](./commands/navigation.md)
   - [sc (squash/amend)](./commands/sc.md)

--- a/docs/src/commands/log.md
+++ b/docs/src/commands/log.md
@@ -1,0 +1,69 @@
+# `gg log`
+
+Show a smartlog-style view of the current stack.
+
+`gg log` is **stack-scoped**: it renders just the current stack as a tree,
+with each commit's position, short SHA, title, PR/MR state, CI badge, and a
+`<- HEAD` marker on the currently-checked-out commit. For a cross-stack
+overview use [`gg ls --all`](./ls.md).
+
+```bash
+gg log [OPTIONS]
+```
+
+## Options
+
+- `-r, --refresh`: Refresh PR/MR status from the remote before rendering.
+- `--json`: Print structured JSON output (for scripts and automation).
+  Automatically performs a best-effort refresh of PR/MR state from the
+  provider API, so `pr_state` and `ci_status` fields are populated without
+  needing `--refresh`.
+
+## Example output
+
+```text
+my-feature (3 commits, base: main)
+
+  ├── [1] abc1234 feat: add parser open #101 ✓
+  │        #101
+  ├── [2] def5678 feat: wire CLI flag open #102 ●
+  │        #102
+  └── [3] 9abcdef test: coverage for edge cases not pushed  <- HEAD
+```
+
+## JSON shape
+
+```json
+{
+  "version": 1,
+  "log": {
+    "stack": "my-feature",
+    "base": "main",
+    "current_position": 3,
+    "entries": [
+      {
+        "position": 1,
+        "sha": "abc1234",
+        "title": "feat: add parser",
+        "gg_id": "c-abc1234",
+        "gg_parent": null,
+        "pr_number": 101,
+        "pr_state": "open",
+        "approved": false,
+        "ci_status": "success",
+        "is_current": false,
+        "in_merge_train": false,
+        "merge_train_position": null
+      }
+    ]
+  }
+}
+```
+
+Entry fields match [`gg ls --json`](./ls.md) so consumers can share
+parsers across both commands.
+
+## See also
+
+- [`gg ls`](./ls.md) — current stack details with more summary metrics, plus
+  `--all` and `--remote` modes.

--- a/docs/src/mcp-server.md
+++ b/docs/src/mcp-server.md
@@ -46,6 +46,15 @@ List the current stack with commit entries and PR/MR status.
 
 **Returns:** Stack name, base branch, commit entries with positions, SHAs, titles, GG-IDs, PR numbers, states, CI status, and approval status.
 
+### `stack_log`
+
+Render the current stack as a smartlog-style view (stack-scoped). Mirrors the CLI `gg log --json` output.
+
+**Parameters:**
+- `refresh` (boolean, optional): Refresh PR/MR status from remote before rendering. Default: `false`.
+
+**Returns:** `{ stack, base, current_position, entries: [...] }`. Entry fields match `stack_list`. Use `stack_list_all` when you need a cross-stack overview.
+
 ### `stack_list_all`
 
 List all stacks in the repository with summary information.

--- a/skills/gg/SKILL.md
+++ b/skills/gg/SKILL.md
@@ -96,7 +96,8 @@ git commit -m "feat: add input validation"
 3. Check stack state:
 
 ```bash
-gg ls --json
+gg ls --json        # single-stack details + summary metrics
+gg log --json       # smartlog-style view of the current stack
 ```
 
 4. Publish/update PR/MR chain:
@@ -241,7 +242,7 @@ Reconcile is skipped under `--until` to avoid partial-stack inconsistencies.
 The `gg-mcp` binary exposes git-gud as an MCP server (stdio transport). Set `GG_REPO_PATH` to the target repo.
 
 ### Read-only tools (safe, no side effects)
-- `stack_list` / `stack_list_all` / `stack_status` — inspect stacks
+- `stack_list` / `stack_log` / `stack_list_all` / `stack_status` — inspect stacks (`stack_log` gives a smartlog-style view of the current stack; `stack_list_all` is cross-stack)
 - `pr_info` — check PR state, CI, approval
 - `config_show` — read repo configuration
 

--- a/skills/gg/reference.md
+++ b/skills/gg/reference.md
@@ -66,6 +66,14 @@ List current/all/remote stacks.
 - `--remote`
 - `--json`
 
+#### `gg log [OPTIONS]`
+Smartlog-style view of the **current** stack (tree with HEAD marker, PR/CI
+badges). Stack-scoped — use `gg ls --all` for cross-stack browsing.
+
+- `-r, --refresh`
+- `--json` (auto-refreshes PR/MR state; shape mirrors `gg ls --json` entries
+  under a `log` key)
+
 #### `gg sync [OPTIONS]`
 Push and create/update PRs/MRs.
 
@@ -308,6 +316,37 @@ Field types:
 }
 ```
 
+### `gg log --json`
+
+```json
+{
+  "version": 1,
+  "log": {
+    "stack": "feature-auth",
+    "base": "main",
+    "current_position": 2,
+    "entries": [
+      {
+        "position": 1,
+        "sha": "abc1234",
+        "title": "feat: add parser",
+        "gg_id": "c-abc1234",
+        "gg_parent": null,
+        "pr_number": 101,
+        "pr_state": "open",
+        "approved": false,
+        "ci_status": "success",
+        "is_current": false,
+        "in_merge_train": false,
+        "merge_train_position": null
+      }
+    ]
+  }
+}
+```
+
+Entry fields match `gg ls --json` so consumers can share parsers.
+
 ### `gg sync --json`
 
 ```json
@@ -465,6 +504,11 @@ Transport: stdio (JSON-RPC over stdin/stdout).
 List the current stack with commit entries and PR/MR status.
 - **Params:** `refresh` (bool, default false) — refresh PR status from remote
 - **Returns:** `{ name, base, total_commits, synced_commits, current_position, entries: [{ position, sha, title, gg_id, gg_parent, pr_number, pr_state, approved, ci_status, is_current }] }`
+
+#### `stack_log`
+Smartlog-style view of the current stack (stack-scoped). Mirrors `gg log --json`.
+- **Params:** `refresh` (bool, default false) — refresh PR status from remote
+- **Returns:** `{ stack, base, current_position, entries: [...] }` (entry fields match `stack_list`)
 
 #### `stack_list_all`
 List all stacks in the repository.


### PR DESCRIPTION
## Summary

- Add a first-class `gg log` command that renders the **current stack**
  as a smartlog-style tree (positions, short SHAs, titles, PR/MR status,
  CI badges, `<- HEAD` marker). Stack-scoped by design — cross-stack
  browsing stays under `gg ls --all`.
- Support `--json` (auto-refreshes PR state from the provider, same
  contract as `gg ls --json`) and `-r/--refresh` for human-readable
  output.
- Reuse `Stack::load` and `StackEntryJson` so CLI, MCP, and docs share
  one data shape.
- Ship the matching MCP tool `stack_log` in the same PR, mirroring the
  CLI JSON output under a `log` key.
- Update docs (`docs/src/commands/log.md`, `SUMMARY.md`,
  `mcp-server.md`) and the gg agent skill (`SKILL.md`, `reference.md`).

## Test plan

- [x] `cargo test --workspace` (604 passing)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] New integration tests cover: tree rendering with glyphs/positions/
      HEAD marker, `--json` shape, empty stack, and off-stack failure in
      both text and JSON output.
- [x] `gg log --help` surfaces the new command and flags.