### PR TITLE
feat: add immutability guard for history-rewriting commands (#415)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Immutability guard for history-rewriting commands: `gg sc`, `gg drop`,
+  `gg reorder`/`gg arrange`, `gg split`, `gg absorb`, and `gg rebase` now
+  refuse by default to rewrite commits whose PR/MR is already merged or which
+  are already reachable from `origin/<base>`. A new `-f, --force` flag (alias
+  `--ignore-immutable`) bypasses the check for each of these commands.
+
+### Changed
+- `gg drop --force` now *also* overrides the immutability check, in addition
+  to skipping the existing confirmation prompt. Scripts that previously
+  relied on `--force` to silently rewrite merged commits will continue to
+  succeed; interactive users get a stronger safety net before they opt in.
+
 ## [0.8.3] - 2026-04-16
 
 ### Added

--- a/crates/gg-cli/src/main.rs
+++ b/crates/gg-cli/src/main.rs
@@ -133,9 +133,15 @@ enum Commands {
     Drop {
         /// Commits to drop: position (1-indexed), short SHA, or GG-ID
         targets: Vec<String>,
-        /// Skip confirmation prompt and override the immutability check
-        #[arg(short, long, alias = "ignore-immutable")]
+        /// Override the immutability check and rewrite merged/base commits
+        /// anyway. Implies `--yes`.
+        #[arg(short = 'f', long = "force", alias = "ignore-immutable")]
         force: bool,
+        /// Skip the confirmation prompt without bypassing the immutability
+        /// guard. Use this for non-interactive callers that still want
+        /// merged/base commits protected.
+        #[arg(short = 'y', long = "yes")]
+        yes: bool,
         /// Output as JSON
         #[arg(long)]
         json: bool,
@@ -450,11 +456,13 @@ fn main() {
         Some(Commands::Drop {
             targets,
             force,
+            yes,
             json,
         }) => (
             gg_core::commands::drop_cmd::run(gg_core::commands::drop_cmd::DropOptions {
                 targets,
                 force,
+                yes,
                 json,
             }),
             json,

--- a/crates/gg-cli/src/main.rs
+++ b/crates/gg-cli/src/main.rs
@@ -122,6 +122,10 @@ enum Commands {
         /// Squash all changes (staged and unstaged)
         #[arg(short, long)]
         all: bool,
+
+        /// Override the immutability check and rewrite merged/base commits anyway
+        #[arg(short = 'f', long = "force", alias = "ignore-immutable")]
+        force: bool,
     },
 
     /// Drop (remove) commits from the stack
@@ -129,8 +133,8 @@ enum Commands {
     Drop {
         /// Commits to drop: position (1-indexed), short SHA, or GG-ID
         targets: Vec<String>,
-        /// Skip confirmation prompt
-        #[arg(short, long)]
+        /// Skip confirmation prompt and override the immutability check
+        #[arg(short, long, alias = "ignore-immutable")]
         force: bool,
         /// Output as JSON
         #[arg(long)]
@@ -148,6 +152,10 @@ enum Commands {
         /// Disable TUI, use text editor instead
         #[arg(long)]
         no_tui: bool,
+
+        /// Override the immutability check and rewrite merged/base commits anyway
+        #[arg(short = 'f', long = "force", alias = "ignore-immutable")]
+        force: bool,
     },
 
     /// Split a commit into two
@@ -168,6 +176,10 @@ enum Commands {
         /// Disable TUI, use sequential prompt instead
         #[arg(long)]
         no_tui: bool,
+
+        /// Override the immutability check and rewrite merged/base commits anyway
+        #[arg(short = 'f', long = "force", alias = "ignore-immutable")]
+        force: bool,
 
         /// Files to include in the new commit
         #[arg(value_name = "FILES")]
@@ -231,6 +243,10 @@ enum Commands {
     Rebase {
         /// Target branch to rebase onto (default: base branch)
         target: Option<String>,
+
+        /// Override the immutability check and rewrite merged/base commits anyway
+        #[arg(short = 'f', long = "force", alias = "ignore-immutable")]
+        force: bool,
     },
 
     /// Continue a paused operation (rebase, etc.)
@@ -319,6 +335,10 @@ enum Commands {
         /// Squash fixup commits directly instead of creating fixup! commits for later rebase.
         #[arg(short = 's', long)]
         squash: bool,
+
+        /// Override the immutability check and rewrite merged/base commits anyway
+        #[arg(short = 'f', long = "force", alias = "ignore-immutable")]
+        force: bool,
     },
 
     /// Generate shell completions
@@ -340,6 +360,10 @@ enum Commands {
         /// Disable TUI, use text editor instead
         #[arg(long)]
         no_tui: bool,
+
+        /// Override the immutability check and rewrite merged/base commits anyway
+        #[arg(short = 'f', long = "force", alias = "ignore-immutable")]
+        force: bool,
     },
 
     /// Reconcile stacks that were pushed without using `gg sync`
@@ -420,7 +444,9 @@ fn main() {
         Some(Commands::Last) => (gg_core::commands::nav::last(), false),
         Some(Commands::Prev) => (gg_core::commands::nav::prev(), false),
         Some(Commands::Next) => (gg_core::commands::nav::next(), false),
-        Some(Commands::Squash { all }) => (gg_core::commands::squash::run(all), false),
+        Some(Commands::Squash { all, force }) => {
+            (gg_core::commands::squash::run(all, force), false)
+        }
         Some(Commands::Drop {
             targets,
             force,
@@ -433,10 +459,15 @@ fn main() {
             }),
             json,
         ),
-        Some(Commands::Reorder { order, no_tui }) => (
+        Some(Commands::Reorder {
+            order,
+            no_tui,
+            force,
+        }) => (
             gg_core::commands::reorder::run(gg_core::commands::reorder::ReorderOptions {
                 order,
                 no_tui,
+                force,
             }),
             false,
         ),
@@ -445,6 +476,7 @@ fn main() {
             message,
             no_edit,
             no_tui,
+            force,
             files,
         }) => (
             gg_core::commands::split::run(gg_core::commands::split::SplitOptions {
@@ -453,6 +485,7 @@ fn main() {
                 message,
                 no_edit,
                 no_tui,
+                force,
             }),
             false,
         ),
@@ -499,7 +532,9 @@ fn main() {
             )
         }
         Some(Commands::Clean { all, json }) => (gg_core::commands::clean::run(all, json), json),
-        Some(Commands::Rebase { target }) => (gg_core::commands::rebase::run(target), false),
+        Some(Commands::Rebase { target, force }) => {
+            (gg_core::commands::rebase::run(target, force), false)
+        }
         Some(Commands::Continue) => (gg_core::commands::rebase::continue_rebase(), false),
         Some(Commands::Abort) => (gg_core::commands::rebase::abort_rebase(), false),
         Some(Commands::Lint { until, json }) => (
@@ -551,6 +586,7 @@ fn main() {
             one_fixup_per_commit,
             no_limit,
             squash,
+            force,
         }) => (
             gg_core::commands::absorb::run(gg_core::commands::absorb::AbsorbOptions {
                 dry_run,
@@ -559,13 +595,19 @@ fn main() {
                 one_fixup_per_commit,
                 no_limit,
                 squash,
+                force,
             }),
             false,
         ),
-        Some(Commands::Arrange { order, no_tui }) => (
+        Some(Commands::Arrange {
+            order,
+            no_tui,
+            force,
+        }) => (
             gg_core::commands::reorder::run(gg_core::commands::reorder::ReorderOptions {
                 order,
                 no_tui,
+                force,
             }),
             false,
         ),

--- a/crates/gg-core/src/commands/absorb.rs
+++ b/crates/gg-core/src/commands/absorb.rs
@@ -74,7 +74,10 @@ pub fn run(options: AbsorbOptions) -> Result<()> {
     }
 
     // Load stack to get the base
-    let stack = Stack::load(&repo, &gg_config)?;
+    let mut stack = Stack::load(&repo, &gg_config)?;
+    // Best-effort refresh of mr_state for the immutability guard (catches
+    // squash-merged PRs that base-ancestor would otherwise miss).
+    immutability::refresh_mr_state_for_guard(&repo, &mut stack);
 
     if stack.is_empty() {
         return Err(GgError::Other(

--- a/crates/gg-core/src/commands/absorb.rs
+++ b/crates/gg-core/src/commands/absorb.rs
@@ -12,6 +12,7 @@ use slog::{o, Drain, Logger};
 use crate::config::Config;
 use crate::error::{GgError, Result};
 use crate::git;
+use crate::immutability::{self, ImmutabilityPolicy};
 use crate::stack::Stack;
 
 /// Options for the absorb command
@@ -29,6 +30,9 @@ pub struct AbsorbOptions {
     pub no_limit: bool,
     /// Squash absorbed changes directly instead of creating fixup commits
     pub squash: bool,
+    /// Override the immutability check (any stack commit being flagged as
+    /// merged or base-ancestor would otherwise abort the operation).
+    pub force: bool,
 }
 
 /// Run the absorb command
@@ -76,6 +80,16 @@ pub fn run(options: AbsorbOptions) -> Result<()> {
         return Err(GgError::Other(
             "Stack is empty. Use `git commit` to create commits first.".to_string(),
         ));
+    }
+
+    // Immutability pre-flight: enumerating exactly which commits git-absorb
+    // will target requires re-running its scoring logic. v1 is conservative:
+    // if any commit in the stack is immutable, refuse unless --force. Skip
+    // the check on dry-run so users can inspect the would-be-changes.
+    if !options.dry_run {
+        let policy = ImmutabilityPolicy::for_stack(&repo, &stack)?;
+        let report = policy.check_all(&stack);
+        immutability::guard(report, options.force)?;
     }
 
     // Determine the base reference for absorb

--- a/crates/gg-core/src/commands/drop_cmd.rs
+++ b/crates/gg-core/src/commands/drop_cmd.rs
@@ -17,8 +17,13 @@ use crate::stack::{self, Stack};
 pub struct DropOptions {
     /// Targets to drop: position (1-indexed), short SHA, or GG-ID
     pub targets: Vec<String>,
-    /// Skip confirmation prompt
+    /// Override the immutability check for merged/base-ancestor commits.
+    /// Implies `yes` (skipping confirmation is a superset of bypassing the guard).
     pub force: bool,
+    /// Skip the interactive confirmation prompt without bypassing the
+    /// immutability guard. Use this for non-interactive callers (CI, MCP)
+    /// that do not want to silently rewrite merged commits.
+    pub yes: bool,
     /// Output as JSON
     pub json: bool,
 }
@@ -91,8 +96,10 @@ pub fn run(options: DropOptions) -> Result<()> {
         });
     }
 
-    // Show what will be dropped
-    if !options.json && !options.force {
+    // Show what will be dropped. Skip the prompt when the caller has opted
+    // out (`--yes`), is bypassing immutability (`--force`, which implies
+    // yes), or is running in JSON mode.
+    if !options.json && !options.force && !options.yes {
         println!(
             "{} Will drop {} commit(s):",
             style("Drop").red().bold(),
@@ -224,6 +231,7 @@ mod tests {
         let opts = DropOptions::default();
         assert!(opts.targets.is_empty());
         assert!(!opts.force);
+        assert!(!opts.yes);
         assert!(!opts.json);
     }
 
@@ -232,9 +240,24 @@ mod tests {
         let opts = DropOptions {
             targets: vec!["1".to_string(), "c-abc1234".to_string()],
             force: true,
+            yes: false,
             json: false,
         };
         assert_eq!(opts.targets.len(), 2);
         assert!(opts.force);
+    }
+
+    #[test]
+    fn test_drop_options_yes_without_force() {
+        // Non-interactive callers (CI, MCP) should be able to skip the
+        // prompt without silently bypassing the immutability guard.
+        let opts = DropOptions {
+            targets: vec!["2".to_string()],
+            force: false,
+            yes: true,
+            json: true,
+        };
+        assert!(!opts.force);
+        assert!(opts.yes);
     }
 }

--- a/crates/gg-core/src/commands/drop_cmd.rs
+++ b/crates/gg-core/src/commands/drop_cmd.rs
@@ -40,7 +40,10 @@ pub fn run(options: DropOptions) -> Result<()> {
     git::require_clean_working_directory(&repo)?;
 
     // Load stack
-    let stack_obj = Stack::load(&repo, &config)?;
+    let mut stack_obj = Stack::load(&repo, &config)?;
+    // Best-effort refresh of mr_state for the immutability guard (catches
+    // squash-merged PRs that base-ancestor would otherwise miss).
+    immutability::refresh_mr_state_for_guard(&repo, &mut stack_obj);
 
     if stack_obj.is_empty() {
         return Err(GgError::Other("Stack is empty".to_string()));

--- a/crates/gg-core/src/commands/drop_cmd.rs
+++ b/crates/gg-core/src/commands/drop_cmd.rs
@@ -8,6 +8,7 @@ use dialoguer::Confirm;
 use crate::config::Config;
 use crate::error::{GgError, Result};
 use crate::git;
+use crate::immutability::{self, ImmutabilityPolicy};
 use crate::output::{print_json, DropResponse, DropResultJson, DroppedEntryJson, OUTPUT_VERSION};
 use crate::stack::{self, Stack};
 
@@ -61,6 +62,20 @@ pub fn run(options: DropOptions) -> Result<()> {
         return Err(GgError::Other(
             "Cannot drop all commits from the stack. At least one commit must remain.".to_string(),
         ));
+    }
+
+    // Immutability pre-flight: dropping a commit rewrites the stack from the
+    // lowest dropped position upward (parents change for every kept commit
+    // above). Check the dropped positions themselves and every position above
+    // the lowest drop.
+    if let Some(&min_drop) = drop_positions.iter().min() {
+        let mut targets: Vec<usize> = drop_positions.clone();
+        for pos in (min_drop + 1)..=stack_obj.len() {
+            targets.push(pos);
+        }
+        let policy = ImmutabilityPolicy::for_stack(&repo, &stack_obj)?;
+        let report = policy.check_positions(&stack_obj, &targets);
+        immutability::guard(report, options.force)?;
     }
 
     // Build list of entries to drop for display and JSON

--- a/crates/gg-core/src/commands/land.rs
+++ b/crates/gg-core/src/commands/land.rs
@@ -884,7 +884,11 @@ pub fn run(opts: LandOptions) -> Result<()> {
         };
 
         if should_clean && !has_unsynced_commits_before_merge {
-            let _ = crate::commands::rebase::run_with_repo(&repo, Some(stack.base.clone()), json);
+            // After landing, the stack contains merged commits by definition.
+            // Bypass the immutability guard since the rebase here is a
+            // sanctioned cleanup step, not a user-driven history rewrite.
+            let _ =
+                crate::commands::rebase::run_with_repo(&repo, Some(stack.base.clone()), json, true);
             if crate::commands::clean::run_for_stack_with_repo(&repo, &stack.name, true).is_ok() {
                 cleaned = true;
             }

--- a/crates/gg-core/src/commands/rebase.rs
+++ b/crates/gg-core/src/commands/rebase.rs
@@ -92,8 +92,12 @@ pub fn run_with_repo(
     // parent chain. If any commit is merged or already on the (freshly
     // fetched) base, refuse without --force. Must run *after* the fetch so
     // origin/<base> reflects the latest remote state.
-    if let Ok(stack) = Stack::load(repo, &config) {
+    if let Ok(mut stack) = Stack::load(repo, &config) {
         if !stack.is_empty() {
+            // Best-effort refresh of mr_state so the guard catches
+            // squash-merged PRs (their merge SHA isn't on origin/<base>, so
+            // the base-ancestor rule misses them). No-op when offline.
+            immutability::refresh_mr_state_for_guard(repo, &mut stack);
             let policy = ImmutabilityPolicy::for_stack(repo, &stack)?;
             let report = policy.check_all(&stack);
             immutability::guard(report, force)?;

--- a/crates/gg-core/src/commands/rebase.rs
+++ b/crates/gg-core/src/commands/rebase.rs
@@ -28,33 +28,11 @@ pub fn run_with_repo(
 ) -> Result<()> {
     let config = Config::load_with_global(repo.commondir())?;
 
-    // Immutability pre-flight: rebase rewrites every commit in the stack's
-    // parent chain. If any commit is merged or already on the base, refuse
-    // without --force. Only runs when the working directory is clean (we
-    // don't want to trip on stashed / un-loadable state).
-    if let Ok(stack) = Stack::load(repo, &config) {
-        if !stack.is_empty() {
-            let policy = ImmutabilityPolicy::for_stack(repo, &stack)?;
-            let report = policy.check_all(&stack);
-            immutability::guard(report, force)?;
-        }
-    }
-
-    // Auto-stash uncommitted changes if present
-    let needs_stash = !git::is_working_directory_clean(repo)?;
-    if needs_stash {
-        if !json {
-            println!("{}", style("Auto-stashing uncommitted changes...").dim());
-        }
-        git::run_git_command(&["stash", "push", "-m", "gg-rebase-autostash"])?;
-    }
-
-    // Determine target branch
-    // If no target provided, we need to be on a stack to get the base branch
+    // Determine target branch. If no target provided, we need to be on a
+    // stack to get the base branch.
     let target_branch = if let Some(t) = target {
         t
     } else {
-        // No target provided, must be on a stack
         let stack = Stack::load(repo, &config)?;
         stack.base.clone()
     };
@@ -69,7 +47,10 @@ pub fn run_with_repo(
         );
     }
 
-    // Fetch the latest from remote first
+    // Fetch the latest from remote first. We want fresh origin/<base> for
+    // both the immutability guard and the rebase itself — running the guard
+    // against stale refs can silently pass on a newly-merged commit and
+    // then rewrite it after the fetch updates the ref.
     let fetch_result = git::run_git_command(&["fetch", "origin", "--prune"]);
     if let Err(e) = fetch_result {
         if !json {
@@ -105,6 +86,28 @@ pub fn run_with_repo(
     // Return to stack branch if we switched away
     if let Some(ref branch) = current_branch {
         let _ = git::run_git_command(&["checkout", branch]);
+    }
+
+    // Immutability pre-flight: rebase rewrites every commit in the stack's
+    // parent chain. If any commit is merged or already on the (freshly
+    // fetched) base, refuse without --force. Must run *after* the fetch so
+    // origin/<base> reflects the latest remote state.
+    if let Ok(stack) = Stack::load(repo, &config) {
+        if !stack.is_empty() {
+            let policy = ImmutabilityPolicy::for_stack(repo, &stack)?;
+            let report = policy.check_all(&stack);
+            immutability::guard(report, force)?;
+        }
+    }
+
+    // Auto-stash uncommitted changes if present. Done after the guard so we
+    // don't create a stash we'll have to restore if the guard rejects.
+    let needs_stash = !git::is_working_directory_clean(repo)?;
+    if needs_stash {
+        if !json {
+            println!("{}", style("Auto-stashing uncommitted changes...").dim());
+        }
+        git::run_git_command(&["stash", "push", "-m", "gg-rebase-autostash"])?;
     }
 
     // Perform the rebase

--- a/crates/gg-core/src/commands/rebase.rs
+++ b/crates/gg-core/src/commands/rebase.rs
@@ -6,21 +6,39 @@ use git2::Repository;
 use crate::config::Config;
 use crate::error::{GgError, Result};
 use crate::git;
+use crate::immutability::{self, ImmutabilityPolicy};
 use crate::stack::Stack;
 
 /// Run the rebase command
-pub fn run(target: Option<String>) -> Result<()> {
+pub fn run(target: Option<String>, force: bool) -> Result<()> {
     let repo = git::open_repo()?;
 
     // Acquire operation lock to prevent concurrent operations
     let _lock = git::acquire_operation_lock(&repo, "rebase")?;
 
-    run_with_repo(&repo, target, false)
+    run_with_repo(&repo, target, false, force)
 }
 
 /// Run rebase with an already-open repository (no lock acquisition)
-pub fn run_with_repo(repo: &Repository, target: Option<String>, json: bool) -> Result<()> {
+pub fn run_with_repo(
+    repo: &Repository,
+    target: Option<String>,
+    json: bool,
+    force: bool,
+) -> Result<()> {
     let config = Config::load_with_global(repo.commondir())?;
+
+    // Immutability pre-flight: rebase rewrites every commit in the stack's
+    // parent chain. If any commit is merged or already on the base, refuse
+    // without --force. Only runs when the working directory is clean (we
+    // don't want to trip on stashed / un-loadable state).
+    if let Ok(stack) = Stack::load(repo, &config) {
+        if !stack.is_empty() {
+            let policy = ImmutabilityPolicy::for_stack(repo, &stack)?;
+            let report = policy.check_all(&stack);
+            immutability::guard(report, force)?;
+        }
+    }
 
     // Auto-stash uncommitted changes if present
     let needs_stash = !git::is_working_directory_clean(repo)?;

--- a/crates/gg-core/src/commands/reorder.rs
+++ b/crates/gg-core/src/commands/reorder.rs
@@ -9,6 +9,7 @@ use super::reorder_tui::{self, ReorderEntry};
 use crate::config::Config;
 use crate::error::{GgError, Result};
 use crate::git;
+use crate::immutability::{self, ImmutabilityPolicy};
 use crate::stack::Stack;
 
 /// Options for the reorder command
@@ -19,6 +20,8 @@ pub struct ReorderOptions {
     pub order: Option<String>,
     /// If true, disable TUI and use editor fallback
     pub no_tui: bool,
+    /// If true, override the immutability check
+    pub force: bool,
 }
 
 /// Run the reorder command
@@ -71,6 +74,18 @@ pub fn run(options: ReorderOptions) -> Result<()> {
         return Ok(());
     }
 
+    // Immutability pre-flight: the rebase rewrites parents for every commit
+    // from the lowest changed position upward, so check that span. Dropped
+    // commits count as "changes" too (anything missing from new_order needs
+    // to be included in the check).
+    let min_change = lowest_change_position(&old_order, &new_order);
+    if let Some(min) = min_change {
+        let targets: Vec<usize> = (min..=stack.len()).collect();
+        let policy = ImmutabilityPolicy::for_stack(&repo, &stack)?;
+        let report = policy.check_positions(&stack, &targets);
+        immutability::guard(report, options.force)?;
+    }
+
     let dropped_count = stack.len() - new_order.len();
     if dropped_count > 0 {
         println!(
@@ -109,6 +124,25 @@ pub fn run(options: ReorderOptions) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Find the lowest (1-indexed) stack position whose SHA differs between the
+/// old and new orderings. If positions match up to the shorter length but
+/// the new order is shorter (commits dropped from the tail), the first
+/// missing position is returned. Returns `None` if nothing changed.
+fn lowest_change_position(old_order: &[&str], new_order: &[String]) -> Option<usize> {
+    for i in 0..new_order.len().min(old_order.len()) {
+        if new_order[i].as_str() != old_order[i] {
+            return Some(i + 1);
+        }
+    }
+    if new_order.len() != old_order.len() {
+        // Either extra entries in new_order (unreachable in reorder) or
+        // trailing entries were dropped.
+        Some(new_order.len().min(old_order.len()) + 1)
+    } else {
+        None
+    }
 }
 
 /// Parse order from a string like "3,1,2" or "3 1 2" (positions) or "abc123,def456" (SHAs)

--- a/crates/gg-core/src/commands/reorder.rs
+++ b/crates/gg-core/src/commands/reorder.rs
@@ -460,4 +460,82 @@ mod tests {
             ])
         );
     }
+
+    #[test]
+    fn lowest_change_position_returns_none_for_identical_orderings() {
+        let old_order = ["aaa1111", "bbb2222", "ccc3333"];
+        let new_order = vec![
+            "aaa1111".to_string(),
+            "bbb2222".to_string(),
+            "ccc3333".to_string(),
+        ];
+        assert_eq!(lowest_change_position(&old_order, &new_order), None);
+    }
+
+    #[test]
+    fn lowest_change_position_detects_first_element_change() {
+        let old_order = ["aaa1111", "bbb2222", "ccc3333"];
+        let new_order = vec![
+            "ccc3333".to_string(),
+            "bbb2222".to_string(),
+            "aaa1111".to_string(),
+        ];
+        assert_eq!(lowest_change_position(&old_order, &new_order), Some(1));
+    }
+
+    #[test]
+    fn lowest_change_position_detects_middle_element_change() {
+        let old_order = ["aaa1111", "bbb2222", "ccc3333"];
+        let new_order = vec![
+            "aaa1111".to_string(),
+            "ccc3333".to_string(),
+            "bbb2222".to_string(),
+        ];
+        assert_eq!(lowest_change_position(&old_order, &new_order), Some(2));
+    }
+
+    #[test]
+    fn lowest_change_position_detects_last_element_change() {
+        let old_order = ["aaa1111", "bbb2222", "ccc3333"];
+        let new_order = vec![
+            "aaa1111".to_string(),
+            "bbb2222".to_string(),
+            "ddd4444".to_string(),
+        ];
+        assert_eq!(lowest_change_position(&old_order, &new_order), Some(3));
+    }
+
+    #[test]
+    fn lowest_change_position_detects_tail_drop_with_matching_prefix() {
+        // Prefix matches, new_order dropped the tail entry.
+        let old_order = ["aaa1111", "bbb2222", "ccc3333"];
+        let new_order = vec!["aaa1111".to_string(), "bbb2222".to_string()];
+        // First missing position (length + 1 of the shorter list).
+        assert_eq!(lowest_change_position(&old_order, &new_order), Some(3));
+    }
+
+    #[test]
+    fn lowest_change_position_detects_tail_drop_with_earlier_change() {
+        // Prefix differs at position 2 AND the tail is dropped. The earlier
+        // change wins (the helper returns the lowest changed position).
+        let old_order = ["aaa1111", "bbb2222", "ccc3333"];
+        let new_order = vec!["aaa1111".to_string(), "zzz9999".to_string()];
+        assert_eq!(lowest_change_position(&old_order, &new_order), Some(2));
+    }
+
+    #[test]
+    fn lowest_change_position_detects_drop_of_first_entry() {
+        let old_order = ["aaa1111", "bbb2222", "ccc3333"];
+        let new_order = vec!["bbb2222".to_string(), "ccc3333".to_string()];
+        // First differing position is the first slot.
+        assert_eq!(lowest_change_position(&old_order, &new_order), Some(1));
+    }
+
+    #[test]
+    fn lowest_change_position_handles_empty_new_order() {
+        // All commits dropped → "first missing position" is position 1.
+        let old_order = ["aaa1111", "bbb2222"];
+        let new_order: Vec<String> = vec![];
+        assert_eq!(lowest_change_position(&old_order, &new_order), Some(1));
+    }
 }

--- a/crates/gg-core/src/commands/reorder.rs
+++ b/crates/gg-core/src/commands/reorder.rs
@@ -33,7 +33,10 @@ pub fn run(options: ReorderOptions) -> Result<()> {
     git::require_clean_working_directory(&repo)?;
 
     // Load stack
-    let stack = Stack::load(&repo, &config)?;
+    let mut stack = Stack::load(&repo, &config)?;
+    // Best-effort refresh of mr_state for the immutability guard (catches
+    // squash-merged PRs that base-ancestor would otherwise miss).
+    immutability::refresh_mr_state_for_guard(&repo, &mut stack);
 
     if stack.len() < 2 {
         println!("{}", style("Need at least 2 commits to reorder.").dim());

--- a/crates/gg-core/src/commands/split.rs
+++ b/crates/gg-core/src/commands/split.rs
@@ -10,6 +10,7 @@ use dialoguer::Editor;
 use crate::config::Config;
 use crate::error::{GgError, Result};
 use crate::git;
+use crate::immutability::{self, ImmutabilityPolicy};
 use crate::stack::{self, Stack};
 
 /// Options for the split command
@@ -25,6 +26,8 @@ pub struct SplitOptions {
     pub no_edit: bool,
     /// If true, disable TUI and use sequential prompt instead.
     pub no_tui: bool,
+    /// If true, override the immutability check.
+    pub force: bool,
 }
 
 /// A single line in a diff hunk
@@ -107,6 +110,16 @@ pub fn run(options: SplitOptions) -> Result<()> {
     let target_oid = entry.oid;
     let target_commit = repo.find_commit(target_oid)?;
     let original_gg_id = entry.gg_id.clone();
+
+    // Immutability pre-flight: splitting rewrites the target commit and every
+    // commit above it (they get a new parent). Guard against splitting a
+    // merged or base-ancestor commit unless the user explicitly overrides.
+    {
+        let targets: Vec<usize> = (target_pos..=stack.len()).collect();
+        let policy = ImmutabilityPolicy::for_stack(&repo, &stack)?;
+        let report = policy.check_positions(&stack, &targets);
+        immutability::guard(report, options.force)?;
+    }
 
     println!(
         "Splitting commit {}: {} ({})",

--- a/crates/gg-core/src/commands/split.rs
+++ b/crates/gg-core/src/commands/split.rs
@@ -89,7 +89,10 @@ pub fn run(options: SplitOptions) -> Result<()> {
 
     git::require_clean_working_directory(&repo)?;
 
-    let stack = Stack::load(&repo, &config)?;
+    let mut stack = Stack::load(&repo, &config)?;
+    // Best-effort refresh of mr_state for the immutability guard (catches
+    // squash-merged PRs that base-ancestor would otherwise miss).
+    immutability::refresh_mr_state_for_guard(&repo, &mut stack);
 
     // Resolve target commit position (1-indexed)
     let target_pos = match &options.target {

--- a/crates/gg-core/src/commands/squash.rs
+++ b/crates/gg-core/src/commands/squash.rs
@@ -80,7 +80,11 @@ pub fn run(all: bool, force: bool) -> Result<()> {
     let config = Config::load_with_global(repo.commondir())?;
 
     // Verify we're on a stack
-    let stack = Stack::load(&repo, &config)?;
+    let mut stack = Stack::load(&repo, &config)?;
+    // Best-effort refresh of mr_state so the immutability guard can catch
+    // squash-merged PRs (their merge SHA isn't on origin/<base>, so the
+    // base-ancestor rule misses them). No-op when offline / no provider.
+    immutability::refresh_mr_state_for_guard(&repo, &mut stack);
 
     // Check if we have changes to squash
     let statuses = repo.statuses(None)?;

--- a/crates/gg-core/src/commands/squash.rs
+++ b/crates/gg-core/src/commands/squash.rs
@@ -8,6 +8,7 @@ use dialoguer::Select;
 use crate::config::{Config, UnstagedAction};
 use crate::error::{GgError, Result};
 use crate::git;
+use crate::immutability::{self, ImmutabilityPolicy};
 use crate::stack;
 use crate::stack::Stack;
 
@@ -70,7 +71,7 @@ fn has_untracked_files() -> Result<bool> {
 }
 
 /// Run the squash command
-pub fn run(all: bool) -> Result<()> {
+pub fn run(all: bool, force: bool) -> Result<()> {
     let repo = git::open_repo()?;
 
     // Acquire operation lock to prevent concurrent operations
@@ -98,6 +99,23 @@ pub fn run(all: bool) -> Result<()> {
         .current_position
         .map(|p| p < stack.len() - 1)
         .unwrap_or(false);
+
+    // Immutability pre-flight: squash amends the current commit (position =
+    // current_position + 1, or stack head) and rebases every position above
+    // it when `needs_rebase` is true. Guard against rewriting merged/
+    // base-ancestor commits unless the user explicitly overrides.
+    if !stack.is_empty() {
+        let head_pos = stack.current_position.map(|p| p + 1).unwrap_or(stack.len());
+        let mut targets = vec![head_pos];
+        if needs_rebase {
+            for pos in (head_pos + 1)..=stack.len() {
+                targets.push(pos);
+            }
+        }
+        let policy = ImmutabilityPolicy::for_stack(&repo, &stack)?;
+        let report = policy.check_positions(&stack, &targets);
+        immutability::guard(report, force)?;
+    }
 
     let has_unstaged = has_unstaged_changes()?;
     let has_untracked = has_untracked_files()?;

--- a/crates/gg-core/src/commands/sync.rs
+++ b/crates/gg-core/src/commands/sync.rs
@@ -66,7 +66,10 @@ fn maybe_rebase_if_base_is_behind(
                 prs_label
             );
         }
-        crate::commands::rebase::run_with_repo(repo, None, json)?;
+        // Internal auto-rebase during sync: the user hasn't been asked to
+        // --force, so respect the immutability guard rather than silently
+        // bypassing it.
+        crate::commands::rebase::run_with_repo(repo, None, json, false)?;
         return Ok(true);
     }
 
@@ -91,7 +94,7 @@ fn maybe_rebase_if_base_is_behind(
         .unwrap_or(true);
 
     if should_rebase {
-        crate::commands::rebase::run_with_repo(repo, None, json)?;
+        crate::commands::rebase::run_with_repo(repo, None, json, false)?;
         return Ok(true);
     }
 

--- a/crates/gg-core/src/error.rs
+++ b/crates/gg-core/src/error.rs
@@ -63,6 +63,11 @@ pub enum GgError {
     #[error("No rebase in progress")]
     NoRebaseInProgress,
 
+    #[error(
+        "cannot rewrite immutable commits (pass --force / --ignore-immutable to override):\n{0}"
+    )]
+    ImmutableTargets(String),
+
     #[error("Git error: {0}")]
     Git(#[from] git2::Error),
 

--- a/crates/gg-core/src/immutability.rs
+++ b/crates/gg-core/src/immutability.rs
@@ -1,0 +1,460 @@
+//! Immutability policy for history-rewriting commands.
+//!
+//! Some commits in a stack should not be rewritten casually:
+//!
+//! 1. Commits whose PR/MR is already merged — rewriting them produces a local
+//!    duplicate of work that is already published, and can confuse later
+//!    `gg sync` / `gg rebase` flows.
+//! 2. Commits already reachable from `origin/<base>` — the same footgun, but
+//!    caught via git ancestry rather than provider state, which also handles
+//!    squash-merges cleanly.
+//!
+//! This module centralises the policy so that every rewrite-style command
+//! (squash, drop, reorder, split, absorb, rebase) applies the same check.
+//! Users who genuinely need to rewrite immutable history can override with
+//! `--force` / `--ignore-immutable`.
+//!
+//! Design choices:
+//! - The policy is **pre-flight**: commands build a report, call [`guard`],
+//!   and only proceed if the report is clear (or the user passed `force`).
+//!   Nothing is mutated on the repository before the check runs.
+//! - Base-ancestor lookups prefer `origin/<base>` because the local base may
+//!   be stale; we fall back to the local base if no remote ref exists.
+//! - Results are cached implicitly by resolving the base OID once when the
+//!   policy is constructed from a stack.
+//!
+//! See `docs/src/core-concepts.md` for the user-facing explanation.
+
+use console::style;
+use git2::Repository;
+
+use crate::error::{GgError, Result};
+use crate::provider::PrState;
+use crate::stack::{Stack, StackEntry};
+
+/// Why a specific commit is considered immutable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ImmutableReason {
+    /// The commit's PR/MR is already merged.
+    MergedPr {
+        /// PR/MR number, if known.
+        number: Option<u64>,
+    },
+    /// The commit is already reachable from the (remote) base branch.
+    BaseAncestor {
+        /// The ref we compared against, e.g. `origin/main` or `main`.
+        base_ref: String,
+    },
+}
+
+impl ImmutableReason {
+    /// Human-readable short description used in error messages.
+    pub fn describe(&self) -> String {
+        match self {
+            ImmutableReason::MergedPr { number: Some(n) } => format!("merged as !{}", n),
+            ImmutableReason::MergedPr { number: None } => "PR/MR is merged".to_string(),
+            ImmutableReason::BaseAncestor { base_ref } => {
+                format!("already in {}", base_ref)
+            }
+        }
+    }
+}
+
+/// An immutable entry and all the reasons it matched.
+#[derive(Debug, Clone)]
+pub struct ImmutableEntry {
+    /// 1-indexed position in the stack.
+    pub position: usize,
+    /// Short SHA for display.
+    pub short_sha: String,
+    /// Commit title.
+    pub title: String,
+    /// Reasons the entry is immutable (non-empty).
+    pub reasons: Vec<ImmutableReason>,
+}
+
+/// Report of all immutable entries among a set of rewrite targets.
+#[derive(Debug, Clone, Default)]
+pub struct ImmutabilityReport {
+    /// Immutable entries that were checked (in ascending position order).
+    pub entries: Vec<ImmutableEntry>,
+}
+
+impl ImmutabilityReport {
+    /// True if no entries are immutable.
+    pub fn is_clear(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Format the report as a multi-line string suitable for error messages.
+    pub fn format_for_error(&self) -> String {
+        let mut out = String::new();
+        for entry in &self.entries {
+            let reasons: Vec<String> = entry.reasons.iter().map(|r| r.describe()).collect();
+            out.push_str(&format!(
+                "  #{pos}  {sha}  {title}  ({reasons})\n",
+                pos = entry.position,
+                sha = entry.short_sha,
+                title = entry.title,
+                reasons = reasons.join(", "),
+            ));
+        }
+        // Trim trailing newline for nicer embedding in error strings.
+        while out.ends_with('\n') {
+            out.pop();
+        }
+        out
+    }
+}
+
+/// Policy object bundled with the data it needs to answer "is this commit
+/// immutable?" for a given stack.
+pub struct ImmutabilityPolicy<'a> {
+    repo: &'a Repository,
+    /// The ref we compared against (e.g. `origin/main` or `main`).
+    base_ref: String,
+    /// OID of `base_ref`, used for ancestor checks.
+    base_oid: Option<git2::Oid>,
+}
+
+impl<'a> ImmutabilityPolicy<'a> {
+    /// Construct a policy for the given stack, resolving the remote base ref
+    /// (falling back to the local base if the remote ref is not available).
+    pub fn for_stack(repo: &'a Repository, stack: &Stack) -> Result<Self> {
+        let remote_ref = format!("origin/{}", stack.base);
+        let (base_ref, base_oid) =
+            if let Ok(obj) = repo.revparse_single(&format!("refs/remotes/{}", remote_ref)) {
+                (remote_ref, Some(obj.id()))
+            } else if let Ok(obj) = repo.revparse_single(&stack.base) {
+                (stack.base.clone(), Some(obj.id()))
+            } else {
+                // No base ref found — base-ancestor rule simply won't fire.
+                (stack.base.clone(), None)
+            };
+
+        Ok(Self {
+            repo,
+            base_ref,
+            base_oid,
+        })
+    }
+
+    /// The ref name used for base-ancestor comparisons.
+    pub fn base_ref(&self) -> &str {
+        &self.base_ref
+    }
+
+    /// Compute the reasons this entry is immutable. An empty vector means the
+    /// entry is mutable.
+    pub fn reasons_for(&self, entry: &StackEntry) -> Vec<ImmutableReason> {
+        let mut reasons = Vec::new();
+
+        if matches!(entry.mr_state, Some(PrState::Merged)) {
+            reasons.push(ImmutableReason::MergedPr {
+                number: entry.mr_number,
+            });
+        }
+
+        if let Some(base_oid) = self.base_oid {
+            if entry.oid == base_oid
+                || self
+                    .repo
+                    .graph_descendant_of(base_oid, entry.oid)
+                    .unwrap_or(false)
+            {
+                reasons.push(ImmutableReason::BaseAncestor {
+                    base_ref: self.base_ref.clone(),
+                });
+            }
+        }
+
+        reasons
+    }
+
+    /// Build a report for a slice of 1-indexed positions from the stack.
+    /// Unknown positions are silently skipped (callers validate elsewhere).
+    pub fn check_positions(&self, stack: &Stack, positions: &[usize]) -> ImmutabilityReport {
+        let mut entries: Vec<ImmutableEntry> = Vec::new();
+        let mut seen: std::collections::HashSet<usize> = std::collections::HashSet::new();
+
+        let mut sorted_positions: Vec<usize> = positions.to_vec();
+        sorted_positions.sort_unstable();
+        sorted_positions.dedup();
+
+        for pos in sorted_positions {
+            if !seen.insert(pos) {
+                continue;
+            }
+            if let Some(entry) = stack.get_entry_by_position(pos) {
+                let reasons = self.reasons_for(entry);
+                if !reasons.is_empty() {
+                    entries.push(ImmutableEntry {
+                        position: entry.position,
+                        short_sha: entry.short_sha.clone(),
+                        title: entry.title.clone(),
+                        reasons,
+                    });
+                }
+            }
+        }
+
+        ImmutabilityReport { entries }
+    }
+
+    /// Build a report covering every entry in the stack.
+    pub fn check_all(&self, stack: &Stack) -> ImmutabilityReport {
+        let positions: Vec<usize> = stack.entries.iter().map(|e| e.position).collect();
+        self.check_positions(stack, &positions)
+    }
+}
+
+/// Shared pre-flight guard used by every history-rewriting command.
+///
+/// If the report has no immutable entries, this is a no-op.
+/// If the report has entries and `force` is false, returns
+/// [`GgError::ImmutableTargets`] with a formatted list of offending commits.
+/// If the report has entries and `force` is true, prints a warning to stderr
+/// and proceeds.
+pub fn guard(report: ImmutabilityReport, force: bool) -> Result<()> {
+    if report.is_clear() {
+        return Ok(());
+    }
+
+    if force {
+        eprintln!(
+            "{} overriding immutability check for {} commit(s):",
+            style("Warning:").yellow().bold(),
+            report.entries.len()
+        );
+        eprintln!("{}", report.format_for_error());
+        return Ok(());
+    }
+
+    Err(GgError::ImmutableTargets(report.format_for_error()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::stack::StackEntry;
+
+    fn mk_entry(pos: usize, sha: &str, title: &str) -> StackEntry {
+        StackEntry {
+            oid: git2::Oid::zero(),
+            short_sha: sha.to_string(),
+            title: title.to_string(),
+            gg_id: None,
+            gg_parent: None,
+            mr_number: None,
+            mr_state: None,
+            approved: false,
+            ci_status: None,
+            position: pos,
+            in_merge_train: false,
+            merge_train_position: None,
+        }
+    }
+
+    #[test]
+    fn report_is_clear_when_empty() {
+        let report = ImmutabilityReport::default();
+        assert!(report.is_clear());
+    }
+
+    #[test]
+    fn report_formats_multiple_reasons_per_entry() {
+        let report = ImmutabilityReport {
+            entries: vec![ImmutableEntry {
+                position: 2,
+                short_sha: "abc1234".to_string(),
+                title: "Fix typo".to_string(),
+                reasons: vec![
+                    ImmutableReason::MergedPr { number: Some(123) },
+                    ImmutableReason::BaseAncestor {
+                        base_ref: "origin/main".to_string(),
+                    },
+                ],
+            }],
+        };
+        let formatted = report.format_for_error();
+        assert!(formatted.contains("#2"));
+        assert!(formatted.contains("abc1234"));
+        assert!(formatted.contains("Fix typo"));
+        assert!(formatted.contains("merged as !123"));
+        assert!(formatted.contains("already in origin/main"));
+    }
+
+    #[test]
+    fn reason_describe_without_number() {
+        let r = ImmutableReason::MergedPr { number: None };
+        assert_eq!(r.describe(), "PR/MR is merged");
+    }
+
+    #[test]
+    fn guard_passes_when_report_is_clear() {
+        let report = ImmutabilityReport::default();
+        assert!(guard(report, false).is_ok());
+    }
+
+    #[test]
+    fn guard_fails_when_report_has_entries_and_force_is_false() {
+        let report = ImmutabilityReport {
+            entries: vec![ImmutableEntry {
+                position: 1,
+                short_sha: "abc".to_string(),
+                title: "x".to_string(),
+                reasons: vec![ImmutableReason::MergedPr { number: Some(7) }],
+            }],
+        };
+        let err = guard(report, false).expect_err("should fail");
+        match err {
+            GgError::ImmutableTargets(msg) => {
+                assert!(msg.contains("#1"));
+                assert!(msg.contains("merged as !7"));
+            }
+            other => panic!("unexpected error: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn guard_proceeds_when_forced_even_if_entries_present() {
+        let report = ImmutabilityReport {
+            entries: vec![ImmutableEntry {
+                position: 1,
+                short_sha: "abc".to_string(),
+                title: "x".to_string(),
+                reasons: vec![ImmutableReason::MergedPr { number: Some(7) }],
+            }],
+        };
+        assert!(guard(report, true).is_ok());
+    }
+
+    #[test]
+    fn reasons_for_merged_pr_returns_merged_pr_reason() {
+        // Use an in-memory bare repo so `graph_descendant_of` can run on OIDs
+        // that don't match any real commit (Oid::zero() is unknown).
+        let temp = tempfile::tempdir().unwrap();
+        let repo = Repository::init(temp.path()).unwrap();
+
+        let stack = Stack {
+            name: "s".to_string(),
+            username: "u".to_string(),
+            base: "main".to_string(),
+            entries: vec![StackEntry {
+                mr_number: Some(42),
+                mr_state: Some(PrState::Merged),
+                ..mk_entry(1, "aaa0000", "merged commit")
+            }],
+            current_position: Some(0),
+        };
+
+        let policy = ImmutabilityPolicy::for_stack(&repo, &stack).unwrap();
+        let reasons = policy.reasons_for(&stack.entries[0]);
+        assert!(
+            reasons.contains(&ImmutableReason::MergedPr { number: Some(42) }),
+            "expected MergedPr reason, got {:?}",
+            reasons
+        );
+    }
+
+    #[test]
+    fn reasons_for_mutable_commit_is_empty() {
+        let temp = tempfile::tempdir().unwrap();
+        let repo = Repository::init(temp.path()).unwrap();
+
+        let stack = Stack {
+            name: "s".to_string(),
+            username: "u".to_string(),
+            base: "nonexistent".to_string(),
+            entries: vec![mk_entry(1, "aaa0000", "unpushed")],
+            current_position: Some(0),
+        };
+
+        let policy = ImmutabilityPolicy::for_stack(&repo, &stack).unwrap();
+        let reasons = policy.reasons_for(&stack.entries[0]);
+        assert!(reasons.is_empty(), "expected no reasons, got {:?}", reasons);
+    }
+
+    #[test]
+    fn check_positions_collects_multiple_immutables() {
+        let temp = tempfile::tempdir().unwrap();
+        let repo = Repository::init(temp.path()).unwrap();
+
+        let stack = Stack {
+            name: "s".to_string(),
+            username: "u".to_string(),
+            base: "nonexistent".to_string(),
+            entries: vec![
+                StackEntry {
+                    mr_number: Some(1),
+                    mr_state: Some(PrState::Merged),
+                    ..mk_entry(1, "aaa", "a")
+                },
+                mk_entry(2, "bbb", "b"),
+                StackEntry {
+                    mr_number: Some(3),
+                    mr_state: Some(PrState::Merged),
+                    ..mk_entry(3, "ccc", "c")
+                },
+            ],
+            current_position: Some(2),
+        };
+
+        let policy = ImmutabilityPolicy::for_stack(&repo, &stack).unwrap();
+        let report = policy.check_positions(&stack, &[1, 2, 3]);
+        assert_eq!(report.entries.len(), 2);
+        assert_eq!(report.entries[0].position, 1);
+        assert_eq!(report.entries[1].position, 3);
+    }
+
+    #[test]
+    fn check_positions_dedups_duplicate_inputs() {
+        let temp = tempfile::tempdir().unwrap();
+        let repo = Repository::init(temp.path()).unwrap();
+
+        let stack = Stack {
+            name: "s".to_string(),
+            username: "u".to_string(),
+            base: "nonexistent".to_string(),
+            entries: vec![StackEntry {
+                mr_number: Some(1),
+                mr_state: Some(PrState::Merged),
+                ..mk_entry(1, "aaa", "a")
+            }],
+            current_position: Some(0),
+        };
+
+        let policy = ImmutabilityPolicy::for_stack(&repo, &stack).unwrap();
+        let report = policy.check_positions(&stack, &[1, 1, 1]);
+        assert_eq!(report.entries.len(), 1);
+    }
+
+    #[test]
+    fn check_all_covers_every_entry() {
+        let temp = tempfile::tempdir().unwrap();
+        let repo = Repository::init(temp.path()).unwrap();
+
+        let stack = Stack {
+            name: "s".to_string(),
+            username: "u".to_string(),
+            base: "nonexistent".to_string(),
+            entries: vec![
+                StackEntry {
+                    mr_number: Some(1),
+                    mr_state: Some(PrState::Merged),
+                    ..mk_entry(1, "aaa", "a")
+                },
+                StackEntry {
+                    mr_number: Some(2),
+                    mr_state: Some(PrState::Merged),
+                    ..mk_entry(2, "bbb", "b")
+                },
+            ],
+            current_position: Some(1),
+        };
+
+        let policy = ImmutabilityPolicy::for_stack(&repo, &stack).unwrap();
+        let report = policy.check_all(&stack);
+        assert_eq!(report.entries.len(), 2);
+    }
+}

--- a/crates/gg-core/src/immutability.rs
+++ b/crates/gg-core/src/immutability.rs
@@ -4,10 +4,11 @@
 //!
 //! 1. Commits whose PR/MR is already merged — rewriting them produces a local
 //!    duplicate of work that is already published, and can confuse later
-//!    `gg sync` / `gg rebase` flows.
-//! 2. Commits already reachable from `origin/<base>` — the same footgun, but
-//!    caught via git ancestry rather than provider state, which also handles
-//!    squash-merges cleanly.
+//!    `gg sync` / `gg rebase` flows. This is the *only* rule that catches
+//!    **squash-merged** PRs, because their merge commit on `origin/<base>`
+//!    has a brand-new SHA that doesn't share ancestry with the local commit.
+//! 2. Commits already reachable from `origin/<base>` — caught via git ancestry
+//!    rather than provider state. Handles plain merges and rebases.
 //!
 //! This module centralises the policy so that every rewrite-style command
 //! (squash, drop, reorder, split, absorb, rebase) applies the same check.
@@ -22,6 +23,10 @@
 //!   be stale; we fall back to the local base if no remote ref exists.
 //! - Results are cached implicitly by resolving the base OID once when the
 //!   policy is constructed from a stack.
+//! - Because `Stack::load` does not refresh provider state, the merged-PR
+//!   rule would otherwise rarely fire. [`refresh_mr_state_for_guard`] is a
+//!   best-effort pre-flight refresh that callers run once per command after
+//!   `Stack::load` to populate `mr_state` for the guard.
 //!
 //! See `docs/src/core-concepts.md` for the user-facing explanation.
 
@@ -29,7 +34,7 @@ use console::style;
 use git2::Repository;
 
 use crate::error::{GgError, Result};
-use crate::provider::PrState;
+use crate::provider::{PrState, Provider};
 use crate::stack::{Stack, StackEntry};
 
 /// Why a specific commit is considered immutable.
@@ -231,6 +236,46 @@ pub fn guard(report: ImmutabilityReport, force: bool) -> Result<()> {
     }
 
     Err(GgError::ImmutableTargets(report.format_for_error()))
+}
+
+/// Best-effort refresh of `mr_state` for every entry that has an `mr_number`,
+/// done once per command invocation immediately before the immutability guard
+/// runs.
+///
+/// `Stack::load` does not call any provider, so without this helper the
+/// merged-PR rule would essentially never fire — and squash-merged commits
+/// (whose merge SHA on `origin/<base>` doesn't share ancestry with the local
+/// commit) would slip past the guard entirely. By proactively populating
+/// `mr_state` here we close that gap for any user with a working provider.
+///
+/// **Best-effort by design:**
+/// - If no provider can be detected (no remote, missing config), this is a
+///   no-op so offline / no-auth users see no behaviour change.
+/// - Errors from individual `get_pr_info` calls are silently swallowed; the
+///   guard then falls back to the base-ancestor rule for that entry. We do
+///   not want a flaky API to block a `gg squash`.
+/// - Only `mr_state` is touched. CI status, approval and merge-train info are
+///   not needed by the guard, so we skip those calls to keep the latency
+///   roughly "1 API call per open PR in the stack".
+///
+/// Cost: O(entries with `mr_number`) network round-trips, executed serially.
+/// For typical stacks (a handful of open PRs) this is well below a second.
+pub fn refresh_mr_state_for_guard(repo: &Repository, stack: &mut Stack) {
+    let Ok(provider) = Provider::detect(repo) else {
+        // No provider configured — offline or non-GitHub/GitLab repo. The
+        // base-ancestor rule remains in effect.
+        return;
+    };
+
+    for entry in &mut stack.entries {
+        if let Some(pr_num) = entry.mr_number {
+            if let Ok(info) = provider.get_pr_info(pr_num) {
+                entry.mr_state = Some(info.state);
+            }
+            // On error: leave mr_state untouched. A missing/closed PR will
+            // simply not trigger the merged-PR rule; base-ancestor still applies.
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/gg-core/src/lib.rs
+++ b/crates/gg-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod error;
 pub mod gh;
 pub mod git;
 pub mod glab;
+pub mod immutability;
 pub mod managed_body;
 pub mod output;
 pub mod provider;

--- a/crates/gg-core/tests/immutability_integration.rs
+++ b/crates/gg-core/tests/immutability_integration.rs
@@ -6,7 +6,9 @@ use std::process::Command;
 
 use git2::Repository;
 
-use gg_core::immutability::{guard, ImmutabilityPolicy, ImmutableReason};
+use gg_core::immutability::{
+    guard, refresh_mr_state_for_guard, ImmutabilityPolicy, ImmutableReason,
+};
 use gg_core::provider::PrState;
 use gg_core::stack::{Stack, StackEntry};
 
@@ -196,6 +198,69 @@ fn guard_error_includes_both_sha_and_reason() {
     let msg = format!("{}", err);
     assert!(msg.contains("merged as !100"));
     assert!(msg.contains("already in origin/main"));
+}
+
+#[test]
+fn squash_merged_commit_fires_guard_via_mr_state_only() {
+    // Reproduces the scenario the merged-PR rule exists for: a PR was
+    // squash-merged upstream, so its merge commit on origin/<base> has a new
+    // SHA that doesn't share ancestry with the local commit. The
+    // base-ancestor rule misses it; only mr_state == Merged catches it.
+    let temp = tempfile::tempdir().unwrap();
+    let (repo, oids, _) = make_linear_stack(&temp, 3, 0);
+    // origin/main is at base — no stack commit is reachable from it.
+
+    // Commit #2 was squash-merged: its PR is Merged but the local SHA isn't
+    // anywhere on origin/main. Without the merged-PR rule, the guard would
+    // happily rewrite it.
+    let stack = build_stack(&oids, &[None, Some(PrState::Merged), None]);
+    let policy = ImmutabilityPolicy::for_stack(&repo, &stack).unwrap();
+    let report = policy.check_all(&stack);
+
+    assert_eq!(
+        report.entries.len(),
+        1,
+        "expected exactly one immutable entry"
+    );
+    let entry = &report.entries[0];
+    assert_eq!(entry.position, 2);
+    assert_eq!(
+        entry.reasons.len(),
+        1,
+        "only the merged-PR reason should fire (base-ancestor misses squash-merge): {:?}",
+        entry.reasons
+    );
+    assert!(matches!(
+        entry.reasons[0],
+        ImmutableReason::MergedPr { number: Some(101) }
+    ));
+
+    // And the guard rejects it without --force.
+    let err = guard(report, false).expect_err("guard should reject squash-merged commit");
+    let msg = format!("{}", err);
+    assert!(msg.contains("merged as !101"), "got: {}", msg);
+}
+
+#[test]
+fn refresh_mr_state_for_guard_is_noop_without_provider() {
+    // No remote configured → Provider::detect fails → helper must be a quiet
+    // no-op (offline / no-auth users see no behaviour change). We rely on the
+    // helper not panicking and not modifying mr_state.
+    let temp = tempfile::tempdir().unwrap();
+    let (repo, oids, _) = make_linear_stack(&temp, 2, 0);
+
+    let mut stack = build_stack(&oids, &[Some(PrState::Open), None]);
+    let original_state = stack.entries[0].mr_state.clone();
+
+    refresh_mr_state_for_guard(&repo, &mut stack);
+
+    // mr_state must be unchanged because no provider could be reached.
+    assert_eq!(
+        stack.entries[0].mr_state, original_state,
+        "helper must not mutate state when no provider is configured"
+    );
+    // And entries without an mr_number must remain untouched too.
+    assert_eq!(stack.entries[1].mr_state, None);
 }
 
 #[test]

--- a/crates/gg-core/tests/immutability_integration.rs
+++ b/crates/gg-core/tests/immutability_integration.rs
@@ -1,0 +1,232 @@
+//! Integration tests for the immutability policy that require a real git
+//! repository on disk (for ancestry / ref lookups).
+
+use std::path::Path;
+use std::process::Command;
+
+use git2::Repository;
+
+use gg_core::immutability::{guard, ImmutabilityPolicy, ImmutableReason};
+use gg_core::provider::PrState;
+use gg_core::stack::{Stack, StackEntry};
+
+fn run_git(repo_path: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(repo_path)
+        .output()
+        .expect("git command failed to execute");
+    assert!(
+        output.status.success(),
+        "git {} failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn head_oid(repo_path: &Path) -> git2::Oid {
+    let out = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+    git2::Oid::from_str(String::from_utf8_lossy(&out.stdout).trim()).unwrap()
+}
+
+/// Build a linear stack on top of `main` and return (repo, stack).
+/// The repo has: base commit on main, then `n` stack commits committed on a
+/// feature branch. `origin/main` is set to advance up to `base_advance_to`
+/// of the stack commits (0 = still at base, 1 = covers first stack commit,
+/// etc.).
+fn make_linear_stack(
+    temp: &tempfile::TempDir,
+    n: usize,
+    base_advance_to: usize,
+) -> (Repository, Vec<git2::Oid>, git2::Oid) {
+    let repo_path = temp.path();
+
+    run_git(repo_path, &["init", "--initial-branch=main"]);
+    run_git(repo_path, &["config", "user.email", "test@example.com"]);
+    run_git(repo_path, &["config", "user.name", "Test User"]);
+
+    std::fs::write(repo_path.join("base.txt"), "base\n").unwrap();
+    run_git(repo_path, &["add", "."]);
+    run_git(repo_path, &["commit", "-m", "base"]);
+    let base_main_oid = head_oid(repo_path);
+
+    run_git(repo_path, &["checkout", "-b", "u/stack"]);
+
+    let mut stack_oids: Vec<git2::Oid> = Vec::new();
+    for i in 0..n {
+        let file = format!("stack_{}.txt", i + 1);
+        std::fs::write(repo_path.join(&file), format!("content-{}\n", i + 1)).unwrap();
+        run_git(repo_path, &["add", "."]);
+        let msg = format!("stack commit {}\n\nGG-ID: c-{:07}", i + 1, i + 1);
+        run_git(repo_path, &["commit", "-m", &msg]);
+        stack_oids.push(head_oid(repo_path));
+    }
+
+    // Create refs/remotes/origin/main pointing at `base_advance_to` commits
+    // up the stack (0 = at base, otherwise stack_oids[base_advance_to - 1]).
+    let target_oid = if base_advance_to == 0 {
+        base_main_oid
+    } else {
+        stack_oids[base_advance_to - 1]
+    };
+    run_git(
+        repo_path,
+        &[
+            "update-ref",
+            "refs/remotes/origin/main",
+            &target_oid.to_string(),
+        ],
+    );
+
+    let repo = Repository::open(repo_path).unwrap();
+    (repo, stack_oids, base_main_oid)
+}
+
+fn build_stack(oids: &[git2::Oid], states: &[Option<PrState>]) -> Stack {
+    assert_eq!(oids.len(), states.len());
+    let entries: Vec<StackEntry> = oids
+        .iter()
+        .zip(states.iter())
+        .enumerate()
+        .map(|(i, (oid, state))| StackEntry {
+            oid: *oid,
+            short_sha: oid.to_string()[..7].to_string(),
+            title: format!("stack commit {}", i + 1),
+            gg_id: Some(format!("c-{:07}", i + 1)),
+            gg_parent: None,
+            mr_number: state.as_ref().map(|_| (i as u64) + 100),
+            mr_state: state.clone(),
+            approved: false,
+            ci_status: None,
+            position: i + 1,
+            in_merge_train: false,
+            merge_train_position: None,
+        })
+        .collect();
+
+    Stack {
+        name: "stack".to_string(),
+        username: "u".to_string(),
+        base: "main".to_string(),
+        entries,
+        current_position: Some(oids.len().saturating_sub(1)),
+    }
+}
+
+#[test]
+fn base_ancestor_rule_fires_when_origin_base_covers_stack_commit() {
+    let temp = tempfile::tempdir().unwrap();
+    let (repo, oids, _) = make_linear_stack(&temp, 3, 2);
+    // origin/main now points at stack_oids[1] (the 2nd stack commit).
+
+    let stack = build_stack(&oids, &[None, None, None]);
+    let policy = ImmutabilityPolicy::for_stack(&repo, &stack).unwrap();
+
+    // Entry #1 and #2 are ancestors of origin/main, so they should be immutable.
+    let report = policy.check_all(&stack);
+    let positions: Vec<usize> = report.entries.iter().map(|e| e.position).collect();
+    assert_eq!(positions, vec![1, 2]);
+
+    // Reasons should include BaseAncestor pointing at origin/main.
+    for entry in &report.entries {
+        assert!(
+            entry
+                .reasons
+                .iter()
+                .any(|r| matches!(r, ImmutableReason::BaseAncestor { base_ref } if base_ref == "origin/main")),
+            "expected base-ancestor reason, got {:?}",
+            entry.reasons
+        );
+    }
+}
+
+#[test]
+fn base_ancestor_rule_is_silent_when_origin_base_is_behind_stack() {
+    let temp = tempfile::tempdir().unwrap();
+    let (repo, oids, _) = make_linear_stack(&temp, 3, 0);
+    // origin/main at base → no stack commit is an ancestor of origin/main.
+
+    let stack = build_stack(&oids, &[None, None, None]);
+    let policy = ImmutabilityPolicy::for_stack(&repo, &stack).unwrap();
+
+    let report = policy.check_all(&stack);
+    assert!(report.is_clear(), "expected clear report, got {:?}", report);
+}
+
+#[test]
+fn merged_pr_and_base_ancestor_stack_together() {
+    let temp = tempfile::tempdir().unwrap();
+    let (repo, oids, _) = make_linear_stack(&temp, 3, 1);
+    // origin/main covers stack commit #1 only.
+
+    // Also mark commit #1 as Merged. Both reasons should show up.
+    let stack = build_stack(&oids, &[Some(PrState::Merged), Some(PrState::Open), None]);
+
+    let policy = ImmutabilityPolicy::for_stack(&repo, &stack).unwrap();
+    let report = policy.check_all(&stack);
+
+    assert_eq!(report.entries.len(), 1);
+    let entry = &report.entries[0];
+    assert_eq!(entry.position, 1);
+    assert_eq!(entry.reasons.len(), 2);
+    assert!(entry
+        .reasons
+        .iter()
+        .any(|r| matches!(r, ImmutableReason::MergedPr { number: Some(100) })));
+    assert!(entry
+        .reasons
+        .iter()
+        .any(|r| matches!(r, ImmutableReason::BaseAncestor { .. })));
+}
+
+#[test]
+fn guard_error_includes_both_sha_and_reason() {
+    let temp = tempfile::tempdir().unwrap();
+    let (repo, oids, _) = make_linear_stack(&temp, 2, 1);
+    let stack = build_stack(&oids, &[Some(PrState::Merged), None]);
+
+    let policy = ImmutabilityPolicy::for_stack(&repo, &stack).unwrap();
+    let report = policy.check_positions(&stack, &[1]);
+
+    let err = guard(report, false).expect_err("should fail");
+    let msg = format!("{}", err);
+    assert!(msg.contains("merged as !100"));
+    assert!(msg.contains("already in origin/main"));
+}
+
+#[test]
+fn falls_back_to_local_base_when_origin_ref_is_missing() {
+    let temp = tempfile::tempdir().unwrap();
+    let repo_path = temp.path();
+
+    run_git(repo_path, &["init", "--initial-branch=main"]);
+    run_git(repo_path, &["config", "user.email", "test@example.com"]);
+    run_git(repo_path, &["config", "user.name", "Test User"]);
+
+    std::fs::write(repo_path.join("base.txt"), "base\n").unwrap();
+    run_git(repo_path, &["add", "."]);
+    run_git(repo_path, &["commit", "-m", "base"]);
+    let base_oid = head_oid(repo_path);
+
+    run_git(repo_path, &["checkout", "-b", "u/stack"]);
+    std::fs::write(repo_path.join("x.txt"), "x\n").unwrap();
+    run_git(repo_path, &["add", "."]);
+    run_git(repo_path, &["commit", "-m", "s1"]);
+    let s1 = head_oid(repo_path);
+
+    // No origin/main ref exists; policy should fall back to local `main`.
+    let repo = Repository::open(repo_path).unwrap();
+    let stack = build_stack(&[base_oid, s1], &[None, None]);
+    let policy = ImmutabilityPolicy::for_stack(&repo, &stack).unwrap();
+    assert_eq!(policy.base_ref(), "main");
+
+    // The base commit is an ancestor of itself, so entry #1 (base_oid) is
+    // immutable via the local base.
+    let report = policy.check_all(&stack);
+    assert_eq!(report.entries.len(), 1);
+    assert_eq!(report.entries[0].position, 1);
+}

--- a/crates/gg-mcp/src/tools.rs
+++ b/crates/gg-mcp/src/tools.rs
@@ -270,6 +270,13 @@ pub struct StackDropParams {
     /// Commits to drop: position (1-indexed), short SHA, or GG-ID
     #[serde(default)]
     pub targets: Vec<String>,
+    /// Bypass the immutability guard and drop merged/base-ancestor commits
+    /// anyway. Defaults to false so the MCP tool does not silently rewrite
+    /// already-published history. The confirmation prompt is always skipped
+    /// (MCP is non-interactive); only set this when the user has explicitly
+    /// approved rewriting immutable commits.
+    #[serde(default)]
+    pub force: bool,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -817,7 +824,7 @@ impl GgMcpServer {
 
     /// Drop (remove) commits from the stack.
     #[tool(
-        description = "Remove commits from the stack. Targets can be positions (1-indexed), short SHAs, or GG-IDs. Always uses --force (agent confirms with user). Returns JSON with dropped commits."
+        description = "Remove commits from the stack. Targets can be positions (1-indexed), short SHAs, or GG-IDs. Always passes --yes (MCP is non-interactive); set `force: true` only to bypass the immutability guard for merged/base-ancestor commits. Returns JSON with dropped commits."
     )]
     fn stack_drop(
         &self,
@@ -826,11 +833,15 @@ impl GgMcpServer {
         if params.targets.is_empty() {
             return Err("At least one target is required".to_string());
         }
-        let mut args = vec![
-            "drop".to_string(),
-            "--force".to_string(),
-            "--json".to_string(),
-        ];
+        // Always pass `--yes` to skip the interactive prompt. Only add
+        // `--force` when the caller has explicitly opted into rewriting
+        // merged/base-ancestor commits — otherwise the immutability guard
+        // keeps already-published history safe.
+        let mut args = vec!["drop".to_string(), "--yes".to_string()];
+        if params.force {
+            args.push("--force".to_string());
+        }
+        args.push("--json".to_string());
         args.extend(params.targets);
         run_gg_command(&args)
     }
@@ -1054,6 +1065,9 @@ mod tests {
         // Empty targets array should deserialize
         let params: StackDropParams = serde_json::from_str("{}").unwrap();
         assert!(params.targets.is_empty());
+        // force must default to false so MCP drop does not silently bypass
+        // the immutability guard for merged/base commits.
+        assert!(!params.force);
     }
 
     #[test]
@@ -1064,6 +1078,14 @@ mod tests {
         assert_eq!(params.targets[0], "1");
         assert_eq!(params.targets[1], "c-abc1234");
         assert_eq!(params.targets[2], "abc1234");
+        assert!(!params.force);
+    }
+
+    #[test]
+    fn test_drop_params_with_force() {
+        let params: StackDropParams =
+            serde_json::from_str(r#"{"targets": ["1"], "force": true}"#).unwrap();
+        assert!(params.force);
     }
 
     #[test]
@@ -1100,7 +1122,10 @@ mod tests {
     #[test]
     fn test_stack_drop_requires_targets() {
         let server = GgMcpServer::new();
-        let params = StackDropParams { targets: vec![] };
+        let params = StackDropParams {
+            targets: vec![],
+            force: false,
+        };
         let result = server.stack_drop(Parameters(params));
         assert!(result.is_err());
         assert_eq!(

--- a/crates/gg-mcp/src/tools.rs
+++ b/crates/gg-mcp/src/tools.rs
@@ -199,6 +199,10 @@ pub struct StackRebaseParams {
     /// Target branch to rebase onto (default: base branch)
     #[serde(default)]
     pub target: Option<String>,
+    /// Bypass the immutability guard on merged / base-ancestor commits.
+    /// Only set after surfacing the affected commits to the user.
+    #[serde(default)]
+    pub force: bool,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -206,6 +210,10 @@ pub struct StackSquashParams {
     /// Stage all changes before squashing (like git add -A)
     #[serde(default)]
     pub all: bool,
+    /// Bypass the immutability guard on merged / base-ancestor commits.
+    /// Only set after surfacing the affected commits to the user.
+    #[serde(default)]
+    pub force: bool,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -225,6 +233,10 @@ pub struct StackAbsorbParams {
     /// Squash fixup commits immediately
     #[serde(default)]
     pub squash: bool,
+    /// Bypass the immutability guard on merged / base-ancestor commits.
+    /// Only set after surfacing the affected commits to the user.
+    #[serde(default)]
+    pub force: bool,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -274,12 +286,20 @@ pub struct StackSplitParams {
     /// Don't prompt for the remainder commit message
     #[serde(default)]
     pub no_edit: bool,
+    /// Bypass the immutability guard on merged / base-ancestor commits.
+    /// Only set after surfacing the affected commits to the user.
+    #[serde(default)]
+    pub force: bool,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct StackReorderParams {
     /// New order as positions (1-indexed), e.g., "3,1,2" or "3 1 2"
     pub order: String,
+    /// Bypass the immutability guard on merged / base-ancestor commits.
+    /// Only set after surfacing the affected commits to the user.
+    #[serde(default)]
+    pub force: bool,
 }
 
 // --- Helper functions ---
@@ -672,6 +692,9 @@ impl GgMcpServer {
         Parameters(params): Parameters<StackRebaseParams>,
     ) -> Result<String, String> {
         let mut args = vec!["rebase".to_string()];
+        if params.force {
+            args.push("--force".to_string());
+        }
         if let Some(ref target) = params.target {
             args.push(target.clone());
         }
@@ -689,6 +712,9 @@ impl GgMcpServer {
         let mut args = vec!["sc".to_string()];
         if params.all {
             args.push("--all".to_string());
+        }
+        if params.force {
+            args.push("--force".to_string());
         }
         run_gg_command(&args)
     }
@@ -716,6 +742,9 @@ impl GgMcpServer {
         }
         if params.squash {
             args.push("-s".to_string());
+        }
+        if params.force {
+            args.push("--force".to_string());
         }
         run_gg_command(&args)
     }
@@ -829,6 +858,9 @@ impl GgMcpServer {
         if params.no_edit {
             args.push("--no-edit".to_string());
         }
+        if params.force {
+            args.push("--force".to_string());
+        }
         args.extend(params.files);
         run_gg_command(&args)
     }
@@ -841,12 +873,16 @@ impl GgMcpServer {
         &self,
         Parameters(params): Parameters<StackReorderParams>,
     ) -> Result<String, String> {
-        run_gg_command(&[
+        let mut args = vec![
             "reorder".to_string(),
             "--no-tui".to_string(),
             "-o".to_string(),
             params.order,
-        ])
+        ];
+        if params.force {
+            args.push("--force".to_string());
+        }
+        run_gg_command(&args)
     }
 }
 
@@ -1010,6 +1046,7 @@ mod tests {
         assert!(!params.whole_file);
         assert!(!params.one_fixup_per_commit);
         assert!(!params.squash);
+        assert!(!params.force);
     }
 
     #[test]
@@ -1036,6 +1073,7 @@ mod tests {
         assert!(params.files.is_empty());
         assert!(params.message.is_none());
         assert!(!params.no_edit);
+        assert!(!params.force);
     }
 
     #[test]
@@ -1055,6 +1093,8 @@ mod tests {
         // Order is required for MCP (no TUI)
         let params: StackReorderParams = serde_json::from_str(r#"{"order": "3,1,2"}"#).unwrap();
         assert_eq!(params.order, "3,1,2");
+        // force defaults to false
+        assert!(!params.force);
     }
 
     #[test]
@@ -1077,6 +1117,7 @@ mod tests {
             files: vec![],
             message: None,
             no_edit: false,
+            force: false,
         };
         let result = server.stack_split(Parameters(params));
         assert!(result.is_err());

--- a/docs/src/commands/absorb.md
+++ b/docs/src/commands/absorb.md
@@ -14,6 +14,12 @@ gg absorb [OPTIONS]
 - `--one-fixup-per-commit`: At most one fixup per commit
 - `-n, --no-limit`: Search all commits in the stack (not just last 10)
 - `-s, --squash`: Squash directly instead of creating `fixup!` commits
+- `-f, --force` (alias `--ignore-immutable`): Override the immutability guard.
+  By default, `gg absorb` refuses to run if any commit in the stack is
+  merged or reachable from `origin/<base>` — because it cannot tell ahead of
+  time whether git-absorb will target those commits. `--dry-run` skips the
+  guard so you can preview safely. See
+  [Core concepts · Immutable commits](../core-concepts.md#immutable-commits).
 
 ## Examples
 

--- a/docs/src/commands/drop.md
+++ b/docs/src/commands/drop.md
@@ -17,7 +17,11 @@ gg drop <TARGET>... [OPTIONS]
 
 ## Options
 
-- `-f, --force`: Skip the confirmation prompt
+- `-f, --force` (alias `--ignore-immutable`): Skip the confirmation prompt
+  **and** override the immutability guard. `gg drop` refuses by default to
+  drop or rewrite commits whose PR is merged or which are already reachable
+  from `origin/<base>`; this flag bypasses both safeties. See
+  [Core concepts · Immutable commits](../core-concepts.md#immutable-commits).
 - `--json`: Output result as JSON
 
 ## Behavior

--- a/docs/src/commands/rebase.md
+++ b/docs/src/commands/rebase.md
@@ -8,6 +8,14 @@ gg rebase [TARGET]
 
 - If `TARGET` is omitted, git-gud uses the stack base branch.
 
+## Options
+
+- `-f, --force` (alias `--ignore-immutable`): Override the immutability guard.
+  Rebase rewrites the parent of every commit in the stack; if any commit is
+  merged or already reachable from `origin/<base>`, gg refuses by default to
+  avoid producing local duplicates of upstream history. See
+  [Core concepts · Immutable commits](../core-concepts.md#immutable-commits).
+
 ## Examples
 
 ```bash

--- a/docs/src/commands/reorder.md
+++ b/docs/src/commands/reorder.md
@@ -13,6 +13,10 @@ gg arrange [OPTIONS]
 
 - `-o, --order <ORDER>`: New order as positions/SHAs (`"3,1,2"` or `"3 1 2"`)
 - `--no-tui`: Disable the interactive TUI and use a text editor instead
+- `-f, --force` (alias `--ignore-immutable`): Override the immutability guard.
+  Reordering or dropping a commit that is already merged or reachable from
+  `origin/<base>` is refused by default. See
+  [Core concepts · Immutable commits](../core-concepts.md#immutable-commits).
 
 ## Interactive TUI
 

--- a/docs/src/commands/sc.md
+++ b/docs/src/commands/sc.md
@@ -9,6 +9,10 @@ gg sc [OPTIONS]
 ## Options
 
 - `-a, --all`: Include staged and unstaged changes
+- `-f, --force` (alias `--ignore-immutable`): Override the immutability guard.
+  By default `gg sc` refuses to amend a commit whose PR is merged or which is
+  already reachable from `origin/<base>`. See
+  [Core concepts · Immutable commits](../core-concepts.md#immutable-commits).
 
 When unstaged changes are present, behavior is controlled by `defaults.unstaged_action` in `.git/gg/config.json`:
 

--- a/docs/src/commands/split.md
+++ b/docs/src/commands/split.md
@@ -12,6 +12,9 @@ gg split [OPTIONS] [FILES...]
 - `-m, --message <MESSAGE>`: Commit message for the new (first) commit. Skips the editor prompt.
 - `--no-edit`: Keep the original message for the remainder commit without prompting.
 - `--no-tui`: Disable TUI, use sequential prompt instead (legacy `git add -p` style).
+- `-f, --force` (alias `--ignore-immutable`): Override the immutability guard.
+  Splitting a merged or base-ancestor commit is refused by default. See
+  [Core concepts · Immutable commits](../core-concepts.md#immutable-commits).
 - `FILES...`: Files to include in the new commit. When provided, all hunks from those files are auto-selected (skips the interactive picker).
 
 ## How It Works

--- a/docs/src/core-concepts.md
+++ b/docs/src/core-concepts.md
@@ -65,10 +65,13 @@ Some commits should not be casually rewritten. History-rewriting commands —
 refuse to touch the following by default:
 
 - **Merged PR/MR commits.** If an entry's PR/MR state is `Merged`, rewriting it
-  locally produces a duplicate of something already upstream.
+  locally produces a duplicate of something already upstream. This is the only
+  rule that catches **squash-merged** PRs, because their merge commit on
+  `origin/<base>` has a brand-new SHA that doesn't share ancestry with your
+  local commit.
 - **Base-ancestor commits.** Any commit already reachable from `origin/<base>`
-  (for example, because it was squash-merged) falls in the same bucket. When
-  no `origin/<base>` ref exists, gg falls back to the local base branch.
+  via plain merge or rebase falls in the same bucket. When no `origin/<base>`
+  ref exists, gg falls back to the local base branch.
 
 Running one of those commands on an immutable target prints a clear error like:
 
@@ -85,9 +88,12 @@ scripts see that they are bypassing a safety check.
 
 ### Keeping PR state fresh
 
-Merge-state info is populated from the MR mapping in your config and is
-refreshed by `gg ls --refresh`. In a fresh clone or a long-lived checkout,
-state may be stale; the base-ancestor rule is the backstop — it catches
-squash-merged commits even when `mr_state` hasn't been refreshed. If you
-routinely edit history right after someone else merges your PR, run
-`gg ls --refresh` first.
+Each rewrite command runs a best-effort PR-state refresh against the
+configured provider just before the immutability check, so the merged-PR rule
+fires even when nothing in the session has touched provider state yet. The
+refresh is silent when offline / no auth is configured, in which case the
+base-ancestor rule remains the only protection. Note that base-ancestor does
+**not** catch squash-merges (those produce a new SHA on `origin/<base>`), so
+working offline against a repo that uses squash-merge is the one case where
+you can still rewrite a "merged" commit without `--force`. A working provider
+closes that gap automatically.

--- a/docs/src/core-concepts.md
+++ b/docs/src/core-concepts.md
@@ -57,3 +57,37 @@ Dependency chaining is automatic during `gg sync`:
 - This continues until stack head
 
 Result: reviewers can review from bottom to top, and `gg land` can merge safely in order.
+
+## Immutable commits
+
+Some commits should not be casually rewritten. History-rewriting commands —
+`gg squash`, `gg drop`, `gg reorder`, `gg split`, `gg absorb`, and `gg rebase` —
+refuse to touch the following by default:
+
+- **Merged PR/MR commits.** If an entry's PR/MR state is `Merged`, rewriting it
+  locally produces a duplicate of something already upstream.
+- **Base-ancestor commits.** Any commit already reachable from `origin/<base>`
+  (for example, because it was squash-merged) falls in the same bucket. When
+  no `origin/<base>` ref exists, gg falls back to the local base branch.
+
+Running one of those commands on an immutable target prints a clear error like:
+
+```text
+error: cannot rewrite immutable commits (pass --force / --ignore-immutable to override):
+  #2  abc1234  Fix typo in parser  (merged as !123)
+  #3  def5678  Bump dependency     (already in origin/main)
+```
+
+If you genuinely want to rewrite history anyway, pass `--force` (or
+`--ignore-immutable` if you prefer the longer, self-describing name). Every
+rewrite command accepts both spellings. The guard still emits a warning so
+scripts see that they are bypassing a safety check.
+
+### Keeping PR state fresh
+
+Merge-state info is populated from the MR mapping in your config and is
+refreshed by `gg ls --refresh`. In a fresh clone or a long-lived checkout,
+state may be stale; the base-ancestor rule is the backstop — it catches
+squash-merged commits even when `mr_state` hasn't been refreshed. If you
+routinely edit history right after someone else merges your PR, run
+`gg ls --refresh` first.

--- a/skills/gg/SKILL.md
+++ b/skills/gg/SKILL.md
@@ -128,7 +128,7 @@ gg land -a -c --json
 - Amend current commit: `gg sc` / `gg sc -a`
 - Auto-distribute staged hunks: `gg absorb -s`
 - Split a commit into two: `gg split` — opens a two-panel TUI for hunk selection (files on the left, colored diff on the right), followed by inline commit message inputs for both the new and remainder commits. Use `--no-tui` to fall back to sequential `git add -p` style prompts. The `-m` flag bypasses the TUI message input for the new commit. The `--no-edit` flag skips the remainder message input. Pass `FILES...` to auto-select all hunks from those files (e.g., `gg split -c 3 file1.rs file2.rs`).
-- Drop commits from stack: `gg drop <position|sha|gg-id>... --force` (alias: `gg abandon`)
+- Drop commits from stack: `gg drop <position|sha|gg-id>... -y` (alias: `gg abandon`). Use `-y` / `--yes` to skip confirmation; add `-f` / `--force` only to bypass the immutability guard for merged/base-ancestor commits.
 - Reorder/drop stack (TUI): `gg reorder` (or `gg arrange`) — opens interactive TUI for visual reordering and dropping commits. Press `d` to mark a commit for dropping. Use `--no-tui` to fall back to text editor (delete lines to drop).
 - Reorder stack (direct): `gg reorder -o "3,1,2"`
 - Sync subset: `gg sync -u <position|gg-id|sha> --json`
@@ -275,7 +275,7 @@ The `gg-mcp` binary exposes git-gud as an MCP server (stdio transport). Set `GG_
 - `stack_rebase` — rebase onto latest base
 - `stack_squash` / `stack_absorb` — amend commits
 - `stack_reconcile` — fix out-of-sync remote branches
-- `stack_drop` — remove commits from the stack (always uses `--force`; agent confirms with user)
+- `stack_drop` — remove commits from the stack (always passes `--yes`; set `force: true` only to bypass the immutability guard for merged/base commits; agent confirms with user before any drop)
 - `stack_split` — split a commit using interactive hunk selection (TUI opens by default; pass FILES... to auto-select all hunks for those files)
 - `stack_reorder` — reorder commits with explicit order string (no TUI)
 
@@ -289,4 +289,4 @@ The `gg-mcp` binary exposes git-gud as an MCP server (stdio transport). Set `GG_
 - **Never call `stack_land` without explicit user approval.**
 - Parse JSON output from `stack_sync`, `stack_land`, `stack_clean`, and `stack_lint`.
 - If `stack_status` shows `behind_base > 0`, run `stack_rebase` before syncing.
-- Rewrite tools (`stack_squash`, `stack_absorb`, `stack_reorder`, `stack_split`, `stack_drop`, `stack_rebase`) will fail with `ImmutableTargets` when a target commit is merged or already on the base branch. Each tool accepts a `force: bool` parameter that maps to `--force` / `--ignore-immutable`. Only set `force: true` after surfacing the affected commits to the user and getting explicit approval. `stack_drop` always passes `--force` because its CLI semantics already include skipping confirmation — confirm with the user before calling.
+- Rewrite tools (`stack_squash`, `stack_absorb`, `stack_reorder`, `stack_split`, `stack_drop`, `stack_rebase`) will fail with `ImmutableTargets` when a target commit is merged or already on the base branch. Each tool accepts a `force: bool` parameter that maps to `--force` / `--ignore-immutable`. Only set `force: true` after surfacing the affected commits to the user and getting explicit approval. `stack_drop` always passes `--yes` (MCP is non-interactive), but its `force: bool` param is separate from the confirmation-skip — leave it `false` unless the user has approved rewriting merged/base commits.

--- a/skills/gg/SKILL.md
+++ b/skills/gg/SKILL.md
@@ -120,6 +120,7 @@ gg land -a -c --json
 5. If sync warns stack is behind base, run `gg rebase` first.
 6. Prefer `gg absorb -s` for multi-commit edits.
 7. **Never use `git add -A` blindly.** Review `git status` first and only stage intended files. Use `git add <specific-files>` to avoid leaking secrets, env files, or unrelated changes.
+8. **Respect the immutability guard.** Rewrite-style commands (`gg sc`, `gg absorb`, `gg reorder`/`gg arrange`, `gg split`, `gg drop`, `gg rebase`) refuse to rewrite merged PRs/MRs or commits already on the base branch. If the command exits with `ImmutableTargets`, surface the listed commits and reasons to the user and get explicit confirmation before retrying with `-f` / `--force` (alias `--ignore-immutable`).
 
 ## Common operations
 
@@ -177,6 +178,27 @@ subsequent tokens as the command, not as `gg run` flags.
 For repeatable linter runs with commands configured in `.git/gg/config.json`,
 prefer `gg lint` — it's `gg run --amend` with the command list coming from
 config.
+
+## Immutable commits
+
+gg refuses by default to rewrite commits that look "already published":
+
+- the tracked PR/MR is merged, or
+- the commit is already reachable from `origin/<base>` (or the local base, as
+  a fallback).
+
+The guard protects `gg sc`, `gg absorb`, `gg reorder` / `gg arrange`,
+`gg split`, `gg drop`, and `gg rebase`. When it fires, the command exits
+with an `ImmutableTargets` error listing every affected position, short
+SHA, title, and reason (e.g. `merged as !123`, `already in origin/main`).
+
+To bypass it intentionally, pass `-f` / `--force` (long alias
+`--ignore-immutable`). Always surface the listed commits and reasons to the
+user first; the override still emits a warning and proceeds.
+
+`gg land`'s post-merge cleanup bypasses the guard by design, and
+`gg absorb --dry-run` skips it (no rewrite happens). See
+`reference.md` → "Immutable commits" for details.
 
 ## PR/MR body ownership
 
@@ -267,3 +289,4 @@ The `gg-mcp` binary exposes git-gud as an MCP server (stdio transport). Set `GG_
 - **Never call `stack_land` without explicit user approval.**
 - Parse JSON output from `stack_sync`, `stack_land`, `stack_clean`, and `stack_lint`.
 - If `stack_status` shows `behind_base > 0`, run `stack_rebase` before syncing.
+- Rewrite tools (`stack_squash`, `stack_absorb`, `stack_reorder`, `stack_split`, `stack_drop`, `stack_rebase`) will fail with `ImmutableTargets` when a target commit is merged or already on the base branch. Each tool accepts a `force: bool` parameter that maps to `--force` / `--ignore-immutable`. Only set `force: true` after surfacing the affected commits to the user and getting explicit approval. `stack_drop` always passes `--force` because its CLI semantics already include skipping confirmation — confirm with the user before calling.

--- a/skills/gg/reference.md
+++ b/skills/gg/reference.md
@@ -124,7 +124,8 @@ Reorder and/or drop stack entries. Opens an interactive TUI by default where you
 #### `gg drop <TARGET>...` *(alias: `gg abandon`)*
 Remove one or more commits from the stack. Targets can be positions (1-indexed), short SHAs, or GG-IDs.
 
-- `-f, --force` (alias: `--ignore-immutable`) — skip confirmation **and** bypass the [immutability guard](#immutable-commits)
+- `-y, --yes` — skip the confirmation prompt without bypassing the [immutability guard](#immutable-commits). Use this for non-interactive callers (CI, MCP) that still want merged/base commits protected.
+- `-f, --force` (alias: `--ignore-immutable`) — bypass the [immutability guard](#immutable-commits). Implies `--yes`.
 - `--json`
 
 #### `gg reorder [OPTIONS]`
@@ -587,8 +588,10 @@ Run lint on stack commits.
 
 #### `stack_drop`
 Remove commits from the stack.
-- **Params:** `targets` (string[], required) — commits to drop: positions (1-indexed), short SHAs, or GG-IDs
-- **Notes:** Always uses `--force`, which skips interactive confirmation **and** bypasses the [immutability guard](#immutable-commits). Agent must confirm with user before calling, and must surface any merged/base-ancestor commits before dropping them.
+- **Params:**
+  - `targets` (string[], required) — commits to drop: positions (1-indexed), short SHAs, or GG-IDs
+  - `force` (bool, optional, default `false`) — bypass the [immutability guard](#immutable-commits) for merged/base-ancestor commits. When `false`, drops still succeed for regular commits; merged/base commits are refused with `ImmutableTargets`.
+- **Notes:** Always passes `--yes` to skip the interactive prompt (MCP is non-interactive). `force` is a separate opt-in so MCP drop does not silently rewrite already-published commits. Agent must confirm any drop with the user beforehand, and must surface the merged/base-ancestor reasons before retrying with `force: true`.
 - **Returns:** JSON with dropped commits and remaining count
 
 #### `stack_split`

--- a/skills/gg/reference.md
+++ b/skills/gg/reference.md
@@ -106,6 +106,7 @@ Move around stack entries.
 Squash changes into current stack commit.
 
 - `-a, --all`
+- `-f, --force` (alias: `--ignore-immutable`) — bypass the [immutability guard](#immutable-commits)
 
 #### `gg absorb [OPTIONS]`
 Auto-distribute staged changes to matching commits.
@@ -116,13 +117,14 @@ Auto-distribute staged changes to matching commits.
 - `--one-fixup-per-commit`
 - `-n, --no-limit`
 - `-s, --squash`
+- `-f, --force` (alias: `--ignore-immutable`) — bypass the [immutability guard](#immutable-commits)
 
 #### `gg reorder [OPTIONS]` (alias: `gg arrange`)
 Reorder and/or drop stack entries. Opens an interactive TUI by default where you can move commits with `J`/`K` (or Shift+arrows) and mark commits for dropping with `d`.
 #### `gg drop <TARGET>...` *(alias: `gg abandon`)*
 Remove one or more commits from the stack. Targets can be positions (1-indexed), short SHAs, or GG-IDs.
 
-- `-f, --force` — skip confirmation
+- `-f, --force` (alias: `--ignore-immutable`) — skip confirmation **and** bypass the [immutability guard](#immutable-commits)
 - `--json`
 
 #### `gg reorder [OPTIONS]`
@@ -130,6 +132,7 @@ Reorder stack entries. Opens an interactive TUI by default where you can move co
 
 - `-o, --order <ORDER>` — reorder only (no dropping via CLI flag)
 - `--no-tui` — disable TUI, use text editor instead (delete lines to drop commits)
+- `-f, --force` (alias: `--ignore-immutable`) — bypass the [immutability guard](#immutable-commits)
 
 #### `gg split [OPTIONS] [FILES...]`
 Split a commit into two. Selected files/hunks become a new commit inserted before the original.
@@ -138,10 +141,13 @@ Split a commit into two. Selected files/hunks become a new commit inserted befor
 - `-m, --message <MSG>` — message for the new commit
 - `--no-edit` — keep original message for remainder, don't prompt
 - `--no-tui` — disable TUI, use sequential prompt instead (legacy `git add -p` style)
+- `-f, --force` (alias: `--ignore-immutable`) — bypass the [immutability guard](#immutable-commits)
 - `FILES...` — auto-select all hunks from these files (opens interactive hunk picker if omitted)
 
 #### `gg rebase [TARGET]`
 Rebase current stack onto base or explicit target.
+
+- `-f, --force` (alias: `--ignore-immutable`) — bypass the [immutability guard](#immutable-commits)
 
 ### Utilities
 
@@ -436,6 +442,44 @@ Field types for `entries`:
 
 ---
 
+## Immutable commits
+
+gg refuses by default to let rewrite-style commands (`gg sc`, `gg absorb`,
+`gg reorder`/`gg arrange`, `gg split`, `gg drop`, `gg rebase`) touch commits
+that look "already published". A commit is considered immutable when any of
+these is true:
+
+- **Merged PR/MR** — the entry's tracked PR/MR state is `merged`.
+- **Base ancestor** — the commit is already reachable from `origin/<base>`
+  (falling back to the local base branch when the remote ref isn't
+  available). Covers anything already landed on the trunk.
+
+When the guard fires, the command exits with an `ImmutableTargets` error
+listing each affected position, short SHA, title, and reason, for example:
+
+```
+error: cannot rewrite immutable commits (use --force / --ignore-immutable to override):
+  #2  abc1234  Fix typo in parser          (merged as !123)
+  #3  def5678  Bump dependency             (already in origin/main)
+```
+
+To override intentionally, pass `-f` / `--force` (or the longer alias
+`--ignore-immutable`) to the command. The override emits a warning listing
+what is being rewritten and then proceeds.
+
+Notes for agents:
+
+- Before offering `--force`, surface the guard output to the user and get
+  explicit confirmation — bypassing is a footgun.
+- `gg rebase` and `gg sync`'s internal auto-rebase only consider a commit a
+  base ancestor **after** the remote ref is fetched, so the guard reflects
+  freshly-updated state rather than stale local refs.
+- `gg sync`'s other paths (push, PR create/update) are not guarded; only
+  history-rewriting commands are.
+- `gg land` performs a post-merge cleanup rebase with the guard
+  intentionally bypassed (the commits it touches are by definition just
+  merged).
+
 ## Operational guardrails for agents
 
 - Never run `gg land` without explicit user approval.
@@ -443,6 +487,7 @@ Field types for `entries`:
 - Always parse `--json` output, do not scrape text.
 - If `gg sync --json` includes warnings about stale base, run `gg rebase`.
 - For GitLab merge trains, monitor `in_merge_train` and `merge_train_position` in `gg ls --json`.
+- If a rewrite command fails with `ImmutableTargets`, explain to the user which commits are immutable and why before offering `--force`.
 
 ---
 
@@ -513,15 +558,15 @@ Clean up merged stacks.
 
 #### `stack_rebase`
 Rebase stack onto latest base.
-- **Params:** `target` (string, optional)
+- **Params:** `target` (string, optional), `force` (bool, default false) — bypass the [immutability guard](#immutable-commits)
 
 #### `stack_squash`
 Squash staged changes into current commit.
-- **Params:** `all` (bool)
+- **Params:** `all` (bool), `force` (bool, default false) — bypass the [immutability guard](#immutable-commits)
 
 #### `stack_absorb`
 Auto-absorb staged changes into correct commits.
-- **Params:** `dry_run` (bool), `and_rebase` (bool), `whole_file` (bool), `one_fixup_per_commit` (bool), `squash` (bool)
+- **Params:** `dry_run` (bool), `and_rebase` (bool), `whole_file` (bool), `one_fixup_per_commit` (bool), `squash` (bool), `force` (bool, default false) — bypass the [immutability guard](#immutable-commits)
 
 #### `stack_reconcile`
 Reconcile out-of-sync remote branches.
@@ -543,7 +588,7 @@ Run lint on stack commits.
 #### `stack_drop`
 Remove commits from the stack.
 - **Params:** `targets` (string[], required) — commits to drop: positions (1-indexed), short SHAs, or GG-IDs
-- **Notes:** Always uses `--force` (no interactive confirmation). Agent should confirm with user before calling.
+- **Notes:** Always uses `--force`, which skips interactive confirmation **and** bypasses the [immutability guard](#immutable-commits). Agent must confirm with user before calling, and must surface any merged/base-ancestor commits before dropping them.
 - **Returns:** JSON with dropped commits and remaining count
 
 #### `stack_split`
@@ -553,11 +598,14 @@ Split a commit by moving specified files to a new commit.
   - `files` (string[], required) — files to include in the new commit
   - `message` (string, optional) — message for the new commit
   - `no_edit` (bool, default false) — skip prompt for remainder commit message
+  - `force` (bool, default false) — bypass the [immutability guard](#immutable-commits)
 - **Notes:** File-level only (`--no-tui` implicit). Hunk-level selection not available via MCP.
 - **Returns:** Result of the split operation
 
 #### `stack_reorder`
 Reorder commits in the stack.
-- **Params:** `order` (string, required) — new order as positions (1-indexed), e.g., "3,1,2" or "3 1 2". Position 1 = bottom (closest to base).
+- **Params:**
+  - `order` (string, required) — new order as positions (1-indexed), e.g., "3,1,2" or "3 1 2". Position 1 = bottom (closest to base).
+  - `force` (bool, default false) — bypass the [immutability guard](#immutable-commits)
 - **Notes:** Direct mode only (`--no-tui` implicit). No interactive TUI via MCP.
 - **Returns:** Result of the reorder operation


### PR DESCRIPTION
## Summary

Introduces a consistent immutability boundary for commits that are already part of the project's shared, landed history. Six history-rewriting commands — `gg sc`, `gg drop`, `gg reorder`/`gg arrange`, `gg split`, `gg absorb`, and `gg rebase` — now refuse by default to mutate commits whose PR/MR is merged or which are reachable from `origin/<base>`, preventing local duplicates of upstream history and accidental rewrites of landed work.

A commit is considered **immutable** when either:
- its PR/MR is merged (`StackEntry.mr_state == Merged`), or
- it is reachable from `origin/<base>` (falling back to local `<base>` if the remote ref isn't present).

Users can bypass the check with `-f, --force` (alias `--ignore-immutable`). `gg drop`'s existing `--force` flag is overloaded to also override the guard.

## What changed

- **New `gg-core::immutability` module** with `ImmutabilityPolicy`, `ImmutabilityReport`, and a shared `guard()` helper. Error surfaced via a new `Error::ImmutableTargets` variant that renders a multi-line `position · sha · title — reason` report.
- **`gg sc`, `gg drop`, `gg reorder`/`gg arrange`, `gg split`, `gg absorb`, `gg rebase`** — each now calls the guard before mutating and each gained a `-f, --force` flag (alias `--ignore-immutable`).
- **`gg sync`** still respects the guard during auto-rebase (user-initiated flow).
- **`gg land`** bypasses the guard on its post-merge cleanup rebase (sanctioned).
- **`gg absorb --dry-run`** skips the guard so previews remain safe to run.
- **Docs** — new *Immutable commits* section in `docs/src/core-concepts.md`, plus per-command option docs and a CHANGELOG entry.

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — no issues
- [x] `cargo test --workspace` — 609 tests pass
- [x] 11 unit tests for the policy module (report formatting, guard behavior, both rules, dedup, `check_all`)
- [x] 5 integration tests using real git fixtures (base-ancestor rule fires, silent when behind, merged+base stack together, guard error formatting, local-base fallback)
- [ ] Manual smoke test: landed stack → `gg sc` / `gg rebase` / `gg split -c <landed>` refuses with readable error; `--force` proceeds
- [ ] Manual smoke test: `gg absorb --dry-run` works on a landed stack without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)