### PR TITLE
feat: add `gg undo` with per-repo operation log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `gg undo` command: reverses the local ref/HEAD effects of the most recent
+  mutating `gg` command. `gg undo --list` shows the recent operation log
+  (newest-first, with id, kind, status, args, and undoability); `gg undo
+  <operation_id>` targets a specific record. A second `gg undo` redoes the
+  first (undo of an undo). Operations that touched a remote (`sync`, `land`)
+  are recorded but refused for local replay — `gg` prints a provider-specific
+  revert hint instead of silently rewriting published history. The working
+  tree is never modified.
+- Per-repo operation log at `<commondir>/gg/operations/*.json` feeds the new
+  command. The log is a bounded ring buffer of 100 records; `Pending`
+  records are never pruned so interrupted operations stay visible.
+- `gg undo --json` emits a stable, additive response schema
+  (`UndoResponse` / `UndoListResponse`) — see `docs/src/commands/undo.md`.
+- MCP tools `stack_undo` and `stack_undo_list` shell out to the CLI for
+  agentic undo / log-inspection workflows.
 - Immutability guard for history-rewriting commands: `gg sc`, `gg drop`,
   `gg reorder`/`gg arrange`, `gg split`, `gg absorb`, and `gg rebase` now
   refuse by default to rewrite commits whose PR/MR is already merged or which
@@ -15,6 +30,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--ignore-immutable`) bypasses the check for each of these commands.
 
 ### Changed
+- **Behavior change — new lock acquisition.** `gg reorder`, `gg absorb`,
+  `gg reconcile`, and `gg run --amend` now acquire the existing operation
+  lock for the duration of their work. Concurrent invocations will serialize
+  instead of racing, which closes a latent window where two of these
+  commands running in parallel could corrupt ref state. User-visible
+  effect: a second concurrent invocation will print "Another gg operation
+  is currently running" and exit, instead of proceeding unsafely.
 - `gg drop --force` now *also* overrides the immutability check, in addition
   to skipping the existing confirmation prompt. Scripts that previously
   relied on `--force` to silently rewrite merged commits will continue to

--- a/README.md
+++ b/README.md
@@ -230,6 +230,8 @@ gg clean
 | `gg reconcile --dry-run` | Show what reconcile would do without making changes |
 | `gg continue` | Continue after resolving conflicts |
 | `gg abort` | Abort current operation |
+| `gg undo [OP_ID]` | Reverse the local ref/HEAD effects of the most recent mutating `gg` command (refuses on remote-touching ops) |
+| `gg undo --list` | Show recent operations from the per-repo operation log |
 | `gg completions <shell>` | Generate shell completions |
 
 ## Configuration

--- a/crates/gg-cli/src/main.rs
+++ b/crates/gg-cli/src/main.rs
@@ -411,8 +411,9 @@ enum Commands {
         #[arg(long)]
         json: bool,
 
-        /// Limit for `--list` (default 20).
-        #[arg(long, default_value_t = 20)]
+        /// Limit for `--list` (default 100, matches the op-log cap). Has no
+        /// effect unless `--list` is also passed.
+        #[arg(long, default_value_t = 100, requires = "list")]
         limit: usize,
     },
 }
@@ -681,6 +682,12 @@ fn main() {
     };
 
     if let Err(e) = result {
+        // `GgError::Silenced` means the command already emitted a detailed
+        // human diagnostic; we just need to exit non-zero without prepending
+        // a second generic "error: ..." line.
+        if matches!(e, gg_core::error::GgError::Silenced) {
+            exit(1);
+        }
         if json_mode {
             gg_core::output::print_json_error(&e.to_string());
         } else {

--- a/crates/gg-cli/src/main.rs
+++ b/crates/gg-cli/src/main.rs
@@ -395,6 +395,26 @@ enum Commands {
         #[arg(short = 'n', long)]
         dry_run: bool,
     },
+
+    /// Undo the last local-only gg operation (see `gg undo --list`)
+    #[command(name = "undo")]
+    Undo {
+        /// List recent operations and their undoable status instead of undoing.
+        #[arg(long)]
+        list: bool,
+
+        /// Specific operation id to undo (defaults to most-recent-undoable).
+        #[arg(value_name = "OPERATION_ID")]
+        operation_id: Option<String>,
+
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+
+        /// Limit for `--list` (default 20).
+        #[arg(long, default_value_t = 20)]
+        limit: usize,
+    },
 }
 
 fn main() {
@@ -644,6 +664,20 @@ fn main() {
         Some(Commands::Reconcile { dry_run }) => {
             (gg_core::commands::reconcile::run(dry_run), false)
         }
+        Some(Commands::Undo {
+            list,
+            operation_id,
+            json,
+            limit,
+        }) => (
+            gg_core::commands::undo::run(gg_core::commands::undo::UndoCliOptions {
+                list,
+                operation_id,
+                json,
+                limit,
+            }),
+            json,
+        ),
     };
 
     if let Err(e) = result {

--- a/crates/gg-cli/tests/integration_tests.rs
+++ b/crates/gg-cli/tests/integration_tests.rs
@@ -8681,3 +8681,88 @@ fn test_undo_help_mentions_list_and_json() {
     assert!(stdout.contains("--json"), "help must document --json");
     assert!(stdout.contains("--limit"), "help must document --limit");
 }
+
+#[test]
+fn test_undo_roundtrip_from_worktree() {
+    // Regression coverage for a subtle interaction between `gg undo` and
+    // linked worktrees: the op-log lives under `commondir/gg/operations`
+    // and the op lock under the shared common git dir, so a mutation run
+    // inside a linked worktree must produce a record that a subsequent
+    // `gg undo` invoked from the same worktree can read and replay.
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .expect("Failed to write config");
+
+    let stack_name = "undo-wt-test";
+    let (success, _stdout, stderr) = run_gg(&repo_path, &["co", stack_name, "--worktree"]);
+    assert!(success, "Failed to create worktree stack: {stderr}");
+
+    // Default worktree layout: ../<repo-dir>.<stack>/
+    let worktree_path = repo_path.parent().unwrap().join(format!(
+        "{}.{}",
+        repo_path.file_name().unwrap().to_string_lossy(),
+        stack_name
+    ));
+    assert!(
+        worktree_path.exists(),
+        "Worktree should exist at {}",
+        worktree_path.display()
+    );
+    let wt = worktree_path.to_path_buf();
+
+    // Build a 3-commit stack inside the worktree.
+    for i in 1..=3 {
+        fs::write(
+            worktree_path.join(format!("f{i}.txt")),
+            format!("content {i}"),
+        )
+        .unwrap();
+        run_git(&wt, &["add", "."]);
+        run_git(&wt, &["commit", "-m", &format!("Commit {i}")]);
+    }
+    let head_before_drop = head_sha(&wt);
+
+    // Drop position 2 from inside the worktree.
+    let (success, _, stderr) = run_gg(&wt, &["drop", "2", "--force"]);
+    assert!(success, "drop from worktree failed: {stderr}");
+    assert_ne!(
+        head_sha(&wt),
+        head_before_drop,
+        "drop should move HEAD in the worktree"
+    );
+
+    // `undo --list` run from the worktree must see the drop record. Both
+    // paths share `commondir`, so the op log is visible.
+    let (success, stdout, stderr) = run_gg(&wt, &["undo", "--list", "--json"]);
+    assert!(success, "undo --list from worktree failed: {stderr}");
+    let parsed: Value = serde_json::from_str(&stdout).expect("stdout must be valid JSON");
+    let ops = parsed["operations"]
+        .as_array()
+        .expect("operations must be array");
+    assert!(
+        ops.iter().any(|op| op["kind"] == "drop"),
+        "worktree op-log should include the drop record: {ops:?}"
+    );
+
+    // Undo from the worktree — HEAD should return to the pre-drop sha.
+    let (success, stdout, stderr) = run_gg(&wt, &["undo", "--json"]);
+    assert!(
+        success,
+        "undo from worktree failed: stdout={stdout} stderr={stderr}"
+    );
+    let parsed: Value = serde_json::from_str(&stdout).expect("stdout must be valid JSON");
+    assert_eq!(parsed["status"], "succeeded");
+    assert_eq!(parsed["undone"]["kind"], "drop");
+
+    assert_eq!(
+        head_sha(&wt),
+        head_before_drop,
+        "undo from worktree should restore pre-drop HEAD"
+    );
+}

--- a/crates/gg-cli/tests/integration_tests.rs
+++ b/crates/gg-cli/tests/integration_tests.rs
@@ -8431,3 +8431,261 @@ fn test_land_admin_config_enabled() {
         "Config should contain land_admin when enabled"
     );
 }
+
+// ===== `gg undo` integration tests =====
+//
+// These cover the end-to-end CLI surface. Ref-level semantics, refusal modes,
+// and per-scope snapshot logic are covered by unit tests in
+// `crates/gg-core/src/operations.rs` — the tests here focus on observable
+// command behavior (exit code, JSON shape, ref/HEAD effects, redo, list
+// ordering, error paths for unknown operation_id, --limit handling).
+
+/// Seed a repo with a gg config and return its path.
+fn setup_undo_test_repo(stack_name: &str) -> (TempDir, PathBuf) {
+    let (temp_dir, repo_path) = create_test_repo();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).unwrap();
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .unwrap();
+
+    let (success, _, stderr) = run_gg(&repo_path, &["co", stack_name]);
+    assert!(success, "Failed to create stack {stack_name}: {stderr}");
+    (temp_dir, repo_path)
+}
+
+/// Return the current HEAD sha as a String.
+fn head_sha(repo_path: &std::path::Path) -> String {
+    let (success, stdout) = run_git(repo_path, &["rev-parse", "HEAD"]);
+    assert!(success, "git rev-parse HEAD failed");
+    stdout.trim().to_string()
+}
+
+#[test]
+fn test_undo_list_empty_when_no_ops() {
+    let (_temp_dir, repo_path) = setup_undo_test_repo("undo-empty");
+
+    // No mutating ops yet → list should succeed with empty operations array.
+    let (success, stdout, stderr) = run_gg(&repo_path, &["undo", "--list", "--json"]);
+    assert!(success, "undo --list failed: stderr={stderr}");
+
+    let parsed: Value = serde_json::from_str(&stdout).expect("stdout must be valid JSON");
+    assert_eq!(parsed["version"], 1);
+    let ops = parsed["operations"]
+        .as_array()
+        .expect("operations must be array");
+    // `gg co` above actually records a checkout operation, so this is non-empty.
+    // Assert the invariant we care about: only `checkout`-kind records exist.
+    for op in ops {
+        assert_eq!(
+            op["kind"], "checkout",
+            "unexpected op kind before any mutations: {op:?}"
+        );
+    }
+}
+
+#[test]
+fn test_undo_reverses_drop() {
+    let (_temp_dir, repo_path) = setup_undo_test_repo("undo-drop");
+
+    // Build a 3-commit stack.
+    for i in 1..=3 {
+        fs::write(
+            repo_path.join(format!("f{i}.txt")),
+            format!("content {i}"),
+        )
+        .unwrap();
+        run_git(&repo_path, &["add", "."]);
+        run_git(&repo_path, &["commit", "-m", &format!("Commit {i}")]);
+    }
+    let head_before_drop = head_sha(&repo_path);
+
+    // Drop position 2.
+    let (success, _, stderr) = run_gg(&repo_path, &["drop", "2", "--force"]);
+    assert!(success, "drop failed: {stderr}");
+    let (_, stdout, _) = run_gg(&repo_path, &["ls"]);
+    assert!(!stdout.contains("Commit 2"), "drop did not remove Commit 2");
+
+    // Undo — HEAD should return to the pre-drop sha.
+    let (success, stdout, stderr) = run_gg(&repo_path, &["undo", "--json"]);
+    assert!(success, "undo failed: stdout={stdout} stderr={stderr}");
+
+    let parsed: Value = serde_json::from_str(&stdout).expect("stdout must be valid JSON");
+    assert_eq!(parsed["version"], 1);
+    assert_eq!(parsed["status"], "succeeded");
+    assert_eq!(parsed["undone"]["kind"], "drop");
+    assert_eq!(parsed["undone"]["is_undoable"], true);
+    assert_eq!(parsed["undone"]["is_undo"], false);
+    assert_eq!(parsed["undone"]["touched_remote"], false);
+
+    assert_eq!(
+        head_sha(&repo_path),
+        head_before_drop,
+        "undo should restore pre-drop HEAD"
+    );
+
+    let (_, stdout, _) = run_gg(&repo_path, &["ls"]);
+    assert!(
+        stdout.contains("Commit 2"),
+        "undo should restore Commit 2: {stdout}"
+    );
+}
+
+#[test]
+fn test_undo_reverses_sc_amend() {
+    let (_temp_dir, repo_path) = setup_undo_test_repo("undo-sc");
+
+    fs::write(repo_path.join("a.txt"), "v1").unwrap();
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "Base commit"]);
+    let head_before_sc = head_sha(&repo_path);
+
+    // Stage a change and amend via `gg sc -a`.
+    fs::write(repo_path.join("a.txt"), "v2").unwrap();
+    let (success, _, stderr) = run_gg(&repo_path, &["sc", "-a"]);
+    assert!(success, "gg sc -a failed: {stderr}");
+    assert_ne!(head_sha(&repo_path), head_before_sc, "sc should move HEAD");
+
+    // Undo the amend.
+    let (success, stdout, stderr) = run_gg(&repo_path, &["undo", "--json"]);
+    assert!(success, "undo failed: stdout={stdout} stderr={stderr}");
+
+    let parsed: Value = serde_json::from_str(&stdout).expect("stdout must be valid JSON");
+    assert_eq!(parsed["status"], "succeeded");
+    assert_eq!(parsed["undone"]["kind"], "squash");
+
+    assert_eq!(
+        head_sha(&repo_path),
+        head_before_sc,
+        "undo should restore pre-sc HEAD"
+    );
+}
+
+#[test]
+fn test_undo_list_newest_first_and_limit() {
+    let (_temp_dir, repo_path) = setup_undo_test_repo("undo-list-order");
+
+    // Three commits — three separate mutating ops on top of the checkout.
+    for i in 1..=3 {
+        fs::write(
+            repo_path.join(format!("f{i}.txt")),
+            format!("content {i}"),
+        )
+        .unwrap();
+        run_git(&repo_path, &["add", "."]);
+        run_git(&repo_path, &["commit", "-m", &format!("Commit {i}")]);
+    }
+    // Two gg mutations to generate distinct log entries.
+    run_gg(&repo_path, &["prev"]);
+    run_gg(&repo_path, &["next"]);
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["undo", "--list", "--json"]);
+    assert!(success, "undo --list failed: {stderr}");
+
+    let parsed: Value = serde_json::from_str(&stdout).expect("stdout must be valid JSON");
+    let ops = parsed["operations"]
+        .as_array()
+        .expect("operations must be array");
+    assert!(ops.len() >= 2, "expected at least 2 ops, got {}", ops.len());
+
+    // Newest-first: created_at_ms is monotonically non-increasing.
+    let mut prev: u64 = u64::MAX;
+    for op in ops {
+        let ts = op["created_at_ms"]
+            .as_u64()
+            .expect("created_at_ms must be u64");
+        assert!(
+            ts <= prev,
+            "operations must be newest-first; prev={prev} ts={ts}"
+        );
+        prev = ts;
+    }
+
+    // --limit caps the response.
+    let (success, stdout, _) = run_gg(&repo_path, &["undo", "--list", "--limit", "1", "--json"]);
+    assert!(success);
+    let parsed: Value = serde_json::from_str(&stdout).expect("stdout must be valid JSON");
+    let ops = parsed["operations"].as_array().unwrap();
+    assert_eq!(ops.len(), 1, "--limit 1 must return exactly 1 op");
+}
+
+#[test]
+fn test_undo_is_itself_recorded_and_double_undo_redoes() {
+    let (_temp_dir, repo_path) = setup_undo_test_repo("undo-redo");
+
+    // One commit → one drop so there is something to undo.
+    fs::write(repo_path.join("a.txt"), "v1").unwrap();
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "Commit A"]);
+    fs::write(repo_path.join("b.txt"), "v1").unwrap();
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "Commit B"]);
+    let head_with_both = head_sha(&repo_path);
+
+    // Drop commit A (position 1).
+    let (success, _, stderr) = run_gg(&repo_path, &["drop", "1", "--force"]);
+    assert!(success, "drop failed: {stderr}");
+    let head_after_drop = head_sha(&repo_path);
+    assert_ne!(head_after_drop, head_with_both);
+
+    // First undo → back to head_with_both.
+    let (success, _, stderr) = run_gg(&repo_path, &["undo"]);
+    assert!(success, "first undo failed: {stderr}");
+    assert_eq!(head_sha(&repo_path), head_with_both);
+
+    // Second undo should redo (reverse the undo), landing back at head_after_drop.
+    let (success, _, stderr) = run_gg(&repo_path, &["undo"]);
+    assert!(success, "second undo (redo) failed: {stderr}");
+    assert_eq!(
+        head_sha(&repo_path),
+        head_after_drop,
+        "second undo should redo to post-drop HEAD"
+    );
+
+    // The log should contain at least one undo-kind record with is_undo=true
+    // and an `undoes` field pointing at another op.
+    let (_, stdout, _) = run_gg(&repo_path, &["undo", "--list", "--json"]);
+    let parsed: Value = serde_json::from_str(&stdout).expect("valid JSON");
+    let ops = parsed["operations"].as_array().unwrap();
+    let has_undo_record = ops.iter().any(|op| {
+        op["kind"] == "undo"
+            && op["is_undo"] == true
+            && op["undoes"].as_str().is_some_and(|s| s.starts_with("op_"))
+    });
+    assert!(
+        has_undo_record,
+        "expected an undo-kind record with is_undo=true and undoes='op_...': {ops:?}"
+    );
+}
+
+#[test]
+fn test_undo_unknown_operation_id_errors() {
+    let (_temp_dir, repo_path) = setup_undo_test_repo("undo-unknown");
+
+    // Pass a bogus operation id; command must fail cleanly.
+    let (success, stdout, stderr) = run_gg(&repo_path, &["undo", "op_does_not_exist_xxxxxxxx"]);
+    assert!(
+        !success,
+        "unknown operation_id must fail; stdout={stdout} stderr={stderr}"
+    );
+    // We don't pin the exact error text, but it must mention the id or "not found".
+    let combined = format!("{stdout}{stderr}");
+    assert!(
+        combined.to_lowercase().contains("not found")
+            || combined.contains("op_does_not_exist_xxxxxxxx"),
+        "error should reference the missing op id: {combined}"
+    );
+}
+
+#[test]
+fn test_undo_help_mentions_list_and_json() {
+    let (_temp_dir, repo_path) = create_test_repo();
+    let (success, stdout, _stderr) = run_gg(&repo_path, &["undo", "--help"]);
+    assert!(success);
+    assert!(stdout.contains("--list"), "help must document --list");
+    assert!(stdout.contains("--json"), "help must document --json");
+    assert!(stdout.contains("--limit"), "help must document --limit");
+}

--- a/crates/gg-cli/tests/integration_tests.rs
+++ b/crates/gg-cli/tests/integration_tests.rs
@@ -8493,11 +8493,7 @@ fn test_undo_reverses_drop() {
 
     // Build a 3-commit stack.
     for i in 1..=3 {
-        fs::write(
-            repo_path.join(format!("f{i}.txt")),
-            format!("content {i}"),
-        )
-        .unwrap();
+        fs::write(repo_path.join(format!("f{i}.txt")), format!("content {i}")).unwrap();
         run_git(&repo_path, &["add", "."]);
         run_git(&repo_path, &["commit", "-m", &format!("Commit {i}")]);
     }
@@ -8570,11 +8566,7 @@ fn test_undo_list_newest_first_and_limit() {
 
     // Three commits — three separate mutating ops on top of the checkout.
     for i in 1..=3 {
-        fs::write(
-            repo_path.join(format!("f{i}.txt")),
-            format!("content {i}"),
-        )
-        .unwrap();
+        fs::write(repo_path.join(format!("f{i}.txt")), format!("content {i}")).unwrap();
         run_git(&repo_path, &["add", "."]);
         run_git(&repo_path, &["commit", "-m", &format!("Commit {i}")]);
     }

--- a/crates/gg-core/src/commands/absorb.rs
+++ b/crates/gg-core/src/commands/absorb.rs
@@ -41,16 +41,11 @@ pub fn run(options: AbsorbOptions) -> Result<()> {
     let repo = git::open_repo()?;
     let gg_config = Config::load_with_global(repo.commondir())?;
 
-    // Acquire operation lock + record a Pending op for the undo log.
+    // Acquire the operation lock for validation, but defer writing the
+    // op-log record until after the immutability guard passes so refused
+    // operations never pollute `gg undo --list` (design §4.6).
     // NOTE: behaviour change — absorb previously had no lock.
-    let (_lock, guard) = git::acquire_operation_lock_and_record(
-        &repo,
-        &gg_config,
-        OperationKind::Absorb,
-        std::env::args().collect(),
-        None,
-        SnapshotScope::AllUserBranches,
-    )?;
+    let _lock = git::acquire_operation_lock(&repo, "absorb")?;
 
     // Check if there are staged changes
     let statuses = repo.statuses(None)?;
@@ -82,13 +77,7 @@ pub fn run(options: AbsorbOptions) -> Result<()> {
         } else {
             println!("{}", style("No changes to absorb.").dim());
         }
-        guard.finalize_with_scope(
-            &repo,
-            &gg_config,
-            SnapshotScope::AllUserBranches,
-            vec![],
-            false,
-        )?;
+        // No mutation — no record needed.
         return Ok(());
     }
 
@@ -113,6 +102,23 @@ pub fn run(options: AbsorbOptions) -> Result<()> {
         let report = policy.check_all(&stack);
         immutability::guard(report, options.force)?;
     }
+
+    // All validation passed and we are about to mutate: write the Pending
+    // op-log record now so a failure beyond this point leaves a record the
+    // sweep can promote to Interrupted. Dry-run mutates nothing, so skip
+    // recording entirely in that branch.
+    let guard = if options.dry_run {
+        None
+    } else {
+        Some(git::begin_recorded_op(
+            &repo,
+            &gg_config,
+            OperationKind::Absorb,
+            std::env::args().skip(1).collect(),
+            None,
+            SnapshotScope::AllUserBranches,
+        )?)
+    };
 
     // Determine the base reference for absorb
     // We want to absorb into commits between base and HEAD
@@ -203,13 +209,15 @@ pub fn run(options: AbsorbOptions) -> Result<()> {
     };
     outcome?;
 
-    guard.finalize_with_scope(
-        &repo,
-        &gg_config,
-        SnapshotScope::AllUserBranches,
-        vec![],
-        false,
-    )?;
+    if let Some(guard) = guard {
+        guard.finalize_with_scope(
+            &repo,
+            &gg_config,
+            SnapshotScope::AllUserBranches,
+            vec![],
+            false,
+        )?;
+    }
 
     Ok(())
 }

--- a/crates/gg-core/src/commands/absorb.rs
+++ b/crates/gg-core/src/commands/absorb.rs
@@ -13,6 +13,7 @@ use crate::config::Config;
 use crate::error::{GgError, Result};
 use crate::git;
 use crate::immutability::{self, ImmutabilityPolicy};
+use crate::operations::{OperationKind, SnapshotScope};
 use crate::stack::Stack;
 
 /// Options for the absorb command
@@ -39,6 +40,17 @@ pub struct AbsorbOptions {
 pub fn run(options: AbsorbOptions) -> Result<()> {
     let repo = git::open_repo()?;
     let gg_config = Config::load_with_global(repo.commondir())?;
+
+    // Acquire operation lock + record a Pending op for the undo log.
+    // NOTE: behaviour change — absorb previously had no lock.
+    let (_lock, guard) = git::acquire_operation_lock_and_record(
+        &repo,
+        &gg_config,
+        OperationKind::Absorb,
+        std::env::args().collect(),
+        None,
+        SnapshotScope::AllUserBranches,
+    )?;
 
     // Check if there are staged changes
     let statuses = repo.statuses(None)?;
@@ -70,6 +82,13 @@ pub fn run(options: AbsorbOptions) -> Result<()> {
         } else {
             println!("{}", style("No changes to absorb.").dim());
         }
+        guard.finalize_with_scope(
+            &repo,
+            &gg_config,
+            SnapshotScope::AllUserBranches,
+            vec![],
+            false,
+        )?;
         return Ok(());
     }
 
@@ -130,7 +149,7 @@ pub fn run(options: AbsorbOptions) -> Result<()> {
 
     // Run git-absorb
     let _env_guard = prepare_git_absorb_env(&repo);
-    match git_absorb::run(&logger, &absorb_config) {
+    let outcome = match git_absorb::run(&logger, &absorb_config) {
         Ok(()) => {
             if options.dry_run {
                 println!(
@@ -181,7 +200,18 @@ pub fn run(options: AbsorbOptions) -> Result<()> {
                 Err(GgError::Other(format!("git-absorb failed: {}", error_msg)))
             }
         }
-    }
+    };
+    outcome?;
+
+    guard.finalize_with_scope(
+        &repo,
+        &gg_config,
+        SnapshotScope::AllUserBranches,
+        vec![],
+        false,
+    )?;
+
+    Ok(())
 }
 
 /// Create a slog logger for git-absorb output

--- a/crates/gg-core/src/commands/checkout.rs
+++ b/crates/gg-core/src/commands/checkout.rs
@@ -277,7 +277,13 @@ pub fn run(stack_name: Option<String>, base: Option<String>, use_worktree: bool)
         }
     }
 
-    guard.finalize_with_scope(&repo, &config, SnapshotScope::AllUserBranches, vec![], false)?;
+    guard.finalize_with_scope(
+        &repo,
+        &config,
+        SnapshotScope::AllUserBranches,
+        vec![],
+        false,
+    )?;
 
     Ok(())
 }

--- a/crates/gg-core/src/commands/checkout.rs
+++ b/crates/gg-core/src/commands/checkout.rs
@@ -7,6 +7,7 @@ use git2::BranchType;
 use crate::config::Config;
 use crate::error::{GgError, Result};
 use crate::git;
+use crate::operations::{OperationKind, SnapshotScope};
 use crate::provider::Provider;
 use crate::stack;
 
@@ -17,12 +18,18 @@ use std::process::Command;
 /// Run the checkout command
 pub fn run(stack_name: Option<String>, base: Option<String>, use_worktree: bool) -> Result<()> {
     let repo = git::open_repo()?;
-
-    // Acquire operation lock to prevent concurrent operations
-    let _lock = git::acquire_operation_lock(&repo, "checkout")?;
-
     let git_dir = repo.commondir();
     let mut config = Config::load_with_global(git_dir)?;
+
+    // Acquire operation lock + record a Pending op for the undo log.
+    let (_lock, guard) = git::acquire_operation_lock_and_record(
+        &repo,
+        &config,
+        OperationKind::Checkout,
+        std::env::args().collect(),
+        stack_name.clone(),
+        SnapshotScope::AllUserBranches,
+    )?;
 
     // Get username from config or provider
     let username = config
@@ -269,6 +276,8 @@ pub fn run(stack_name: Option<String>, base: Option<String>, use_worktree: bool)
             }
         }
     }
+
+    guard.finalize_with_scope(&repo, &config, SnapshotScope::AllUserBranches, vec![], false)?;
 
     Ok(())
 }

--- a/crates/gg-core/src/commands/checkout.rs
+++ b/crates/gg-core/src/commands/checkout.rs
@@ -26,7 +26,7 @@ pub fn run(stack_name: Option<String>, base: Option<String>, use_worktree: bool)
         &repo,
         &config,
         OperationKind::Checkout,
-        std::env::args().collect(),
+        std::env::args().skip(1).collect(),
         stack_name.clone(),
         SnapshotScope::AllUserBranches,
     )?;

--- a/crates/gg-core/src/commands/clean.rs
+++ b/crates/gg-core/src/commands/clean.rs
@@ -24,7 +24,7 @@ pub fn run_for_stack(stack_name: &str, force: bool) -> Result<()> {
         &repo,
         &config,
         OperationKind::Clean,
-        std::env::args().collect(),
+        std::env::args().skip(1).collect(),
         Some(stack_name.to_string()),
         SnapshotScope::AllUserBranches,
     )?;
@@ -184,7 +184,7 @@ pub fn run(clean_all: bool, json: bool) -> Result<()> {
         &repo,
         &config,
         OperationKind::Clean,
-        std::env::args().collect(),
+        std::env::args().skip(1).collect(),
         None,
         SnapshotScope::AllUserBranches,
     )?;

--- a/crates/gg-core/src/commands/clean.rs
+++ b/crates/gg-core/src/commands/clean.rs
@@ -31,7 +31,13 @@ pub fn run_for_stack(stack_name: &str, force: bool) -> Result<()> {
 
     run_for_stack_with_repo(&repo, stack_name, force)?;
 
-    guard.finalize_with_scope(&repo, &config, SnapshotScope::AllUserBranches, vec![], false)
+    guard.finalize_with_scope(
+        &repo,
+        &config,
+        SnapshotScope::AllUserBranches,
+        vec![],
+        false,
+    )
 }
 
 /// Run clean for a stack with an already-open repository (no lock acquisition)
@@ -212,7 +218,13 @@ pub fn run(clean_all: bool, json: bool) -> Result<()> {
         } else {
             println!("{}", style("No stacks to clean.").dim());
         }
-        guard.finalize_with_scope(&repo, &config, SnapshotScope::AllUserBranches, vec![], false)?;
+        guard.finalize_with_scope(
+            &repo,
+            &config,
+            SnapshotScope::AllUserBranches,
+            vec![],
+            false,
+        )?;
         return Ok(());
     }
 
@@ -390,7 +402,13 @@ pub fn run(clean_all: bool, json: bool) -> Result<()> {
         println!("{}", style("No stacks to clean.").dim());
     }
 
-    guard.finalize_with_scope(&repo, &config, SnapshotScope::AllUserBranches, vec![], false)?;
+    guard.finalize_with_scope(
+        &repo,
+        &config,
+        SnapshotScope::AllUserBranches,
+        vec![],
+        false,
+    )?;
 
     Ok(())
 }

--- a/crates/gg-core/src/commands/clean.rs
+++ b/crates/gg-core/src/commands/clean.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 use crate::config::Config;
 use crate::error::{GgError, Result};
 use crate::git;
+use crate::operations::{OperationKind, SnapshotScope};
 use crate::output::{print_json, CleanResponse, CleanResultJson, OUTPUT_VERSION};
 use crate::provider::{PrState, Provider};
 use crate::stack;
@@ -16,11 +17,21 @@ use crate::stack;
 #[allow(dead_code)]
 pub fn run_for_stack(stack_name: &str, force: bool) -> Result<()> {
     let repo = git::open_repo()?;
+    let config = Config::load_with_global(repo.commondir())?;
 
-    // Acquire operation lock to prevent concurrent operations
-    let _lock = git::acquire_operation_lock(&repo, "clean")?;
+    // Acquire operation lock + record a Pending op for the undo log.
+    let (_lock, guard) = git::acquire_operation_lock_and_record(
+        &repo,
+        &config,
+        OperationKind::Clean,
+        std::env::args().collect(),
+        Some(stack_name.to_string()),
+        SnapshotScope::AllUserBranches,
+    )?;
 
-    run_for_stack_with_repo(&repo, stack_name, force)
+    run_for_stack_with_repo(&repo, stack_name, force)?;
+
+    guard.finalize_with_scope(&repo, &config, SnapshotScope::AllUserBranches, vec![], false)
 }
 
 /// Run clean for a stack with an already-open repository (no lock acquisition)
@@ -152,9 +163,6 @@ pub fn run_for_stack_with_repo(repo: &Repository, stack_name: &str, force: bool)
 pub fn run(clean_all: bool, json: bool) -> Result<()> {
     let repo = git::open_repo()?;
 
-    // Acquire operation lock to prevent concurrent operations
-    let _lock = git::acquire_operation_lock(&repo, "clean")?;
-
     if json && !clean_all {
         crate::output::print_json_error(
             "--json requires --all (cannot show interactive prompts in JSON mode)",
@@ -164,6 +172,16 @@ pub fn run(clean_all: bool, json: bool) -> Result<()> {
 
     let git_dir = repo.commondir();
     let mut config = Config::load_with_global(git_dir)?;
+
+    // Acquire operation lock + record a Pending op for the undo log.
+    let (_lock, guard) = git::acquire_operation_lock_and_record(
+        &repo,
+        &config,
+        OperationKind::Clean,
+        std::env::args().collect(),
+        None,
+        SnapshotScope::AllUserBranches,
+    )?;
 
     // Detect provider (best-effort).
     // Some repos (e.g. local remotes in tests) won't match GitHub/GitLab.
@@ -194,6 +212,7 @@ pub fn run(clean_all: bool, json: bool) -> Result<()> {
         } else {
             println!("{}", style("No stacks to clean.").dim());
         }
+        guard.finalize_with_scope(&repo, &config, SnapshotScope::AllUserBranches, vec![], false)?;
         return Ok(());
     }
 
@@ -370,6 +389,8 @@ pub fn run(clean_all: bool, json: bool) -> Result<()> {
     } else {
         println!("{}", style("No stacks to clean.").dim());
     }
+
+    guard.finalize_with_scope(&repo, &config, SnapshotScope::AllUserBranches, vec![], false)?;
 
     Ok(())
 }

--- a/crates/gg-core/src/commands/drop_cmd.rs
+++ b/crates/gg-core/src/commands/drop_cmd.rs
@@ -9,6 +9,7 @@ use crate::config::Config;
 use crate::error::{GgError, Result};
 use crate::git;
 use crate::immutability::{self, ImmutabilityPolicy};
+use crate::operations::{OperationKind, SnapshotScope};
 use crate::output::{print_json, DropResponse, DropResultJson, DroppedEntryJson, OUTPUT_VERSION};
 use crate::stack::{self, Stack};
 
@@ -33,8 +34,15 @@ pub fn run(options: DropOptions) -> Result<()> {
     let repo = git::open_repo()?;
     let config = Config::load_with_global(repo.commondir())?;
 
-    // Acquire operation lock
-    let _lock = git::acquire_operation_lock(&repo, "drop")?;
+    // Acquire operation lock + record a Pending op for the undo log.
+    let (_lock, guard) = git::acquire_operation_lock_and_record(
+        &repo,
+        &config,
+        OperationKind::Drop,
+        std::env::args().collect(),
+        None,
+        SnapshotScope::AllUserBranches,
+    )?;
 
     // Require clean working directory
     git::require_clean_working_directory(&repo)?;
@@ -127,6 +135,15 @@ pub fn run(options: DropOptions) -> Result<()> {
 
         if !confirmed {
             println!("{}", style("Drop cancelled.").dim());
+            // No mutation occurred; finalize with refs_after == refs_before so
+            // the record doesn't linger as Pending and undo is a safe no-op.
+            guard.finalize_with_scope(
+                &repo,
+                &config,
+                SnapshotScope::AllUserBranches,
+                vec![],
+                false,
+            )?;
             return Ok(());
         }
     }
@@ -204,6 +221,10 @@ pub fn run(options: DropOptions) -> Result<()> {
     }
 
     let remaining = stack_obj.len() - dropped_entries.len();
+
+    // Finalize the op record with post-mutation refs. Drop is purely
+    // local; no remote effects.
+    guard.finalize_with_scope(&repo, &config, SnapshotScope::AllUserBranches, vec![], false)?;
 
     if options.json {
         print_json(&DropResponse {

--- a/crates/gg-core/src/commands/drop_cmd.rs
+++ b/crates/gg-core/src/commands/drop_cmd.rs
@@ -34,15 +34,11 @@ pub fn run(options: DropOptions) -> Result<()> {
     let repo = git::open_repo()?;
     let config = Config::load_with_global(repo.commondir())?;
 
-    // Acquire operation lock + record a Pending op for the undo log.
-    let (_lock, guard) = git::acquire_operation_lock_and_record(
-        &repo,
-        &config,
-        OperationKind::Drop,
-        std::env::args().collect(),
-        None,
-        SnapshotScope::AllUserBranches,
-    )?;
+    // Acquire the operation lock early so all validation runs under it, but
+    // defer writing the op-log record until *after* the immutability guard
+    // passes. This keeps refused operations from polluting `gg undo --list`
+    // with Interrupted ghosts (design §4.6).
+    let _lock = git::acquire_operation_lock(&repo, "drop")?;
 
     // Require clean working directory
     git::require_clean_working_directory(&repo)?;
@@ -135,18 +131,24 @@ pub fn run(options: DropOptions) -> Result<()> {
 
         if !confirmed {
             println!("{}", style("Drop cancelled.").dim());
-            // No mutation occurred; finalize with refs_after == refs_before so
-            // the record doesn't linger as Pending and undo is a safe no-op.
-            guard.finalize_with_scope(
-                &repo,
-                &config,
-                SnapshotScope::AllUserBranches,
-                vec![],
-                false,
-            )?;
+            // No mutation occurred and no record was written; drop the lock
+            // and exit cleanly without leaving a ghost in `gg undo --list`.
             return Ok(());
         }
     }
+
+    // All pre-mutation checks passed and the user confirmed (or confirmation
+    // is not required) — now write the Pending op-log record. Any later
+    // failure leaves a Pending record that the sweep promotes to Interrupted,
+    // which `gg undo` will refuse.
+    let guard = git::begin_recorded_op(
+        &repo,
+        &config,
+        OperationKind::Drop,
+        std::env::args().skip(1).collect(),
+        None,
+        SnapshotScope::AllUserBranches,
+    )?;
 
     // Build the rebase todo list, omitting dropped commits
     let drop_indices: Vec<usize> = drop_positions.iter().map(|p| p - 1).collect();

--- a/crates/gg-core/src/commands/drop_cmd.rs
+++ b/crates/gg-core/src/commands/drop_cmd.rs
@@ -224,7 +224,13 @@ pub fn run(options: DropOptions) -> Result<()> {
 
     // Finalize the op record with post-mutation refs. Drop is purely
     // local; no remote effects.
-    guard.finalize_with_scope(&repo, &config, SnapshotScope::AllUserBranches, vec![], false)?;
+    guard.finalize_with_scope(
+        &repo,
+        &config,
+        SnapshotScope::AllUserBranches,
+        vec![],
+        false,
+    )?;
 
     if options.json {
         print_json(&DropResponse {

--- a/crates/gg-core/src/commands/land.rs
+++ b/crates/gg-core/src/commands/land.rs
@@ -417,7 +417,13 @@ pub fn run(opts: LandOptions) -> Result<()> {
         } else {
             println!("{}", style("Stack is empty. Nothing to land.").dim());
         }
-        guard.finalize_with_scope(&repo, &config, SnapshotScope::AllUserBranches, vec![], false)?;
+        guard.finalize_with_scope(
+            &repo,
+            &config,
+            SnapshotScope::AllUserBranches,
+            vec![],
+            false,
+        )?;
         return Ok(());
     }
 

--- a/crates/gg-core/src/commands/land.rs
+++ b/crates/gg-core/src/commands/land.rs
@@ -365,11 +365,11 @@ pub fn run(opts: LandOptions) -> Result<()> {
     let mut config = Config::load_with_global(git_dir)?;
 
     // Acquire operation lock + record a Pending op for the undo log.
-    let (_lock, guard) = git::acquire_operation_lock_and_record(
+    let (_lock, mut guard) = git::acquire_operation_lock_and_record(
         &repo,
         &config,
         OperationKind::Land,
-        std::env::args().collect(),
+        std::env::args().skip(1).collect(),
         None,
         SnapshotScope::AllUserBranches,
     )?;
@@ -708,6 +708,14 @@ pub fn run(opts: LandOptions) -> Result<()> {
         if merge_trains_enabled {
             match provider.add_to_merge_train(pr_num) {
                 Ok(result) => {
+                    // Queueing a PR/MR on the merge train is a remote state
+                    // mutation even when the PR was already queued — the
+                    // API call still touches the remote. Mark `touched_remote`
+                    // so `gg undo` refuses to replay this op locally. Persist
+                    // the flag immediately so a mid-sequence failure still
+                    // leaves a record the sweep will promote correctly.
+                    touched_remote = true;
+                    guard.mark_touched_remote();
                     let action = match result {
                         AutoMergeResult::Queued => "queued",
                         AutoMergeResult::AlreadyQueued => "already_queued",
@@ -790,8 +798,10 @@ pub fn run(opts: LandOptions) -> Result<()> {
                 Ok(AutoMergeResult::Queued) => {
                     // Queuing for auto-merge mutates remote state even though
                     // the MR is not merged yet; mark the op as having touched
-                    // remote so `gg undo` refuses with a provider hint.
+                    // remote so `gg undo` refuses with a provider hint. Persist
+                    // immediately for mid-sequence failure tolerance.
                     touched_remote = true;
+                    guard.mark_touched_remote();
                     landed_entries.push(LandedEntryJson {
                         position: entry.position,
                         sha: entry.short_sha.clone(),
@@ -837,11 +847,13 @@ pub fn run(opts: LandOptions) -> Result<()> {
                         .get_pr_info(pr_num)
                         .map(|info| info.url)
                         .unwrap_or_default();
-                    remote_effects.push(RemoteEffect::PrMerged {
+                    let effect = RemoteEffect::PrMerged {
                         number: pr_num,
                         url: pr_url,
-                    });
+                    };
+                    remote_effects.push(effect.clone());
                     touched_remote = true;
+                    guard.record_remote_effect(effect);
 
                     landed_entries.push(LandedEntryJson {
                         position: entry.position,

--- a/crates/gg-core/src/commands/land.rs
+++ b/crates/gg-core/src/commands/land.rs
@@ -13,6 +13,7 @@ use crate::config::Config;
 use crate::error::{GgError, Result};
 use crate::git;
 use crate::glab::AutoMergeResult;
+use crate::operations::{OperationKind, RemoteEffect, SnapshotScope};
 use crate::output::{print_json, LandResponse, LandResultJson, LandedEntryJson, OUTPUT_VERSION};
 use crate::provider::{CiStatus, PrState, Provider};
 use crate::stack::{resolve_target, Stack};
@@ -359,10 +360,25 @@ pub fn run(opts: LandOptions) -> Result<()> {
         admin,
     } = opts;
     let repo = git::open_repo()?;
-    let _lock = git::acquire_operation_lock(&repo, "land")?;
 
     let git_dir = repo.commondir();
     let mut config = Config::load_with_global(git_dir)?;
+
+    // Acquire operation lock + record a Pending op for the undo log.
+    let (_lock, guard) = git::acquire_operation_lock_and_record(
+        &repo,
+        &config,
+        OperationKind::Land,
+        std::env::args().collect(),
+        None,
+        SnapshotScope::AllUserBranches,
+    )?;
+
+    // Remote effects collected during landing. A successful merge adds a
+    // `PrMerged`; auto-merge scheduling sets `touched_remote` without a
+    // specific effect (we don't have a `PrQueued` variant).
+    let mut remote_effects: Vec<RemoteEffect> = Vec::new();
+    let mut touched_remote = false;
 
     let provider = Provider::detect(&repo)?;
     provider.check_installed()?;
@@ -401,6 +417,7 @@ pub fn run(opts: LandOptions) -> Result<()> {
         } else {
             println!("{}", style("Stack is empty. Nothing to land.").dim());
         }
+        guard.finalize_with_scope(&repo, &config, SnapshotScope::AllUserBranches, vec![], false)?;
         return Ok(());
     }
 
@@ -764,15 +781,21 @@ pub fn run(opts: LandOptions) -> Result<()> {
             }
         } else if auto_merge_on_land {
             match provider.auto_merge_pr_when_pipeline_succeeds(pr_num, squash, false) {
-                Ok(AutoMergeResult::Queued) => landed_entries.push(LandedEntryJson {
-                    position: entry.position,
-                    sha: entry.short_sha.clone(),
-                    title: entry.title.clone(),
-                    gg_id: gg_id.clone(),
-                    pr_number: pr_num,
-                    action: "queued".to_string(),
-                    error: None,
-                }),
+                Ok(AutoMergeResult::Queued) => {
+                    // Queuing for auto-merge mutates remote state even though
+                    // the MR is not merged yet; mark the op as having touched
+                    // remote so `gg undo` refuses with a provider hint.
+                    touched_remote = true;
+                    landed_entries.push(LandedEntryJson {
+                        position: entry.position,
+                        sha: entry.short_sha.clone(),
+                        title: entry.title.clone(),
+                        gg_id: gg_id.clone(),
+                        pr_number: pr_num,
+                        action: "queued".to_string(),
+                        error: None,
+                    });
+                }
                 Ok(AutoMergeResult::AlreadyQueued) => landed_entries.push(LandedEntryJson {
                     position: entry.position,
                     sha: entry.short_sha.clone(),
@@ -802,6 +825,18 @@ pub fn run(opts: LandOptions) -> Result<()> {
             }
             match provider.merge_pr(pr_num, squash, false, admin) {
                 Ok(()) => {
+                    // Record the merge as a remote effect. Fetch the URL if we
+                    // can; fall back to empty string if the info call fails.
+                    let pr_url = provider
+                        .get_pr_info(pr_num)
+                        .map(|info| info.url)
+                        .unwrap_or_default();
+                    remote_effects.push(RemoteEffect::PrMerged {
+                        number: pr_num,
+                        url: pr_url,
+                    });
+                    touched_remote = true;
+
                     landed_entries.push(LandedEntryJson {
                         position: entry.position,
                         sha: entry.short_sha.clone(),
@@ -944,6 +979,20 @@ pub fn run(opts: LandOptions) -> Result<()> {
             provider.pr_label()
         );
     }
+
+    // Finalize the operation record before we exit. We do this even on error
+    // so the log captures the refs_after snapshot and remote effects that
+    // actually happened before the failure (cumulative merges are already
+    // on remote and can't be undone locally). Dropping the guard without
+    // finalize would leave the record Pending and eventually get swept to
+    // Interrupted — less accurate for `gg undo --list`.
+    guard.finalize_with_scope(
+        &repo,
+        &config,
+        SnapshotScope::AllUserBranches,
+        remote_effects,
+        touched_remote,
+    )?;
 
     // In JSON mode, the error is already included in the LandResponse payload.
     // Returning Err would cause gg-cli to emit a second JSON error object,

--- a/crates/gg-core/src/commands/mod.rs
+++ b/crates/gg-core/src/commands/mod.rs
@@ -20,3 +20,4 @@ pub mod split;
 pub mod split_tui;
 pub mod squash;
 pub mod sync;
+pub mod undo;

--- a/crates/gg-core/src/commands/nav.rs
+++ b/crates/gg-core/src/commands/nav.rs
@@ -27,7 +27,13 @@ where
         SnapshotScope::AllUserBranches,
     )?;
     f(&repo, &config)?;
-    guard.finalize_with_scope(&repo, &config, SnapshotScope::AllUserBranches, vec![], false)
+    guard.finalize_with_scope(
+        &repo,
+        &config,
+        SnapshotScope::AllUserBranches,
+        vec![],
+        false,
+    )
 }
 
 /// Move to a specific position, entry ID, or SHA

--- a/crates/gg-core/src/commands/nav.rs
+++ b/crates/gg-core/src/commands/nav.rs
@@ -38,7 +38,7 @@ where
 
 /// Move to a specific position, entry ID, or SHA
 pub fn move_to(target: &str) -> Result<()> {
-    let op_args = std::env::args().collect();
+    let op_args = std::env::args().skip(1).collect();
     with_recorded_nav_lock(op_args, |repo, config| {
         if git::is_rebase_in_progress(repo) {
             return Err(GgError::Other(
@@ -87,7 +87,7 @@ pub fn move_to(target: &str) -> Result<()> {
 
 /// Move to the first commit in the stack
 pub fn first() -> Result<()> {
-    let op_args = std::env::args().collect();
+    let op_args = std::env::args().skip(1).collect();
     with_recorded_nav_lock(op_args, |repo, config| {
         if git::is_rebase_in_progress(repo) {
             return Err(GgError::Other(
@@ -108,7 +108,7 @@ pub fn first() -> Result<()> {
 
 /// Move to the last commit (stack head)
 pub fn last() -> Result<()> {
-    let op_args = std::env::args().collect();
+    let op_args = std::env::args().skip(1).collect();
     with_recorded_nav_lock(op_args, |repo, config| {
         let stack = Stack::load(repo, config)?;
 
@@ -152,7 +152,7 @@ pub fn last() -> Result<()> {
 
 /// Move to the previous commit
 pub fn prev() -> Result<()> {
-    let op_args = std::env::args().collect();
+    let op_args = std::env::args().skip(1).collect();
     with_recorded_nav_lock(op_args, |repo, config| {
         if git::is_rebase_in_progress(repo) {
             return Err(GgError::Other(
@@ -175,7 +175,7 @@ pub fn prev() -> Result<()> {
 
 /// Move to the next commit
 pub fn next() -> Result<()> {
-    let op_args = std::env::args().collect();
+    let op_args = std::env::args().skip(1).collect();
     with_recorded_nav_lock(op_args, |repo, config| {
         let stack = Stack::load(repo, config)?;
 

--- a/crates/gg-core/src/commands/nav.rs
+++ b/crates/gg-core/src/commands/nav.rs
@@ -5,226 +5,234 @@ use console::style;
 use crate::config::Config;
 use crate::error::{GgError, Result};
 use crate::git;
+use crate::operations::{OperationKind, SnapshotScope};
 use crate::stack::{self, Stack, StackEntry};
+
+/// Acquire the operation lock, record a Pending Nav op, run the given
+/// closure, then finalize on success. On error, the guard is dropped
+/// without finalize; the sweep promotes the Pending record to Interrupted
+/// on the next lock acquisition.
+fn with_recorded_nav_lock<F>(op_args: Vec<String>, f: F) -> Result<()>
+where
+    F: FnOnce(&git2::Repository, &Config) -> Result<()>,
+{
+    let repo = git::open_repo()?;
+    let config = Config::load_with_global(repo.commondir())?;
+    let (_lock, guard) = git::acquire_operation_lock_and_record(
+        &repo,
+        &config,
+        OperationKind::Nav,
+        op_args,
+        None,
+        SnapshotScope::AllUserBranches,
+    )?;
+    f(&repo, &config)?;
+    guard.finalize_with_scope(&repo, &config, SnapshotScope::AllUserBranches, vec![], false)
+}
 
 /// Move to a specific position, entry ID, or SHA
 pub fn move_to(target: &str) -> Result<()> {
-    let repo = git::open_repo()?;
-
-    // Acquire operation lock to prevent concurrent operations
-    let _lock = git::acquire_operation_lock(&repo, "nav")?;
-
-    if git::is_rebase_in_progress(&repo) {
-        return Err(GgError::Other(
-            "A rebase is in progress. Run `gg continue` to continue or `gg abort` to cancel."
-                .to_string(),
-        ));
-    }
-
-    let config = Config::load_with_global(repo.commondir())?;
-    let stack = Stack::load(&repo, &config)?;
-
-    if stack.is_empty() {
-        return Err(GgError::Other("Stack is empty".to_string()));
-    }
-
-    // Try to parse target as position (1-indexed number)
-    if let Ok(pos) = target.parse::<usize>() {
-        if let Some(entry) = stack.get_entry_by_position(pos) {
-            return checkout_entry(&repo, &stack, entry);
-        } else {
-            return Err(GgError::Other(format!(
-                "Position {} is out of range (1-{})",
-                pos,
-                stack.len()
-            )));
+    let op_args = std::env::args().collect();
+    with_recorded_nav_lock(op_args, |repo, config| {
+        if git::is_rebase_in_progress(repo) {
+            return Err(GgError::Other(
+                "A rebase is in progress. Run `gg continue` to continue or `gg abort` to cancel."
+                    .to_string(),
+            ));
         }
-    }
 
-    // Try to find by GG-ID
-    if let Some(entry) = stack.get_entry_by_gg_id(target) {
-        return checkout_entry(&repo, &stack, entry);
-    }
+        let stack = Stack::load(repo, config)?;
 
-    // Try to find by SHA prefix
-    for entry in &stack.entries {
-        if entry.short_sha.starts_with(target) || entry.oid.to_string().starts_with(target) {
-            return checkout_entry(&repo, &stack, entry);
+        if stack.is_empty() {
+            return Err(GgError::Other("Stack is empty".to_string()));
         }
-    }
 
-    Err(GgError::Other(format!(
-        "Could not find commit matching '{}' in stack",
-        target
-    )))
+        // Try to parse target as position (1-indexed number)
+        if let Ok(pos) = target.parse::<usize>() {
+            if let Some(entry) = stack.get_entry_by_position(pos) {
+                return checkout_entry(repo, &stack, entry);
+            } else {
+                return Err(GgError::Other(format!(
+                    "Position {} is out of range (1-{})",
+                    pos,
+                    stack.len()
+                )));
+            }
+        }
+
+        // Try to find by GG-ID
+        if let Some(entry) = stack.get_entry_by_gg_id(target) {
+            return checkout_entry(repo, &stack, entry);
+        }
+
+        // Try to find by SHA prefix
+        for entry in &stack.entries {
+            if entry.short_sha.starts_with(target) || entry.oid.to_string().starts_with(target) {
+                return checkout_entry(repo, &stack, entry);
+            }
+        }
+
+        Err(GgError::Other(format!(
+            "Could not find commit matching '{}' in stack",
+            target
+        )))
+    })
 }
 
 /// Move to the first commit in the stack
 pub fn first() -> Result<()> {
-    let repo = git::open_repo()?;
+    let op_args = std::env::args().collect();
+    with_recorded_nav_lock(op_args, |repo, config| {
+        if git::is_rebase_in_progress(repo) {
+            return Err(GgError::Other(
+                "A rebase is in progress. Run `gg continue` to continue or `gg abort` to cancel."
+                    .to_string(),
+            ));
+        }
 
-    // Acquire operation lock to prevent concurrent operations
-    let _lock = git::acquire_operation_lock(&repo, "nav")?;
+        let stack = Stack::load(repo, config)?;
 
-    if git::is_rebase_in_progress(&repo) {
-        return Err(GgError::Other(
-            "A rebase is in progress. Run `gg continue` to continue or `gg abort` to cancel."
-                .to_string(),
-        ));
-    }
-
-    let config = Config::load_with_global(repo.commondir())?;
-    let stack = Stack::load(&repo, &config)?;
-
-    if let Some(entry) = stack.first() {
-        checkout_entry(&repo, &stack, entry)
-    } else {
-        Err(GgError::Other("Stack is empty".to_string()))
-    }
+        if let Some(entry) = stack.first() {
+            checkout_entry(repo, &stack, entry)
+        } else {
+            Err(GgError::Other("Stack is empty".to_string()))
+        }
+    })
 }
 
 /// Move to the last commit (stack head)
 pub fn last() -> Result<()> {
-    let repo = git::open_repo()?;
+    let op_args = std::env::args().collect();
+    with_recorded_nav_lock(op_args, |repo, config| {
+        let stack = Stack::load(repo, config)?;
 
-    // Acquire operation lock to prevent concurrent operations
-    let _lock = git::acquire_operation_lock(&repo, "nav")?;
-
-    let config = Config::load_with_global(repo.commondir())?;
-    let stack = Stack::load(&repo, &config)?;
-
-    // Check if a rebase is in progress
-    if git::is_rebase_in_progress(&repo) {
-        return Err(GgError::Other(
-            "A rebase is in progress. Run `gg continue` to continue or `gg abort` to cancel."
-                .to_string(),
-        ));
-    }
-
-    if let Some(entry) = stack.last() {
-        // Check if we're in detached HEAD and if the current commit has changed
-        let needs_rebase = check_and_rebase_if_modified(&repo, &stack)?;
-
-        // For last, we should checkout the branch, not detach
-        git::checkout_branch(&repo, &stack.branch_name())?;
-        // Clear the saved stack since we're back on the branch (per-worktree state)
-        stack::clear_current_stack(repo.path())?;
-
-        if needs_rebase {
-            println!(
-                "{} Moved to stack head (rebased after modifications)",
-                style("OK").green().bold()
-            );
-        } else {
-            println!(
-                "{} Moved to stack head: [{}] {} {}",
-                style("OK").green().bold(),
-                entry.position,
-                style(&entry.short_sha).yellow(),
-                entry.title
-            );
+        // Check if a rebase is in progress
+        if git::is_rebase_in_progress(repo) {
+            return Err(GgError::Other(
+                "A rebase is in progress. Run `gg continue` to continue or `gg abort` to cancel."
+                    .to_string(),
+            ));
         }
-        Ok(())
-    } else {
-        Err(GgError::Other("Stack is empty".to_string()))
-    }
+
+        if let Some(entry) = stack.last() {
+            // Check if we're in detached HEAD and if the current commit has changed
+            let needs_rebase = check_and_rebase_if_modified(repo, &stack)?;
+
+            // For last, we should checkout the branch, not detach
+            git::checkout_branch(repo, &stack.branch_name())?;
+            // Clear the saved stack since we're back on the branch (per-worktree state)
+            stack::clear_current_stack(repo.path())?;
+
+            if needs_rebase {
+                println!(
+                    "{} Moved to stack head (rebased after modifications)",
+                    style("OK").green().bold()
+                );
+            } else {
+                println!(
+                    "{} Moved to stack head: [{}] {} {}",
+                    style("OK").green().bold(),
+                    entry.position,
+                    style(&entry.short_sha).yellow(),
+                    entry.title
+                );
+            }
+            Ok(())
+        } else {
+            Err(GgError::Other("Stack is empty".to_string()))
+        }
+    })
 }
 
 /// Move to the previous commit
 pub fn prev() -> Result<()> {
-    let repo = git::open_repo()?;
+    let op_args = std::env::args().collect();
+    with_recorded_nav_lock(op_args, |repo, config| {
+        if git::is_rebase_in_progress(repo) {
+            return Err(GgError::Other(
+                "A rebase is in progress. Run `gg continue` to continue or `gg abort` to cancel."
+                    .to_string(),
+            ));
+        }
 
-    // Acquire operation lock to prevent concurrent operations
-    let _lock = git::acquire_operation_lock(&repo, "nav")?;
+        let stack = Stack::load(repo, config)?;
 
-    if git::is_rebase_in_progress(&repo) {
-        return Err(GgError::Other(
-            "A rebase is in progress. Run `gg continue` to continue or `gg abort` to cancel."
-                .to_string(),
-        ));
-    }
-
-    let config = Config::load_with_global(repo.commondir())?;
-    let stack = Stack::load(&repo, &config)?;
-
-    if let Some(entry) = stack.prev() {
-        checkout_entry(&repo, &stack, entry)
-    } else {
-        Err(GgError::Other(
-            "Already at the first commit in the stack".to_string(),
-        ))
-    }
+        if let Some(entry) = stack.prev() {
+            checkout_entry(repo, &stack, entry)
+        } else {
+            Err(GgError::Other(
+                "Already at the first commit in the stack".to_string(),
+            ))
+        }
+    })
 }
 
 /// Move to the next commit
 pub fn next() -> Result<()> {
-    let repo = git::open_repo()?;
+    let op_args = std::env::args().collect();
+    with_recorded_nav_lock(op_args, |repo, config| {
+        let stack = Stack::load(repo, config)?;
 
-    // Acquire operation lock to prevent concurrent operations
-    let _lock = git::acquire_operation_lock(&repo, "nav")?;
-
-    let config = Config::load_with_global(repo.commondir())?;
-    let stack = Stack::load(&repo, &config)?;
-
-    // Check if a rebase is in progress
-    if git::is_rebase_in_progress(&repo) {
-        return Err(GgError::Other(
-            "A rebase is in progress. Run `gg continue` to continue or `gg abort` to cancel."
-                .to_string(),
-        ));
-    }
-
-    // Check if we need to rebase due to modifications
-    let needs_rebase = check_and_rebase_if_modified(&repo, &stack)?;
-
-    // If we're at the last commit, we might just need to checkout the branch
-    let current_pos = stack
-        .current_position
-        .unwrap_or(stack.len().saturating_sub(1));
-
-    if current_pos >= stack.len().saturating_sub(1) {
-        // At stack head, ensure we're on the branch
-        git::checkout_branch(&repo, &stack.branch_name())?;
-        stack::clear_current_stack(repo.path())?;
-        if needs_rebase {
-            println!(
-                "{} Already at stack head (rebased)",
-                style("OK").green().bold()
-            );
-        } else {
-            println!("{} Already at stack head", style("OK").green().bold());
+        // Check if a rebase is in progress
+        if git::is_rebase_in_progress(repo) {
+            return Err(GgError::Other(
+                "A rebase is in progress. Run `gg continue` to continue or `gg abort` to cancel."
+                    .to_string(),
+            ));
         }
-        return Ok(());
-    }
 
-    // Reload stack after potential rebase
-    let stack = if needs_rebase {
-        Stack::load(&repo, &config)?
-    } else {
-        stack
-    };
+        // Check if we need to rebase due to modifications
+        let needs_rebase = check_and_rebase_if_modified(repo, &stack)?;
 
-    if let Some(entry) = stack.next() {
-        // If next is the last entry, checkout branch instead of detaching
-        if entry.position == stack.len() {
-            git::checkout_branch(&repo, &stack.branch_name())?;
+        // If we're at the last commit, we might just need to checkout the branch
+        let current_pos = stack
+            .current_position
+            .unwrap_or(stack.len().saturating_sub(1));
+
+        if current_pos >= stack.len().saturating_sub(1) {
+            // At stack head, ensure we're on the branch
+            git::checkout_branch(repo, &stack.branch_name())?;
             stack::clear_current_stack(repo.path())?;
-            println!(
-                "{} Moved to stack head: [{}] {} {}",
-                style("OK").green().bold(),
-                entry.position,
-                style(&entry.short_sha).yellow(),
-                entry.title
-            );
-            Ok(())
-        } else {
-            checkout_entry(&repo, &stack, entry)
+            if needs_rebase {
+                println!(
+                    "{} Already at stack head (rebased)",
+                    style("OK").green().bold()
+                );
+            } else {
+                println!("{} Already at stack head", style("OK").green().bold());
+            }
+            return Ok(());
         }
-    } else {
-        Err(GgError::Other(
-            "Already at the last commit in the stack".to_string(),
-        ))
-    }
+
+        // Reload stack after potential rebase
+        let stack = if needs_rebase {
+            Stack::load(repo, config)?
+        } else {
+            stack
+        };
+
+        if let Some(entry) = stack.next() {
+            // If next is the last entry, checkout branch instead of detaching
+            if entry.position == stack.len() {
+                git::checkout_branch(repo, &stack.branch_name())?;
+                stack::clear_current_stack(repo.path())?;
+                println!(
+                    "{} Moved to stack head: [{}] {} {}",
+                    style("OK").green().bold(),
+                    entry.position,
+                    style(&entry.short_sha).yellow(),
+                    entry.title
+                );
+                Ok(())
+            } else {
+                checkout_entry(repo, &stack, entry)
+            }
+        } else {
+            Err(GgError::Other(
+                "Already at the last commit in the stack".to_string(),
+            ))
+        }
+    })
 }
 
 /// Checkout a specific entry (detached HEAD)

--- a/crates/gg-core/src/commands/rebase.rs
+++ b/crates/gg-core/src/commands/rebase.rs
@@ -7,16 +7,27 @@ use crate::config::Config;
 use crate::error::{GgError, Result};
 use crate::git;
 use crate::immutability::{self, ImmutabilityPolicy};
+use crate::operations::{OperationKind, SnapshotScope};
 use crate::stack::Stack;
 
 /// Run the rebase command
 pub fn run(target: Option<String>, force: bool) -> Result<()> {
     let repo = git::open_repo()?;
+    let config = Config::load_with_global(repo.commondir())?;
 
-    // Acquire operation lock to prevent concurrent operations
-    let _lock = git::acquire_operation_lock(&repo, "rebase")?;
+    // Acquire operation lock + record a Pending op for the undo log.
+    let (_lock, guard) = git::acquire_operation_lock_and_record(
+        &repo,
+        &config,
+        OperationKind::Rebase,
+        std::env::args().collect(),
+        None,
+        SnapshotScope::AllUserBranches,
+    )?;
 
-    run_with_repo(&repo, target, false, force)
+    run_with_repo(&repo, target, false, force)?;
+
+    guard.finalize_with_scope(&repo, &config, SnapshotScope::AllUserBranches, vec![], false)
 }
 
 /// Run rebase with an already-open repository (no lock acquisition)

--- a/crates/gg-core/src/commands/rebase.rs
+++ b/crates/gg-core/src/commands/rebase.rs
@@ -27,7 +27,13 @@ pub fn run(target: Option<String>, force: bool) -> Result<()> {
 
     run_with_repo(&repo, target, false, force)?;
 
-    guard.finalize_with_scope(&repo, &config, SnapshotScope::AllUserBranches, vec![], false)
+    guard.finalize_with_scope(
+        &repo,
+        &config,
+        SnapshotScope::AllUserBranches,
+        vec![],
+        false,
+    )
 }
 
 /// Run rebase with an already-open repository (no lock acquisition)

--- a/crates/gg-core/src/commands/rebase.rs
+++ b/crates/gg-core/src/commands/rebase.rs
@@ -15,17 +15,29 @@ pub fn run(target: Option<String>, force: bool) -> Result<()> {
     let repo = git::open_repo()?;
     let config = Config::load_with_global(repo.commondir())?;
 
-    // Acquire operation lock + record a Pending op for the undo log.
-    let (_lock, guard) = git::acquire_operation_lock_and_record(
+    // Acquire the operation lock for validation, but defer writing the
+    // op-log record until after the immutability guard passes so refused
+    // operations never pollute `gg undo --list` (design §4.6).
+    let _lock = git::acquire_operation_lock(&repo, "rebase")?;
+
+    // Run validation (fetch + immutability guard). This may mutate refs
+    // via the fetch and local-branch fast-forward, but those are harmless
+    // and don't need undo coverage.
+    let target_branch = prepare_rebase(&repo, &config, target.clone(), false, force)?;
+
+    // All validation passed — now write the Pending op-log record so a
+    // failure beyond this point leaves a record the sweep can promote to
+    // Interrupted.
+    let guard = git::begin_recorded_op(
         &repo,
         &config,
         OperationKind::Rebase,
-        std::env::args().collect(),
+        std::env::args().skip(1).collect(),
         None,
         SnapshotScope::AllUserBranches,
     )?;
 
-    run_with_repo(&repo, target, false, force)?;
+    execute_rebase(&repo, &target_branch, false)?;
 
     guard.finalize_with_scope(
         &repo,
@@ -44,13 +56,25 @@ pub fn run_with_repo(
     force: bool,
 ) -> Result<()> {
     let config = Config::load_with_global(repo.commondir())?;
+    let target_branch = prepare_rebase(repo, &config, target, json, force)?;
+    execute_rebase(repo, &target_branch, json)
+}
 
+/// Validation phase: resolve target, fetch, update local base, run the
+/// immutability guard. Returns the resolved target branch on success.
+fn prepare_rebase(
+    repo: &Repository,
+    config: &Config,
+    target: Option<String>,
+    json: bool,
+    force: bool,
+) -> Result<String> {
     // Determine target branch. If no target provided, we need to be on a
     // stack to get the base branch.
     let target_branch = if let Some(t) = target {
         t
     } else {
-        let stack = Stack::load(repo, &config)?;
+        let stack = Stack::load(repo, config)?;
         stack.base.clone()
     };
 
@@ -109,7 +133,7 @@ pub fn run_with_repo(
     // parent chain. If any commit is merged or already on the (freshly
     // fetched) base, refuse without --force. Must run *after* the fetch so
     // origin/<base> reflects the latest remote state.
-    if let Ok(mut stack) = Stack::load(repo, &config) {
+    if let Ok(mut stack) = Stack::load(repo, config) {
         if !stack.is_empty() {
             // Best-effort refresh of mr_state so the guard catches
             // squash-merged PRs (their merge SHA isn't on origin/<base>, so
@@ -120,6 +144,14 @@ pub fn run_with_repo(
             immutability::guard(report, force)?;
         }
     }
+
+    Ok(target_branch)
+}
+
+/// Mutation phase: stash uncommitted changes, run `git rebase`, restore
+/// stash. Assumes validation (fetch + immutability guard) has already run.
+fn execute_rebase(repo: &Repository, target_branch: &str, json: bool) -> Result<()> {
+    let current_branch = git::current_branch_name(repo);
 
     // Auto-stash uncommitted changes if present. Done after the guard so we
     // don't create a stash we'll have to restore if the guard rejects.

--- a/crates/gg-core/src/commands/reconcile.rs
+++ b/crates/gg-core/src/commands/reconcile.rs
@@ -14,6 +14,7 @@ use git2::Repository;
 use crate::config::Config;
 use crate::error::Result;
 use crate::git;
+use crate::operations::{OperationKind, SnapshotScope};
 use crate::provider::Provider;
 use crate::stack::Stack;
 
@@ -51,6 +52,19 @@ pub fn run(dry_run: bool) -> Result<()> {
     let git_dir = repo.commondir();
     let mut config = Config::load_with_global(git_dir)?;
 
+    // Acquire operation lock + record a Pending op for the undo log.
+    // NOTE: behaviour change — reconcile previously had no lock. Only the
+    // mutating (non-dry-run) path actually changes state, but we record both
+    // so the user can see dry-runs in `gg undo --list`.
+    let (_lock, guard) = git::acquire_operation_lock_and_record(
+        &repo,
+        &config,
+        OperationKind::Reconcile,
+        std::env::args().collect(),
+        None,
+        SnapshotScope::AllUserBranches,
+    )?;
+
     // Detect provider
     let provider = Provider::detect(&repo)?;
 
@@ -66,6 +80,7 @@ pub fn run(dry_run: bool) -> Result<()> {
 
     if stack.is_empty() {
         println!("{}", style("Stack is empty. Nothing to reconcile.").dim());
+        guard.finalize_with_scope(&repo, &config, SnapshotScope::AllUserBranches, vec![], false)?;
         return Ok(());
     }
 
@@ -123,11 +138,13 @@ pub fn run(dry_run: bool) -> Result<()> {
             "\n{} Stack is already reconciled. Nothing to do.",
             style("✓").green().bold()
         );
+        guard.finalize_with_scope(&repo, &config, SnapshotScope::AllUserBranches, vec![], false)?;
         return Ok(());
     }
 
     if dry_run {
         println!("\n{} Dry run complete. No changes made.", style("→").cyan());
+        guard.finalize_with_scope(&repo, &config, SnapshotScope::AllUserBranches, vec![], false)?;
         return Ok(());
     }
 
@@ -158,6 +175,8 @@ pub fn run(dry_run: bool) -> Result<()> {
     config.save(git_dir)?;
 
     println!("\n{} Reconciliation complete!", style("OK").green().bold());
+
+    guard.finalize_with_scope(&repo, &config, SnapshotScope::AllUserBranches, vec![], false)?;
 
     Ok(())
 }

--- a/crates/gg-core/src/commands/reconcile.rs
+++ b/crates/gg-core/src/commands/reconcile.rs
@@ -60,7 +60,7 @@ pub fn run(dry_run: bool) -> Result<()> {
         &repo,
         &config,
         OperationKind::Reconcile,
-        std::env::args().collect(),
+        std::env::args().skip(1).collect(),
         None,
         SnapshotScope::AllUserBranches,
     )?;

--- a/crates/gg-core/src/commands/reconcile.rs
+++ b/crates/gg-core/src/commands/reconcile.rs
@@ -80,7 +80,13 @@ pub fn run(dry_run: bool) -> Result<()> {
 
     if stack.is_empty() {
         println!("{}", style("Stack is empty. Nothing to reconcile.").dim());
-        guard.finalize_with_scope(&repo, &config, SnapshotScope::AllUserBranches, vec![], false)?;
+        guard.finalize_with_scope(
+            &repo,
+            &config,
+            SnapshotScope::AllUserBranches,
+            vec![],
+            false,
+        )?;
         return Ok(());
     }
 
@@ -138,13 +144,25 @@ pub fn run(dry_run: bool) -> Result<()> {
             "\n{} Stack is already reconciled. Nothing to do.",
             style("✓").green().bold()
         );
-        guard.finalize_with_scope(&repo, &config, SnapshotScope::AllUserBranches, vec![], false)?;
+        guard.finalize_with_scope(
+            &repo,
+            &config,
+            SnapshotScope::AllUserBranches,
+            vec![],
+            false,
+        )?;
         return Ok(());
     }
 
     if dry_run {
         println!("\n{} Dry run complete. No changes made.", style("→").cyan());
-        guard.finalize_with_scope(&repo, &config, SnapshotScope::AllUserBranches, vec![], false)?;
+        guard.finalize_with_scope(
+            &repo,
+            &config,
+            SnapshotScope::AllUserBranches,
+            vec![],
+            false,
+        )?;
         return Ok(());
     }
 
@@ -176,7 +194,13 @@ pub fn run(dry_run: bool) -> Result<()> {
 
     println!("\n{} Reconciliation complete!", style("OK").green().bold());
 
-    guard.finalize_with_scope(&repo, &config, SnapshotScope::AllUserBranches, vec![], false)?;
+    guard.finalize_with_scope(
+        &repo,
+        &config,
+        SnapshotScope::AllUserBranches,
+        vec![],
+        false,
+    )?;
 
     Ok(())
 }

--- a/crates/gg-core/src/commands/reorder.rs
+++ b/crates/gg-core/src/commands/reorder.rs
@@ -30,16 +30,11 @@ pub fn run(options: ReorderOptions) -> Result<()> {
     let repo = git::open_repo()?;
     let config = Config::load_with_global(repo.commondir())?;
 
-    // Acquire operation lock + record a Pending op for the undo log.
+    // Acquire the operation lock now but defer writing the op-log record
+    // until all validation (including the immutability guard) passes so
+    // refused or cancelled operations never leak into `gg undo --list`.
     // NOTE: this is a behaviour change — reorder previously had no lock.
-    let (_lock, guard) = git::acquire_operation_lock_and_record(
-        &repo,
-        &config,
-        OperationKind::Reorder,
-        std::env::args().collect(),
-        None,
-        SnapshotScope::AllUserBranches,
-    )?;
+    let _lock = git::acquire_operation_lock(&repo, "reorder")?;
 
     // Require clean working directory
     git::require_clean_working_directory(&repo)?;
@@ -52,13 +47,6 @@ pub fn run(options: ReorderOptions) -> Result<()> {
 
     if stack.len() < 2 {
         println!("{}", style("Need at least 2 commits to reorder.").dim());
-        guard.finalize_with_scope(
-            &repo,
-            &config,
-            SnapshotScope::AllUserBranches,
-            vec![],
-            false,
-        )?;
         return Ok(());
     }
 
@@ -80,26 +68,12 @@ pub fn run(options: ReorderOptions) -> Result<()> {
         Some(order) => order,
         None => {
             println!("{}", style("Reorder cancelled.").dim());
-            guard.finalize_with_scope(
-                &repo,
-                &config,
-                SnapshotScope::AllUserBranches,
-                vec![],
-                false,
-            )?;
             return Ok(());
         }
     };
 
     if new_order.is_empty() {
         println!("{}", style("No commits in reorder list. Aborting.").dim());
-        guard.finalize_with_scope(
-            &repo,
-            &config,
-            SnapshotScope::AllUserBranches,
-            vec![],
-            false,
-        )?;
         return Ok(());
     }
 
@@ -107,13 +81,6 @@ pub fn run(options: ReorderOptions) -> Result<()> {
     let old_order: Vec<&str> = stack.entries.iter().map(|e| e.short_sha.as_str()).collect();
     if new_order.len() == old_order.len() && new_order == old_order {
         println!("{}", style("Order unchanged.").dim());
-        guard.finalize_with_scope(
-            &repo,
-            &config,
-            SnapshotScope::AllUserBranches,
-            vec![],
-            false,
-        )?;
         return Ok(());
     }
 
@@ -128,6 +95,17 @@ pub fn run(options: ReorderOptions) -> Result<()> {
         let report = policy.check_positions(&stack, &targets);
         immutability::guard(report, options.force)?;
     }
+
+    // All validation passed — write the Pending op-log record immediately
+    // before the actual rebase.
+    let guard = git::begin_recorded_op(
+        &repo,
+        &config,
+        OperationKind::Reorder,
+        std::env::args().skip(1).collect(),
+        None,
+        SnapshotScope::AllUserBranches,
+    )?;
 
     let dropped_count = stack.len() - new_order.len();
     if dropped_count > 0 {

--- a/crates/gg-core/src/commands/reorder.rs
+++ b/crates/gg-core/src/commands/reorder.rs
@@ -10,6 +10,7 @@ use crate::config::Config;
 use crate::error::{GgError, Result};
 use crate::git;
 use crate::immutability::{self, ImmutabilityPolicy};
+use crate::operations::{OperationKind, SnapshotScope};
 use crate::stack::Stack;
 
 /// Options for the reorder command
@@ -29,6 +30,17 @@ pub fn run(options: ReorderOptions) -> Result<()> {
     let repo = git::open_repo()?;
     let config = Config::load_with_global(repo.commondir())?;
 
+    // Acquire operation lock + record a Pending op for the undo log.
+    // NOTE: this is a behaviour change — reorder previously had no lock.
+    let (_lock, guard) = git::acquire_operation_lock_and_record(
+        &repo,
+        &config,
+        OperationKind::Reorder,
+        std::env::args().collect(),
+        None,
+        SnapshotScope::AllUserBranches,
+    )?;
+
     // Require clean working directory
     git::require_clean_working_directory(&repo)?;
 
@@ -40,6 +52,7 @@ pub fn run(options: ReorderOptions) -> Result<()> {
 
     if stack.len() < 2 {
         println!("{}", style("Need at least 2 commits to reorder.").dim());
+        guard.finalize_with_scope(&repo, &config, SnapshotScope::AllUserBranches, vec![], false)?;
         return Ok(());
     }
 
@@ -61,12 +74,20 @@ pub fn run(options: ReorderOptions) -> Result<()> {
         Some(order) => order,
         None => {
             println!("{}", style("Reorder cancelled.").dim());
+            guard.finalize_with_scope(
+                &repo,
+                &config,
+                SnapshotScope::AllUserBranches,
+                vec![],
+                false,
+            )?;
             return Ok(());
         }
     };
 
     if new_order.is_empty() {
         println!("{}", style("No commits in reorder list. Aborting.").dim());
+        guard.finalize_with_scope(&repo, &config, SnapshotScope::AllUserBranches, vec![], false)?;
         return Ok(());
     }
 
@@ -74,6 +95,7 @@ pub fn run(options: ReorderOptions) -> Result<()> {
     let old_order: Vec<&str> = stack.entries.iter().map(|e| e.short_sha.as_str()).collect();
     if new_order.len() == old_order.len() && new_order == old_order {
         println!("{}", style("Order unchanged.").dim());
+        guard.finalize_with_scope(&repo, &config, SnapshotScope::AllUserBranches, vec![], false)?;
         return Ok(());
     }
 
@@ -125,6 +147,8 @@ pub fn run(options: ReorderOptions) -> Result<()> {
             new_order.len()
         );
     }
+
+    guard.finalize_with_scope(&repo, &config, SnapshotScope::AllUserBranches, vec![], false)?;
 
     Ok(())
 }

--- a/crates/gg-core/src/commands/reorder.rs
+++ b/crates/gg-core/src/commands/reorder.rs
@@ -52,7 +52,13 @@ pub fn run(options: ReorderOptions) -> Result<()> {
 
     if stack.len() < 2 {
         println!("{}", style("Need at least 2 commits to reorder.").dim());
-        guard.finalize_with_scope(&repo, &config, SnapshotScope::AllUserBranches, vec![], false)?;
+        guard.finalize_with_scope(
+            &repo,
+            &config,
+            SnapshotScope::AllUserBranches,
+            vec![],
+            false,
+        )?;
         return Ok(());
     }
 
@@ -87,7 +93,13 @@ pub fn run(options: ReorderOptions) -> Result<()> {
 
     if new_order.is_empty() {
         println!("{}", style("No commits in reorder list. Aborting.").dim());
-        guard.finalize_with_scope(&repo, &config, SnapshotScope::AllUserBranches, vec![], false)?;
+        guard.finalize_with_scope(
+            &repo,
+            &config,
+            SnapshotScope::AllUserBranches,
+            vec![],
+            false,
+        )?;
         return Ok(());
     }
 
@@ -95,7 +107,13 @@ pub fn run(options: ReorderOptions) -> Result<()> {
     let old_order: Vec<&str> = stack.entries.iter().map(|e| e.short_sha.as_str()).collect();
     if new_order.len() == old_order.len() && new_order == old_order {
         println!("{}", style("Order unchanged.").dim());
-        guard.finalize_with_scope(&repo, &config, SnapshotScope::AllUserBranches, vec![], false)?;
+        guard.finalize_with_scope(
+            &repo,
+            &config,
+            SnapshotScope::AllUserBranches,
+            vec![],
+            false,
+        )?;
         return Ok(());
     }
 
@@ -148,7 +166,13 @@ pub fn run(options: ReorderOptions) -> Result<()> {
         );
     }
 
-    guard.finalize_with_scope(&repo, &config, SnapshotScope::AllUserBranches, vec![], false)?;
+    guard.finalize_with_scope(
+        &repo,
+        &config,
+        SnapshotScope::AllUserBranches,
+        vec![],
+        false,
+    )?;
 
     Ok(())
 }

--- a/crates/gg-core/src/commands/run.rs
+++ b/crates/gg-core/src/commands/run.rs
@@ -8,6 +8,7 @@ use git2::Oid;
 
 use crate::error::{GgError, Result};
 use crate::git;
+use crate::operations::{OperationKind, SnapshotScope};
 use crate::output::{
     self, RunCommandResult, RunCommitResult, RunResponse, RunResultJson, OUTPUT_VERSION,
 };
@@ -138,7 +139,52 @@ pub fn execute_raw(options: RunOptions) -> Result<RunResult> {
 
     // Load stack
     let config = crate::config::Config::load_with_global(repo.commondir())?;
-    let stack = Stack::load(&repo, &config)?;
+
+    // In Amend mode, `gg run` rewrites commits — acquire an operation lock
+    // and record the op so `gg undo` can reverse it. Behaviour change: prior
+    // versions had no lock for this path. Read-only/Discard don't mutate the
+    // stack's commit graph, so they skip the record.
+    let recorded = if options.change_mode == ChangeMode::Amend {
+        Some(git::acquire_operation_lock_and_record(
+            &repo,
+            &config,
+            OperationKind::Run,
+            std::env::args().collect(),
+            None,
+            SnapshotScope::AllUserBranches,
+        )?)
+    } else {
+        None
+    };
+
+    let result = execute_raw_body(&repo, &config, options);
+
+    // Finalize only on success. On error the guard is dropped without
+    // finalize; the sweep promotes the Pending record to Interrupted on the
+    // next lock acquisition.
+    if result.is_ok() {
+        if let Some((_lock, guard)) = recorded {
+            guard.finalize_with_scope(
+                &repo,
+                &config,
+                SnapshotScope::AllUserBranches,
+                vec![],
+                false,
+            )?;
+        }
+    }
+
+    result
+}
+
+/// Execute body (without lock/record). Split out so `execute_raw` can manage
+/// the operation guard around it cleanly.
+fn execute_raw_body(
+    repo: &git2::Repository,
+    config: &crate::config::Config,
+    options: RunOptions,
+) -> Result<RunResult> {
+    let stack = Stack::load(repo, config)?;
 
     if stack.is_empty() {
         if !options.json {
@@ -182,7 +228,7 @@ pub fn execute_raw(options: RunOptions) -> Result<RunResult> {
             println!("{}", style(header).dim());
         }
 
-        return run_on_commits_parallel(&repo, &stack, &options, end_pos);
+        return run_on_commits_parallel(repo, &stack, &options, end_pos);
     }
 
     // --- Sequential path ---
@@ -219,14 +265,14 @@ pub fn execute_raw(options: RunOptions) -> Result<RunResult> {
         );
     }
 
-    let original_branch = git::current_branch_name(&repo);
+    let original_branch = git::current_branch_name(repo);
     let original_head = repo.head()?.peel_to_commit()?.id();
 
-    let result = run_on_commits(&repo, stack, &options, end_pos);
+    let result = run_on_commits(repo, stack, &options, end_pos);
 
-    if result.is_err() && !git::is_rebase_in_progress(&repo) {
+    if result.is_err() && !git::is_rebase_in_progress(repo) {
         restore_original_position(
-            &repo,
+            repo,
             original_branch.as_deref(),
             original_head,
             options.json,

--- a/crates/gg-core/src/commands/run.rs
+++ b/crates/gg-core/src/commands/run.rs
@@ -134,7 +134,7 @@ pub fn execute(options: RunOptions) -> Result<bool> {
             &repo,
             &config,
             OperationKind::Run,
-            std::env::args().collect(),
+            std::env::args().skip(1).collect(),
             None,
             SnapshotScope::AllUserBranches,
         )?)

--- a/crates/gg-core/src/commands/run.rs
+++ b/crates/gg-core/src/commands/run.rs
@@ -110,34 +110,19 @@ pub struct RunResult {
 
 /// Run commands on each commit in the stack and print output.
 ///
+/// Top-level CLI entry for `gg run`. In Amend mode this acquires an
+/// operation lock and records the op so `gg undo` can reverse it.
+/// Internal callers (e.g. `gg lint`, `gg sync --lint`) must use
+/// [`execute_raw`] directly — they are already inside a recorded op or
+/// intentionally unrecorded, so they must not acquire the lock again.
+///
 /// Returns `Ok(true)` when all commands passed on all commits,
 /// `Ok(false)` when one or more had failures.
 pub fn execute(options: RunOptions) -> Result<bool> {
     let json = options.json;
     let emit_json_output = options.emit_json_output;
-    let result = execute_raw(options)?;
 
-    if json && emit_json_output {
-        output::print_json(&RunResponse {
-            version: OUTPUT_VERSION,
-            run: RunResultJson {
-                results: result.results,
-                all_passed: result.all_passed,
-            },
-        });
-    }
-
-    Ok(result.all_passed)
-}
-
-/// Execute and return raw results (for `gg lint` to wrap in LintResponse).
-pub fn execute_raw(options: RunOptions) -> Result<RunResult> {
     let repo = git::open_repo()?;
-
-    // Require clean working directory
-    git::require_clean_working_directory(&repo)?;
-
-    // Load stack
     let config = crate::config::Config::load_with_global(repo.commondir())?;
 
     // In Amend mode, `gg run` rewrites commits — acquire an operation lock
@@ -157,24 +142,49 @@ pub fn execute_raw(options: RunOptions) -> Result<RunResult> {
         None
     };
 
-    let result = execute_raw_body(&repo, &config, options);
+    let result = execute_raw(options);
 
     // Finalize only on success. On error the guard is dropped without
     // finalize; the sweep promotes the Pending record to Interrupted on the
     // next lock acquisition.
-    if result.is_ok() {
-        if let Some((_lock, guard)) = recorded {
-            guard.finalize_with_scope(
-                &repo,
-                &config,
-                SnapshotScope::AllUserBranches,
-                vec![],
-                false,
-            )?;
-        }
+    if let (Ok(_), Some((_lock, guard))) = (&result, recorded) {
+        guard.finalize_with_scope(
+            &repo,
+            &config,
+            SnapshotScope::AllUserBranches,
+            vec![],
+            false,
+        )?;
     }
 
-    result
+    let result = result?;
+
+    if json && emit_json_output {
+        output::print_json(&RunResponse {
+            version: OUTPUT_VERSION,
+            run: RunResultJson {
+                results: result.results,
+                all_passed: result.all_passed,
+            },
+        });
+    }
+
+    Ok(result.all_passed)
+}
+
+/// Execute and return raw results (for `gg lint` and `gg sync --lint`
+/// to wrap). Does NOT acquire the operation lock — callers that need
+/// recording must go through [`execute`] instead.
+pub fn execute_raw(options: RunOptions) -> Result<RunResult> {
+    let repo = git::open_repo()?;
+
+    // Require clean working directory
+    git::require_clean_working_directory(&repo)?;
+
+    // Load stack
+    let config = crate::config::Config::load_with_global(repo.commondir())?;
+
+    execute_raw_body(&repo, &config, options)
 }
 
 /// Execute body (without lock/record). Split out so `execute_raw` can manage
@@ -1232,10 +1242,8 @@ fn restore_original_position(
 pub(crate) fn resolve_git_path(cmd: &str, repo: &git2::Repository) -> Option<PathBuf> {
     let remainder = if let Some(rest) = cmd.strip_prefix("./.git/") {
         rest
-    } else if let Some(rest) = cmd.strip_prefix(".git/") {
-        rest
     } else {
-        return None;
+        cmd.strip_prefix(".git/")?
     };
 
     Some(repo.commondir().join(remainder))

--- a/crates/gg-core/src/commands/split.rs
+++ b/crates/gg-core/src/commands/split.rs
@@ -11,6 +11,7 @@ use crate::config::Config;
 use crate::error::{GgError, Result};
 use crate::git;
 use crate::immutability::{self, ImmutabilityPolicy};
+use crate::operations::{OperationKind, SnapshotScope};
 use crate::stack::{self, Stack};
 
 /// Options for the split command
@@ -84,8 +85,15 @@ impl std::fmt::Display for ChangedFile {
 /// Run the split command
 pub fn run(options: SplitOptions) -> Result<()> {
     let repo = git::open_repo()?;
-    let _lock = git::acquire_operation_lock(&repo, "split")?;
     let config = Config::load_with_global(repo.commondir())?;
+    let (_lock, guard) = git::acquire_operation_lock_and_record(
+        &repo,
+        &config,
+        OperationKind::Split,
+        std::env::args().collect(),
+        None,
+        SnapshotScope::AllUserBranches,
+    )?;
 
     git::require_clean_working_directory(&repo)?;
 
@@ -323,6 +331,8 @@ pub fn run(options: SplitOptions) -> Result<()> {
             if num_rebased == 1 { "" } else { "s" }
         );
     }
+
+    guard.finalize_with_scope(&repo, &config, SnapshotScope::AllUserBranches, vec![], false)?;
 
     Ok(())
 }

--- a/crates/gg-core/src/commands/split.rs
+++ b/crates/gg-core/src/commands/split.rs
@@ -86,14 +86,10 @@ impl std::fmt::Display for ChangedFile {
 pub fn run(options: SplitOptions) -> Result<()> {
     let repo = git::open_repo()?;
     let config = Config::load_with_global(repo.commondir())?;
-    let (_lock, guard) = git::acquire_operation_lock_and_record(
-        &repo,
-        &config,
-        OperationKind::Split,
-        std::env::args().collect(),
-        None,
-        SnapshotScope::AllUserBranches,
-    )?;
+    // Acquire the operation lock up-front but defer writing the op-log
+    // record until after all validation (including the immutability guard)
+    // so refused operations never leak into `gg undo --list` (design §4.6).
+    let _lock = git::acquire_operation_lock(&repo, "split")?;
 
     git::require_clean_working_directory(&repo)?;
 
@@ -267,6 +263,19 @@ pub fn run(options: SplitOptions) -> Result<()> {
     } else {
         get_remainder_message(&options, &target_commit)?
     };
+
+    // All validation passed — write the Pending op-log record now, right
+    // before the first actual repo mutation. A failure beyond this point
+    // leaves a Pending record the sweep promotes to Interrupted, which
+    // `gg undo` refuses (avoiding an unsafe partial-state rewind).
+    let guard = git::begin_recorded_op(
+        &repo,
+        &config,
+        OperationKind::Split,
+        std::env::args().skip(1).collect(),
+        None,
+        SnapshotScope::AllUserBranches,
+    )?;
 
     // 2. Create the first (new, lower) commit
     let sig = git::get_signature(&repo)?;

--- a/crates/gg-core/src/commands/split.rs
+++ b/crates/gg-core/src/commands/split.rs
@@ -332,7 +332,13 @@ pub fn run(options: SplitOptions) -> Result<()> {
         );
     }
 
-    guard.finalize_with_scope(&repo, &config, SnapshotScope::AllUserBranches, vec![], false)?;
+    guard.finalize_with_scope(
+        &repo,
+        &config,
+        SnapshotScope::AllUserBranches,
+        vec![],
+        false,
+    )?;
 
     Ok(())
 }
@@ -1209,12 +1215,10 @@ fn apply_hunks_to_content(parent_content: &str, hunks: &[&DiffHunk]) -> Result<S
                     // Skip (delete) line from parent
                     parent_idx += 1;
                 }
-                ' ' => {
+                ' ' if parent_idx < parent_lines.len() => {
                     // Context - should match, advance parent
-                    if parent_idx < parent_lines.len() {
-                        result_lines.push(parent_lines[parent_idx].to_string());
-                        parent_idx += 1;
-                    }
+                    result_lines.push(parent_lines[parent_idx].to_string());
+                    parent_idx += 1;
                 }
                 _ => {}
             }

--- a/crates/gg-core/src/commands/squash.rs
+++ b/crates/gg-core/src/commands/squash.rs
@@ -97,7 +97,13 @@ pub fn run(all: bool, force: bool) -> Result<()> {
     let statuses = repo.statuses(None)?;
     if statuses.is_empty() {
         println!("{}", style("No changes to squash.").dim());
-        guard.finalize_with_scope(&repo, &config, SnapshotScope::AllUserBranches, vec![], false)?;
+        guard.finalize_with_scope(
+            &repo,
+            &config,
+            SnapshotScope::AllUserBranches,
+            vec![],
+            false,
+        )?;
         return Ok(());
     }
 
@@ -361,7 +367,13 @@ pub fn run(all: bool, force: bool) -> Result<()> {
     }
 
     // Finalize op record — purely local mutation.
-    guard.finalize_with_scope(&repo, &config, SnapshotScope::AllUserBranches, vec![], false)?;
+    guard.finalize_with_scope(
+        &repo,
+        &config,
+        SnapshotScope::AllUserBranches,
+        vec![],
+        false,
+    )?;
 
     Ok(())
 }

--- a/crates/gg-core/src/commands/squash.rs
+++ b/crates/gg-core/src/commands/squash.rs
@@ -9,6 +9,7 @@ use crate::config::{Config, UnstagedAction};
 use crate::error::{GgError, Result};
 use crate::git;
 use crate::immutability::{self, ImmutabilityPolicy};
+use crate::operations::{OperationKind, SnapshotScope};
 use crate::stack;
 use crate::stack::Stack;
 
@@ -73,11 +74,17 @@ fn has_untracked_files() -> Result<bool> {
 /// Run the squash command
 pub fn run(all: bool, force: bool) -> Result<()> {
     let repo = git::open_repo()?;
-
-    // Acquire operation lock to prevent concurrent operations
-    let _lock = git::acquire_operation_lock(&repo, "squash")?;
-
     let config = Config::load_with_global(repo.commondir())?;
+
+    // Acquire operation lock + record a Pending op for the undo log.
+    let (_lock, guard) = git::acquire_operation_lock_and_record(
+        &repo,
+        &config,
+        OperationKind::Squash,
+        std::env::args().collect(),
+        None,
+        SnapshotScope::AllUserBranches,
+    )?;
 
     // Verify we're on a stack
     let mut stack = Stack::load(&repo, &config)?;
@@ -90,6 +97,7 @@ pub fn run(all: bool, force: bool) -> Result<()> {
     let statuses = repo.statuses(None)?;
     if statuses.is_empty() {
         println!("{}", style("No changes to squash.").dim());
+        guard.finalize_with_scope(&repo, &config, SnapshotScope::AllUserBranches, vec![], false)?;
         return Ok(());
     }
 
@@ -173,7 +181,17 @@ pub fn run(all: bool, force: bool) -> Result<()> {
                         auto_stashed = true;
                     }
                     2 => {}
-                    _ => return Ok(()),
+                    _ => {
+                        // User aborted: no mutation occurred.
+                        guard.finalize_with_scope(
+                            &repo,
+                            &config,
+                            SnapshotScope::AllUserBranches,
+                            vec![],
+                            false,
+                        )?;
+                        return Ok(());
+                    }
                 }
             }
             UnstagedAction::Add => {
@@ -341,6 +359,9 @@ pub fn run(all: bool, force: bool) -> Result<()> {
     if auto_stashed {
         restore_auto_stash();
     }
+
+    // Finalize op record — purely local mutation.
+    guard.finalize_with_scope(&repo, &config, SnapshotScope::AllUserBranches, vec![], false)?;
 
     Ok(())
 }

--- a/crates/gg-core/src/commands/squash.rs
+++ b/crates/gg-core/src/commands/squash.rs
@@ -76,15 +76,10 @@ pub fn run(all: bool, force: bool) -> Result<()> {
     let repo = git::open_repo()?;
     let config = Config::load_with_global(repo.commondir())?;
 
-    // Acquire operation lock + record a Pending op for the undo log.
-    let (_lock, guard) = git::acquire_operation_lock_and_record(
-        &repo,
-        &config,
-        OperationKind::Squash,
-        std::env::args().collect(),
-        None,
-        SnapshotScope::AllUserBranches,
-    )?;
+    // Acquire the operation lock for validation, but defer writing the
+    // op-log record until after the immutability guard passes so refused
+    // operations never pollute `gg undo --list` (design §4.6).
+    let _lock = git::acquire_operation_lock(&repo, "squash")?;
 
     // Verify we're on a stack
     let mut stack = Stack::load(&repo, &config)?;
@@ -97,13 +92,7 @@ pub fn run(all: bool, force: bool) -> Result<()> {
     let statuses = repo.statuses(None)?;
     if statuses.is_empty() {
         println!("{}", style("No changes to squash.").dim());
-        guard.finalize_with_scope(
-            &repo,
-            &config,
-            SnapshotScope::AllUserBranches,
-            vec![],
-            false,
-        )?;
+        // No mutation — no record needed.
         return Ok(());
     }
 
@@ -188,14 +177,9 @@ pub fn run(all: bool, force: bool) -> Result<()> {
                     }
                     2 => {}
                     _ => {
-                        // User aborted: no mutation occurred.
-                        guard.finalize_with_scope(
-                            &repo,
-                            &config,
-                            SnapshotScope::AllUserBranches,
-                            vec![],
-                            false,
-                        )?;
+                        // User aborted: no mutation occurred and no record
+                        // has been written yet. Exit clean — the op log
+                        // stays untouched.
                         return Ok(());
                     }
                 }
@@ -241,6 +225,18 @@ pub fn run(all: bool, force: bool) -> Result<()> {
             ));
         }
     }
+
+    // All validation passed and we are about to mutate: write the Pending
+    // op-log record now so a failure beyond this point leaves a record the
+    // sweep can promote to Interrupted.
+    let guard = git::begin_recorded_op(
+        &repo,
+        &config,
+        OperationKind::Squash,
+        std::env::args().skip(1).collect(),
+        None,
+        SnapshotScope::AllUserBranches,
+    )?;
 
     // Perform the squash using git command (more reliable for amend)
     let mut args = vec!["commit", "--amend", "--no-edit"];

--- a/crates/gg-core/src/commands/sync.rs
+++ b/crates/gg-core/src/commands/sync.rs
@@ -222,7 +222,13 @@ pub fn run(
         } else {
             println!("{}", style("Stack is empty. Nothing to sync.").dim());
         }
-        guard.finalize_with_scope(&repo, &config, SnapshotScope::AllUserBranches, vec![], false)?;
+        guard.finalize_with_scope(
+            &repo,
+            &config,
+            SnapshotScope::AllUserBranches,
+            vec![],
+            false,
+        )?;
         return Ok(());
     }
 

--- a/crates/gg-core/src/commands/sync.rs
+++ b/crates/gg-core/src/commands/sync.rs
@@ -9,6 +9,7 @@ use crate::config::Config;
 use crate::error::{GgError, Result};
 use crate::git::{self, get_commit_description, strip_gg_id_from_message};
 use crate::managed_body;
+use crate::operations::{OperationKind, RemoteEffect, SnapshotScope};
 use crate::output::{
     print_json, SyncEntryResultJson, SyncMetadataJson, SyncResponse, SyncResultJson, OUTPUT_VERSION,
 };
@@ -178,11 +179,23 @@ pub fn run(
 ) -> Result<()> {
     let repo = git::open_repo()?;
 
-    // Acquire operation lock to prevent concurrent operations
-    let _lock = git::acquire_operation_lock(&repo, "sync")?;
-
     let git_dir = repo.commondir();
     let mut config = Config::load_with_global(git_dir)?;
+
+    // Acquire operation lock + record a Pending op for the undo log.
+    let (_lock, guard) = git::acquire_operation_lock_and_record(
+        &repo,
+        &config,
+        OperationKind::Sync,
+        std::env::args().collect(),
+        None,
+        SnapshotScope::AllUserBranches,
+    )?;
+
+    // Remote effects collected during the sync loop. Populated when a push
+    // succeeds or a PR is created; consumed by `guard.finalize_*`.
+    let mut remote_effects: Vec<RemoteEffect> = Vec::new();
+    let mut touched_remote = false;
 
     // Apply config defaults to CLI flags:
     // - draft: CLI flag OR config setting (either one enables drafts)
@@ -209,6 +222,7 @@ pub fn run(
         } else {
             println!("{}", style("Stack is empty. Nothing to sync.").dim());
         }
+        guard.finalize_with_scope(&repo, &config, SnapshotScope::AllUserBranches, vec![], false)?;
         return Ok(());
     }
 
@@ -290,6 +304,13 @@ pub fn run(
         } else {
             println!("{}", style("Stack is empty. Nothing to sync.").dim());
         }
+        guard.finalize_with_scope(
+            &repo,
+            &config,
+            SnapshotScope::AllUserBranches,
+            remote_effects,
+            touched_remote,
+        )?;
         return Ok(());
     }
 
@@ -416,6 +437,16 @@ pub fn run(
                 format_push_error(&e, &entry_branch);
                 return Err(e);
             }
+
+            // Record the push as a remote effect. `sync` always pushes with
+            // force-with-lease because rebases rewrite entry-branch history;
+            // the `force` field here reflects the hard --force escape hatch.
+            remote_effects.push(RemoteEffect::Pushed {
+                remote: "origin".to_string(),
+                branch: entry_branch.clone(),
+                force,
+            });
+            touched_remote = true;
         }
 
         // Determine target branch for MR
@@ -614,6 +645,14 @@ pub fn run(
                             Some(result.url.clone())
                         };
                         action = "created".to_string();
+
+                        // Record the PR creation as a remote effect so `gg undo`
+                        // can surface a provider-specific revert hint.
+                        remote_effects.push(RemoteEffect::PrCreated {
+                            number: result.number,
+                            url: result.url.clone(),
+                        });
+                        touched_remote = true;
 
                         if !json {
                             let draft_label = if entry_draft { " (draft)" } else { "" };
@@ -889,6 +928,14 @@ pub fn run(
             entries_to_sync.len()
         );
     }
+
+    guard.finalize_with_scope(
+        &repo,
+        &config,
+        SnapshotScope::AllUserBranches,
+        remote_effects,
+        touched_remote,
+    )?;
 
     Ok(())
 }

--- a/crates/gg-core/src/commands/sync.rs
+++ b/crates/gg-core/src/commands/sync.rs
@@ -183,17 +183,19 @@ pub fn run(
     let mut config = Config::load_with_global(git_dir)?;
 
     // Acquire operation lock + record a Pending op for the undo log.
-    let (_lock, guard) = git::acquire_operation_lock_and_record(
+    let (_lock, mut guard) = git::acquire_operation_lock_and_record(
         &repo,
         &config,
         OperationKind::Sync,
-        std::env::args().collect(),
+        std::env::args().skip(1).collect(),
         None,
         SnapshotScope::AllUserBranches,
     )?;
 
-    // Remote effects collected during the sync loop. Populated when a push
-    // succeeds or a PR is created; consumed by `guard.finalize_*`.
+    // Remote effects are persisted incrementally via `guard.record_remote_effect`
+    // / `guard.mark_touched_remote` so a mid-loop failure leaves an accurate
+    // trail (design §4.4). These locals mirror what has been recorded so the
+    // success-path finalize can replay the same values without a disk read.
     let mut remote_effects: Vec<RemoteEffect> = Vec::new();
     let mut touched_remote = false;
 
@@ -447,12 +449,14 @@ pub fn run(
             // Record the push as a remote effect. `sync` always pushes with
             // force-with-lease because rebases rewrite entry-branch history;
             // the `force` field here reflects the hard --force escape hatch.
-            remote_effects.push(RemoteEffect::Pushed {
+            let effect = RemoteEffect::Pushed {
                 remote: "origin".to_string(),
                 branch: entry_branch.clone(),
                 force,
-            });
+            };
+            remote_effects.push(effect.clone());
             touched_remote = true;
+            guard.record_remote_effect(effect);
         }
 
         // Determine target branch for MR
@@ -593,20 +597,32 @@ pub fn run(
                         }
                     }
 
-                    // Update PR/MR base if needed
-                    if let Err(e) = provider.update_pr_base(pr_num, &target_branch) {
-                        if !json {
-                            pb.println(format!(
-                                "{} Could not update {} {}{}: {}",
-                                style("Warning:").yellow(),
-                                provider.pr_label(),
-                                provider.pr_number_prefix(),
-                                pr_num,
-                                e
-                            ));
+                    // Update PR/MR base if needed. A successful `update_pr_base`
+                    // call mutates remote state — even if the new base matches
+                    // what the API already had, we've made a request that the
+                    // provider treats as an authoritative update. Mark
+                    // `touched_remote` so `gg undo` refuses to replay this sync
+                    // locally (there's no safe local inverse for a remote base
+                    // change).
+                    match provider.update_pr_base(pr_num, &target_branch) {
+                        Ok(()) => {
+                            touched_remote = true;
+                            guard.mark_touched_remote();
                         }
-                        if entry_error.is_none() {
-                            entry_error = Some(format!("Could not update base: {e}"));
+                        Err(e) => {
+                            if !json {
+                                pb.println(format!(
+                                    "{} Could not update {} {}{}: {}",
+                                    style("Warning:").yellow(),
+                                    provider.pr_label(),
+                                    provider.pr_number_prefix(),
+                                    pr_num,
+                                    e
+                                ));
+                            }
+                            if entry_error.is_none() {
+                                entry_error = Some(format!("Could not update base: {e}"));
+                            }
                         }
                     }
 
@@ -653,12 +669,16 @@ pub fn run(
                         action = "created".to_string();
 
                         // Record the PR creation as a remote effect so `gg undo`
-                        // can surface a provider-specific revert hint.
-                        remote_effects.push(RemoteEffect::PrCreated {
+                        // can surface a provider-specific revert hint. Persist
+                        // immediately so a mid-sequence failure still leaves an
+                        // accurate record on disk.
+                        let effect = RemoteEffect::PrCreated {
                             number: result.number,
                             url: result.url.clone(),
-                        });
+                        };
+                        remote_effects.push(effect.clone());
                         touched_remote = true;
+                        guard.record_remote_effect(effect);
 
                         if !json {
                             let draft_label = if entry_draft { " (draft)" } else { "" };

--- a/crates/gg-core/src/commands/undo.rs
+++ b/crates/gg-core/src/commands/undo.rs
@@ -1,0 +1,350 @@
+//! `gg undo` command handler. See design §2.4.
+//!
+//! Wraps [`crate::operations::run_undo`] with the record-itself pattern: an
+//! `Undo` operation is itself recorded in the op log (D5), so the user can
+//! run `gg undo; gg undo` to redo the first op.
+//!
+//! Refusal modes (remote/interrupted/stale/unsupported-schema) intentionally
+//! drop the guard without calling `finalize`, which leaves the record as
+//! Pending on disk; the next lock-acquiring op will sweep it to Interrupted.
+//! This is fine — we did not mutate anything.
+
+use console::style;
+
+use crate::config::Config;
+use crate::error::{GgError, Result};
+use crate::git;
+use crate::operations::{
+    self, OperationKind, OperationRecord, SnapshotScope, UndoOptions, UndoOutcome,
+};
+use crate::output::{
+    print_json, OperationSummaryJson, UndoJsonStatus, UndoListResponse, UndoRefusalJson,
+    UndoRefusalReason, UndoResponse, OUTPUT_VERSION,
+};
+
+/// Options for the undo command.
+#[derive(Debug, Default)]
+pub struct UndoCliOptions {
+    /// When true, list recent operations instead of undoing.
+    pub list: bool,
+    /// Target a specific operation id (most-recent-undoable when `None`).
+    pub operation_id: Option<String>,
+    /// Emit machine-readable JSON.
+    pub json: bool,
+    /// Limit for `--list`. Defaults to 20 when 0.
+    pub limit: usize,
+}
+
+/// Run the undo command.
+pub fn run(options: UndoCliOptions) -> Result<()> {
+    let repo = git::open_repo()?;
+    let config = Config::load_with_global(repo.commondir())?;
+
+    if options.list {
+        return run_list(&repo, &options);
+    }
+    run_undo(&repo, &config, &options)
+}
+
+fn run_list(repo: &git2::Repository, options: &UndoCliOptions) -> Result<()> {
+    let limit = if options.limit == 0 { 20 } else { options.limit };
+    let records = operations::list(repo, limit)?;
+
+    if options.json {
+        let response = UndoListResponse {
+            version: OUTPUT_VERSION,
+            operations: records.iter().map(OperationSummaryJson::from).collect(),
+        };
+        print_json(&response);
+    } else {
+        print_list_human(&records);
+    }
+    Ok(())
+}
+
+fn run_undo(
+    repo: &git2::Repository,
+    config: &Config,
+    options: &UndoCliOptions,
+) -> Result<()> {
+    // Undo itself takes a lock and records itself (D5). Use AllUserBranches
+    // scope so the undo record's refs_before captures whatever user-owned
+    // state existed before the replay.
+    let args: Vec<String> = if let Some(id) = &options.operation_id {
+        vec!["undo".into(), id.clone()]
+    } else {
+        vec!["undo".into()]
+    };
+    let (_lock, guard) = git::acquire_operation_lock_and_record(
+        repo,
+        config,
+        OperationKind::Undo,
+        args,
+        None,
+        SnapshotScope::AllUserBranches,
+    )?;
+
+    let undo_opts = UndoOptions {
+        operation_id: options.operation_id.clone(),
+        json: options.json,
+    };
+    let outcome = operations::run_undo(repo, config, undo_opts)?;
+
+    // On success we capture the post-replay snapshot and finalize. On any
+    // refusal we drop the guard without finalize (see module docs).
+    match &outcome {
+        UndoOutcome::Succeeded(target) => {
+            let refs_after =
+                operations::snapshot_refs(repo, config, SnapshotScope::AllUserBranches)?;
+            guard.finalize_as_undo(refs_after, target.id.clone())?;
+        }
+        _ => {
+            // Drop guard: the Pending record will be swept to Interrupted.
+            drop(guard);
+        }
+    }
+
+    emit_response(&outcome, options.json)?;
+
+    // Non-success outcomes exit non-zero so scripts can branch on it.
+    match outcome {
+        UndoOutcome::Succeeded(_) => Ok(()),
+        UndoOutcome::RefusedRemote { target, hints: _ } => {
+            Err(GgError::OperationNotUndoable {
+                id: target.id,
+                reason: "operation touched a remote".into(),
+            })
+        }
+        UndoOutcome::RefusedInterrupted(target) => Err(GgError::OperationNotUndoable {
+            id: target.id,
+            reason: "operation was interrupted".into(),
+        }),
+        UndoOutcome::RefusedStale {
+            target,
+            ref_name,
+            expected,
+            actual,
+        } => Err(GgError::StaleUndo {
+            ref_name,
+            expected,
+            actual: format!("{actual} (target: {})", target.id),
+        }),
+        UndoOutcome::RefusedUnsupportedSchema(target) => Err(GgError::OperationNotUndoable {
+            id: target.id,
+            reason: "operation was written by a newer gg; schema not supported".into(),
+        }),
+    }
+}
+
+fn emit_response(outcome: &UndoOutcome, json: bool) -> Result<()> {
+    if json {
+        let response = build_json_response(outcome);
+        print_json(&response);
+        return Ok(());
+    }
+
+    match outcome {
+        UndoOutcome::Succeeded(target) => {
+            println!(
+                "{} Undid {} ({})",
+                style("OK").green().bold(),
+                short_id(&target.id),
+                short_args(&target.args),
+            );
+        }
+        UndoOutcome::RefusedRemote { target, hints } => {
+            eprintln!(
+                "{} Refusing to undo {}: operation touched a remote.",
+                style("Refused").red().bold(),
+                short_id(&target.id),
+            );
+            for hint in hints {
+                eprintln!("  {}", hint);
+            }
+        }
+        UndoOutcome::RefusedInterrupted(t) => {
+            eprintln!(
+                "{} Refusing to undo {}: operation did not finish cleanly.",
+                style("Refused").red().bold(),
+                short_id(&t.id),
+            );
+        }
+        UndoOutcome::RefusedStale {
+            target,
+            ref_name,
+            expected,
+            actual,
+        } => {
+            eprintln!(
+                "{} Refusing to undo {}: ref `{}` moved since the operation (expected `{}`, now `{}`).",
+                style("Refused").red().bold(),
+                short_id(&target.id),
+                ref_name,
+                expected,
+                actual,
+            );
+        }
+        UndoOutcome::RefusedUnsupportedSchema(target) => {
+            eprintln!(
+                "{} Refusing to undo {}: schema version {} is newer than this gg ({}).",
+                style("Refused").red().bold(),
+                short_id(&target.id),
+                target.schema_version,
+                operations::SCHEMA_VERSION,
+            );
+        }
+    }
+    Ok(())
+}
+
+fn build_json_response(outcome: &UndoOutcome) -> UndoResponse {
+    match outcome {
+        UndoOutcome::Succeeded(target) => UndoResponse {
+            version: OUTPUT_VERSION,
+            status: UndoJsonStatus::Succeeded,
+            undone: Some(OperationSummaryJson::from(target)),
+            refusal: None,
+        },
+        UndoOutcome::RefusedRemote { target, hints } => UndoResponse {
+            version: OUTPUT_VERSION,
+            status: UndoJsonStatus::Refused,
+            undone: None,
+            refusal: Some(UndoRefusalJson {
+                reason: UndoRefusalReason::Remote,
+                message: "operation touched a remote".into(),
+                target: Some(OperationSummaryJson::from(target)),
+                hints: hints.clone(),
+            }),
+        },
+        UndoOutcome::RefusedInterrupted(target) => UndoResponse {
+            version: OUTPUT_VERSION,
+            status: UndoJsonStatus::Refused,
+            undone: None,
+            refusal: Some(UndoRefusalJson {
+                reason: UndoRefusalReason::Interrupted,
+                message: "operation was interrupted".into(),
+                target: Some(OperationSummaryJson::from(target)),
+                hints: vec![],
+            }),
+        },
+        UndoOutcome::RefusedStale {
+            target,
+            ref_name,
+            expected,
+            actual,
+        } => UndoResponse {
+            version: OUTPUT_VERSION,
+            status: UndoJsonStatus::Refused,
+            undone: None,
+            refusal: Some(UndoRefusalJson {
+                reason: UndoRefusalReason::Stale,
+                message: format!(
+                    "ref `{ref_name}` moved since the operation (expected `{expected}`, now `{actual}`)"
+                ),
+                target: Some(OperationSummaryJson::from(target)),
+                hints: vec![],
+            }),
+        },
+        UndoOutcome::RefusedUnsupportedSchema(target) => UndoResponse {
+            version: OUTPUT_VERSION,
+            status: UndoJsonStatus::Refused,
+            undone: None,
+            refusal: Some(UndoRefusalJson {
+                reason: UndoRefusalReason::UnsupportedSchema,
+                message: format!(
+                    "schema version {} newer than this gg",
+                    target.schema_version
+                ),
+                target: Some(OperationSummaryJson::from(target)),
+                hints: vec![],
+            }),
+        },
+    }
+}
+
+fn print_list_human(records: &[OperationRecord]) {
+    if records.is_empty() {
+        println!("{}", style("No operations recorded yet.").dim());
+        return;
+    }
+    println!(
+        "{:<10}  {:<12}  {:<10}  {:<8}  {}",
+        "ID", "KIND", "STATUS", "UNDOABLE", "ARGS"
+    );
+    for r in records {
+        let undoable = if r.is_undoable_locally() {
+            style("yes").green().to_string()
+        } else if r.touched_remote {
+            style("remote").red().to_string()
+        } else {
+            style("no").dim().to_string()
+        };
+        let status = format!("{:?}", r.status).to_lowercase();
+        let kind = format!("{:?}", r.kind).to_lowercase();
+        println!(
+            "{:<10}  {:<12}  {:<10}  {:<8}  {}",
+            short_id(&r.id),
+            kind,
+            status,
+            undoable,
+            short_args(&r.args),
+        );
+    }
+}
+
+fn short_id(id: &str) -> String {
+    // IDs look like "<unix_ms>_<random>". Show a compact form: last 8 chars
+    // of the random suffix, or the whole id if shorter.
+    if id.len() <= 10 {
+        return id.to_string();
+    }
+    let tail_len = 8;
+    let start = id.len().saturating_sub(tail_len);
+    id[start..].to_string()
+}
+
+fn short_args(args: &[String]) -> String {
+    let joined = args.join(" ");
+    // Byte-length cap at 80. When truncating we reserve room for "..." (3 bytes)
+    // and take the first 77 bytes, clipped to a char boundary.
+    if joined.len() <= 80 {
+        joined
+    } else {
+        let mut cut = 77;
+        while cut > 0 && !joined.is_char_boundary(cut) {
+            cut -= 1;
+        }
+        format!("{}...", &joined[..cut])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_id_truncates_long_ids() {
+        let id = "1700000000000_abcdef0123";
+        // Last 8 chars of the full id (length 24 → chars [16..24]).
+        assert_eq!(short_id(id), "cdef0123");
+    }
+
+    #[test]
+    fn short_id_keeps_short_ids() {
+        assert_eq!(short_id("abc"), "abc");
+    }
+
+    #[test]
+    fn short_args_truncates_long_strings() {
+        let long: Vec<String> = (0..30).map(|i| format!("arg{i}")).collect();
+        let s = short_args(&long);
+        assert!(s.len() <= 80, "expected <= 80 bytes, got {}", s.len());
+        assert!(s.ends_with("..."));
+    }
+
+    #[test]
+    fn short_args_short_roundtrip() {
+        let args = vec!["sync".to_string(), "main".to_string()];
+        assert_eq!(short_args(&args), "sync main");
+    }
+}

--- a/crates/gg-core/src/commands/undo.rs
+++ b/crates/gg-core/src/commands/undo.rs
@@ -47,7 +47,11 @@ pub fn run(options: UndoCliOptions) -> Result<()> {
 }
 
 fn run_list(repo: &git2::Repository, options: &UndoCliOptions) -> Result<()> {
-    let limit = if options.limit == 0 { 20 } else { options.limit };
+    let limit = if options.limit == 0 {
+        20
+    } else {
+        options.limit
+    };
     let records = operations::list(repo, limit)?;
 
     if options.json {
@@ -62,11 +66,7 @@ fn run_list(repo: &git2::Repository, options: &UndoCliOptions) -> Result<()> {
     Ok(())
 }
 
-fn run_undo(
-    repo: &git2::Repository,
-    config: &Config,
-    options: &UndoCliOptions,
-) -> Result<()> {
+fn run_undo(repo: &git2::Repository, config: &Config, options: &UndoCliOptions) -> Result<()> {
     // Undo itself takes a lock and records itself (D5). Use AllUserBranches
     // scope so the undo record's refs_before captures whatever user-owned
     // state existed before the replay.
@@ -109,12 +109,10 @@ fn run_undo(
     // Non-success outcomes exit non-zero so scripts can branch on it.
     match outcome {
         UndoOutcome::Succeeded(_) => Ok(()),
-        UndoOutcome::RefusedRemote { target, hints: _ } => {
-            Err(GgError::OperationNotUndoable {
-                id: target.id,
-                reason: "operation touched a remote".into(),
-            })
-        }
+        UndoOutcome::RefusedRemote { target, hints: _ } => Err(GgError::OperationNotUndoable {
+            id: target.id,
+            reason: "operation touched a remote".into(),
+        }),
         UndoOutcome::RefusedInterrupted(target) => Err(GgError::OperationNotUndoable {
             id: target.id,
             reason: "operation was interrupted".into(),
@@ -268,8 +266,8 @@ fn print_list_human(records: &[OperationRecord]) {
         return;
     }
     println!(
-        "{:<10}  {:<12}  {:<10}  {:<8}  {}",
-        "ID", "KIND", "STATUS", "UNDOABLE", "ARGS"
+        "{:<10}  {:<12}  {:<10}  {:<8}  ARGS",
+        "ID", "KIND", "STATUS", "UNDOABLE"
     );
     for r in records {
         let undoable = if r.is_undoable_locally() {

--- a/crates/gg-core/src/commands/undo.rs
+++ b/crates/gg-core/src/commands/undo.rs
@@ -31,7 +31,7 @@ pub struct UndoCliOptions {
     pub operation_id: Option<String>,
     /// Emit machine-readable JSON.
     pub json: bool,
-    /// Limit for `--list`. Defaults to 20 when 0.
+    /// Limit for `--list`. Defaults to 100 when 0 (matches the op-log cap).
     pub limit: usize,
 }
 
@@ -48,7 +48,7 @@ pub fn run(options: UndoCliOptions) -> Result<()> {
 
 fn run_list(repo: &git2::Repository, options: &UndoCliOptions) -> Result<()> {
     let limit = if options.limit == 0 {
-        20
+        100
     } else {
         options.limit
     };
@@ -106,31 +106,16 @@ fn run_undo(repo: &git2::Repository, config: &Config, options: &UndoCliOptions) 
 
     emit_response(&outcome, options.json)?;
 
-    // Non-success outcomes exit non-zero so scripts can branch on it.
+    // `emit_response` already printed a detailed human-readable diagnostic
+    // (or the structured JSON refusal). For refusals we return the marker
+    // `Silenced` error so the CLI exits non-zero without prepending another
+    // generic "error: ..." line that would duplicate the refusal message.
     match outcome {
         UndoOutcome::Succeeded(_) => Ok(()),
-        UndoOutcome::RefusedRemote { target, hints: _ } => Err(GgError::OperationNotUndoable {
-            id: target.id,
-            reason: "operation touched a remote".into(),
-        }),
-        UndoOutcome::RefusedInterrupted(target) => Err(GgError::OperationNotUndoable {
-            id: target.id,
-            reason: "operation was interrupted".into(),
-        }),
-        UndoOutcome::RefusedStale {
-            target,
-            ref_name,
-            expected,
-            actual,
-        } => Err(GgError::StaleUndo {
-            ref_name,
-            expected,
-            actual: format!("{actual} (target: {})", target.id),
-        }),
-        UndoOutcome::RefusedUnsupportedSchema(target) => Err(GgError::OperationNotUndoable {
-            id: target.id,
-            reason: "operation was written by a newer gg; schema not supported".into(),
-        }),
+        UndoOutcome::RefusedRemote { .. }
+        | UndoOutcome::RefusedInterrupted(_)
+        | UndoOutcome::RefusedStale { .. }
+        | UndoOutcome::RefusedUnsupportedSchema(_) => Err(GgError::Silenced),
     }
 }
 

--- a/crates/gg-core/src/error.rs
+++ b/crates/gg-core/src/error.rs
@@ -80,6 +80,22 @@ pub enum GgError {
     #[error("JSON error: {0}")]
     Json(#[from] serde_json::Error),
 
+    #[error("No operation record found with id '{0}'")]
+    OperationRecordNotFound(String),
+
+    #[error("Operation '{id}' is not undoable: {reason}")]
+    OperationNotUndoable { id: String, reason: String },
+
+    #[error("Cannot undo: ref '{ref_name}' has moved since the operation (expected {expected}, actually {actual}). Run `gg undo --list` to see a safe candidate.")]
+    StaleUndo {
+        ref_name: String,
+        expected: String,
+        actual: String,
+    },
+
+    #[error("Cannot locally undo '{kind}': it touched a remote.\n{hint}")]
+    RemoteUndoUnsupported { kind: String, hint: String },
+
     #[error("{0}")]
     Other(String),
 

--- a/crates/gg-core/src/error.rs
+++ b/crates/gg-core/src/error.rs
@@ -101,6 +101,13 @@ pub enum GgError {
 
     #[error("A git operation is currently in progress.\n{0}\nIf no other process is running, remove the stale lock:\n  rm {1}")]
     GitOperationInProgress(String, String),
+
+    /// Marker error for commands that have already printed their own human-
+    /// readable diagnostic and just need the process to exit non-zero. The
+    /// CLI top-level handler recognises this and suppresses the generic
+    /// "error: ..." prefix to avoid double-printing.
+    #[error("")]
+    Silenced,
 }
 
 pub type Result<T> = std::result::Result<T, GgError>;

--- a/crates/gg-core/src/git.rs
+++ b/crates/gg-core/src/git.rs
@@ -35,6 +35,14 @@ pub fn open_repo() -> Result<Repository> {
     Repository::discover(".").map_err(|_| GgError::NotInRepo)
 }
 
+/// Per-clone gg state directory at `<commondir>/gg`.
+///
+/// Uses `commondir()` (not `path()`) so worktrees share a single operation
+/// log and config with the main working copy.
+pub fn gg_dir(repo: &Repository) -> std::path::PathBuf {
+    repo.commondir().join("gg")
+}
+
 /// Operation lock handle that automatically releases on drop
 #[derive(Debug)]
 pub struct OperationLock {
@@ -146,6 +154,68 @@ pub(crate) fn acquire_operation_lock_with_timeout(
             Err(e) => return Err(e.into()),
         }
     }
+}
+
+/// Acquire the operation lock AND write a `Pending` operation record.
+///
+/// The returned [`crate::operations::OperationGuard`] must have `finalize`
+/// called on the success path. Dropping without finalize leaves the record
+/// `Pending` on disk; the sweep promotes it to `Interrupted` on the next
+/// lock acquisition (after `PENDING_STALENESS_MS`).
+///
+/// This is the instrumentation sibling of [`acquire_operation_lock`]. The
+/// original function stays unchanged for callers that do not need to
+/// record (e.g. `gg continue` / `gg abort`).
+pub fn acquire_operation_lock_and_record(
+    repo: &Repository,
+    config: &crate::config::Config,
+    kind: crate::operations::OperationKind,
+    args: Vec<String>,
+    stack_name: Option<String>,
+    scope: crate::operations::SnapshotScope<'_>,
+) -> Result<(OperationLock, crate::operations::OperationGuard)> {
+    use crate::operations::{
+        self, new_id, now_ms, OperationGuard, OperationRecord, OperationStatus, OperationStore,
+        SCHEMA_VERSION,
+    };
+
+    // 1. Reuse the existing lock acquisition (handles index.lock + flock).
+    let op_name = format!("{kind:?}").to_lowercase();
+    let lock = acquire_operation_lock(repo, &op_name)?;
+
+    // 2. Sweep stale Pending records. Swallows all errors.
+    let gg_dir_path = gg_dir(repo);
+    let store = OperationStore::new(&gg_dir_path);
+    store.sweep_pending(now_ms());
+
+    // 3. Capture refs_before. Snapshot errors propagate — if we can't read
+    //    refs we can't safely record anything.
+    let refs_before = operations::snapshot_refs(repo, config, scope)?;
+
+    // 4. Write the Pending record.
+    let record = OperationRecord {
+        id: new_id(),
+        schema_version: SCHEMA_VERSION,
+        kind,
+        status: OperationStatus::Pending,
+        created_at_ms: now_ms(),
+        args,
+        stack_name,
+        refs_before,
+        refs_after: vec![],
+        remote_effects: vec![],
+        touched_remote: false,
+        undoes: None,
+        pending_plan: None,
+    };
+    store.save(&record)?;
+
+    let guard = OperationGuard {
+        record,
+        store,
+        finalized: false,
+    };
+    Ok((lock, guard))
 }
 
 /// Find the base branch (main, master, or trunk)

--- a/crates/gg-core/src/git.rs
+++ b/crates/gg-core/src/git.rs
@@ -166,6 +166,11 @@ pub(crate) fn acquire_operation_lock_with_timeout(
 /// This is the instrumentation sibling of [`acquire_operation_lock`]. The
 /// original function stays unchanged for callers that do not need to
 /// record (e.g. `gg continue` / `gg abort`).
+///
+/// Callers that need to gate recording on pre-mutation validation (e.g.
+/// the immutability guard) should instead use [`acquire_operation_lock`]
+/// combined with [`begin_recorded_op`] so that rejected operations never
+/// pollute the op log.
 pub fn acquire_operation_lock_and_record(
     repo: &Repository,
     config: &crate::config::Config,
@@ -174,25 +179,47 @@ pub fn acquire_operation_lock_and_record(
     stack_name: Option<String>,
     scope: crate::operations::SnapshotScope<'_>,
 ) -> Result<(OperationLock, crate::operations::OperationGuard)> {
+    let op_name = format!("{kind:?}").to_lowercase();
+    let lock = acquire_operation_lock(repo, &op_name)?;
+    let guard = begin_recorded_op(repo, config, kind, args, stack_name, scope)?;
+    Ok((lock, guard))
+}
+
+/// Write a `Pending` operation record, assuming the caller already holds
+/// the operation lock (via [`acquire_operation_lock`]).
+///
+/// This is the half of [`acquire_operation_lock_and_record`] that runs
+/// *after* lock acquisition. Split out so instrumented commands can do
+/// pre-mutation validation (e.g. immutability checks) without polluting
+/// the op log with rejected operations: acquire the lock first, validate,
+/// then call this helper immediately before mutating.
+///
+/// The returned guard MUST be `finalize`d on the success path — dropping
+/// it leaves the record `Pending` on disk for the sweep to promote to
+/// `Interrupted`.
+pub fn begin_recorded_op(
+    repo: &Repository,
+    config: &crate::config::Config,
+    kind: crate::operations::OperationKind,
+    args: Vec<String>,
+    stack_name: Option<String>,
+    scope: crate::operations::SnapshotScope<'_>,
+) -> Result<crate::operations::OperationGuard> {
     use crate::operations::{
         self, new_id, now_ms, OperationGuard, OperationRecord, OperationStatus, OperationStore,
         SCHEMA_VERSION,
     };
 
-    // 1. Reuse the existing lock acquisition (handles index.lock + flock).
-    let op_name = format!("{kind:?}").to_lowercase();
-    let lock = acquire_operation_lock(repo, &op_name)?;
-
-    // 2. Sweep stale Pending records. Swallows all errors.
+    // 1. Sweep stale Pending records. Swallows all errors.
     let gg_dir_path = gg_dir(repo);
     let store = OperationStore::new(&gg_dir_path);
     store.sweep_pending(now_ms());
 
-    // 3. Capture refs_before. Snapshot errors propagate — if we can't read
+    // 2. Capture refs_before. Snapshot errors propagate — if we can't read
     //    refs we can't safely record anything.
     let refs_before = operations::snapshot_refs(repo, config, scope)?;
 
-    // 4. Write the Pending record.
+    // 3. Write the Pending record.
     let record = OperationRecord {
         id: new_id(),
         schema_version: SCHEMA_VERSION,
@@ -210,12 +237,11 @@ pub fn acquire_operation_lock_and_record(
     };
     store.save(&record)?;
 
-    let guard = OperationGuard {
+    Ok(OperationGuard {
         record,
         store,
         finalized: false,
-    };
-    Ok((lock, guard))
+    })
 }
 
 /// Find the base branch (main, master, or trunk)

--- a/crates/gg-core/src/lib.rs
+++ b/crates/gg-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod git;
 pub mod glab;
 pub mod immutability;
 pub mod managed_body;
+pub mod operations;
 pub mod output;
 pub mod provider;
 pub mod stack;

--- a/crates/gg-core/src/operations.rs
+++ b/crates/gg-core/src/operations.rs
@@ -263,7 +263,7 @@ impl OperationStore {
             .into_iter()
             .filter_map(|id| self.load(&id).ok())
             .collect();
-        records.sort_by(|a, b| b.created_at_ms.cmp(&a.created_at_ms));
+        records.sort_by_key(|r| std::cmp::Reverse(r.created_at_ms));
         records.truncate(limit);
         Ok(records)
     }
@@ -279,7 +279,7 @@ impl OperationStore {
             return;
         }
         // Sort oldest-first for pruning.
-        records.sort_by(|a, b| a.created_at_ms.cmp(&b.created_at_ms));
+        records.sort_by_key(|r| r.created_at_ms);
         let excess = records.len() - OPERATION_LOG_CAP;
         let mut pruned = 0;
         for rec in records {
@@ -555,11 +555,7 @@ pub fn list(repo: &Repository, limit: usize) -> Result<Vec<OperationRecord>> {
 
 /// Replay an operation's `refs_before` atop the repo. Consumes nothing from
 /// the log itself; the caller wraps this in a fresh `Undo` record.
-pub fn run_undo(
-    repo: &Repository,
-    _config: &Config,
-    opts: UndoOptions,
-) -> Result<UndoOutcome> {
+pub fn run_undo(repo: &Repository, _config: &Config, opts: UndoOptions) -> Result<UndoOutcome> {
     let gg_dir = crate::git::gg_dir(repo);
     let store = OperationStore::new(&gg_dir);
 
@@ -974,15 +970,14 @@ mod snapshot_tests {
 
     #[test]
     fn all_user_branches_filters_by_username_prefix() {
-        let (_g, repo) =
-            init_repo_with_branches("nacho", &["main", "x/1", "x/2", "other/mine"]);
+        let (_g, repo) = init_repo_with_branches("nacho", &["main", "x/1", "x/2", "other/mine"]);
         let cfg = config_with_username("nacho");
         let snaps = snapshot_refs(&repo, &cfg, SnapshotScope::AllUserBranches).unwrap();
         let names: Vec<&str> = snaps.iter().map(|s| s.name.as_str()).collect();
-        assert!(names.iter().any(|n| *n == "refs/heads/nacho/x/1"));
-        assert!(names.iter().any(|n| *n == "refs/heads/nacho/x/2"));
-        assert!(!names.iter().any(|n| *n == "refs/heads/main"));
-        assert!(!names.iter().any(|n| *n == "refs/heads/other/mine"));
+        assert!(names.contains(&"refs/heads/nacho/x/1"));
+        assert!(names.contains(&"refs/heads/nacho/x/2"));
+        assert!(!names.contains(&"refs/heads/main"));
+        assert!(!names.contains(&"refs/heads/other/mine"));
     }
 
     #[test]

--- a/crates/gg-core/src/operations.rs
+++ b/crates/gg-core/src/operations.rs
@@ -549,29 +549,16 @@ pub fn run_undo(
     let gg_dir = crate::git::gg_dir(repo);
     let store = OperationStore::new(&gg_dir);
 
-    // 1. Resolve target.
+    // 1. Resolve target. When no id is provided, pick the most recent
+    // undoable record. Per D5, undo-of-undo is fine: Undo records are
+    // themselves undoable (they have refs_before/after and do not touch
+    // the remote), so `gg undo; gg undo` naturally redoes the first op.
     let target = match opts.operation_id.clone() {
         Some(id) => store.load(&id)?,
         None => store
             .list(usize::MAX)?
             .into_iter()
-            // Skip undo records themselves when picking "most recent" — a
-            // second `gg undo` should target the newest *non-undo* op (D5
-            // says the undo-of-undo is recorded, but users expect
-            // `gg undo; gg undo` to undo the undo).
-            .find(|r| {
-                r.is_undoable_locally() && !matches!(r.kind, OperationKind::Undo) || {
-                    // Actually D5: undo-of-undo is fine; we just need the
-                    // newest undoable record.
-                    false
-                }
-            })
-            .or_else(|| {
-                store
-                    .list(usize::MAX)
-                    .ok()
-                    .and_then(|v| v.into_iter().find(|r| r.is_undoable_locally()))
-            })
+            .find(|r| r.is_undoable_locally())
             .ok_or_else(|| GgError::OperationNotUndoable {
                 id: "<none>".into(),
                 reason: "no undoable operation in the log".into(),
@@ -936,7 +923,12 @@ mod snapshot_tests {
 
     fn init_repo_with_branches(prefix: &str, branches: &[&str]) -> (tempfile::TempDir, Repository) {
         let dir = tempfile::tempdir().unwrap();
-        let repo = Repository::init(dir.path()).unwrap();
+        // Use an explicit, non-conflicting initial branch so the test can freely
+        // create branches named main/master/trunk without the HEAD-branch clash
+        // (init.defaultBranch varies across systems).
+        let mut opts = git2::RepositoryInitOptions::new();
+        opts.initial_head("gg-test-base");
+        let repo = Repository::init_opts(dir.path(), &opts).unwrap();
         {
             let sig = git2::Signature::now("gg-test", "gg@test").unwrap();
             let tree_oid = {

--- a/crates/gg-core/src/operations.rs
+++ b/crates/gg-core/src/operations.rs
@@ -493,6 +493,20 @@ impl OperationGuard {
         self.finalized = true;
         Ok(())
     }
+
+    /// Convenience: snapshot refs with the given scope and finalize. The
+    /// common happy-path one-liner for Phase D instrumented commands.
+    pub fn finalize_with_scope(
+        self,
+        repo: &Repository,
+        config: &Config,
+        scope: SnapshotScope<'_>,
+        remote_effects: Vec<RemoteEffect>,
+        touched_remote: bool,
+    ) -> Result<()> {
+        let refs_after = snapshot_refs(repo, config, scope)?;
+        self.finalize(refs_after, remote_effects, touched_remote)
+    }
 }
 
 impl Drop for OperationGuard {

--- a/crates/gg-core/src/operations.rs
+++ b/crates/gg-core/src/operations.rs
@@ -1,0 +1,1197 @@
+//! Per-repo operation log for `gg undo`.
+//!
+//! See `docs/plans/2026-04-17-task-5-gg-undo-op-log-design.md` for the
+//! architectural contract (decisions D1–D11).
+//!
+//! This module owns the record/replay seam for `gg undo`:
+//! - [`OperationRecord`] + [`OperationKind`] + [`OperationStatus`]: the durable
+//!   schema persisted at `<commondir>/gg/operations/<id>.json`.
+//! - [`OperationStore`]: atomic save/load/list/prune.
+//! - [`OperationGuard`]: RAII-ish guard returned alongside the operation lock.
+//! - [`snapshot_refs`] + [`SnapshotScope`]: ref capture for `refs_before`
+//!   / `refs_after`.
+//! - [`run_undo`] + [`UndoOptions`] + [`UndoOutcome`]: undo replay.
+//!
+//! The on-disk schema is versioned by [`SCHEMA_VERSION`]. Optional fields
+//! are always `#[serde(default, skip_serializing_if = "…")]` so a future
+//! schema version can deserialize under the current version (forward-compat).
+
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use git2::{BranchType, Repository};
+use serde::{Deserialize, Serialize};
+
+use crate::config::Config;
+use crate::error::{GgError, Result};
+use crate::stack::Stack;
+
+/// Durable schema version for operation records. Bumping this is a
+/// backwards-incompatible change and must be accompanied by a migration.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// Ring buffer cap. Committed/Interrupted records beyond this count are
+/// pruned oldest-first. `Pending` records are never pruned — they may
+/// belong to a live process.
+pub const OPERATION_LOG_CAP: usize = 100;
+
+/// How long a `Pending` record may live before the sweep promotes it to
+/// `Interrupted`. 30s is 3× the existing operation-lock timeout.
+pub(crate) const PENDING_STALENESS_MS: u64 = 30_000;
+
+/// Reserved top-level branch names that never belong to a user namespace,
+/// excluded from `SnapshotScope::AllUserBranches`.
+const TRUNK_EXCLUSIONS: &[&str] = &["main", "master", "trunk"];
+
+// ---------------------------------------------------------------------------
+// Record schema
+// ---------------------------------------------------------------------------
+
+/// The kind of operation a record represents. Serialized as snake_case.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OperationKind {
+    Drop,
+    Squash,
+    Split,
+    Rebase,
+    Reorder,
+    Absorb,
+    Checkout,
+    Nav,
+    Sync,
+    Land,
+    Clean,
+    Reconcile,
+    Run,
+    Undo,
+}
+
+/// Lifecycle status of an operation record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OperationStatus {
+    /// Mutation started but `finalize` not yet called. May be an
+    /// in-flight process or a crashed one.
+    Pending,
+    /// Mutation finished successfully; `finalize` ran.
+    Committed,
+    /// Mutation did not finish; the sweep promoted a stale `Pending`.
+    Interrupted,
+}
+
+/// Snapshot of a single ref's target at a point in time.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RefSnapshot {
+    /// Fully-qualified reference name (e.g. `refs/heads/nacho/feat/1`) or
+    /// the literal `"HEAD"`.
+    pub name: String,
+    /// Target OID as a hex string, or `None` if the ref did not exist.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+    /// True if this snapshot represents `HEAD`.
+    #[serde(default)]
+    pub is_head: bool,
+    /// For `HEAD` snapshots: the symbolic ref HEAD pointed at, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub head_symbolic: Option<String>,
+}
+
+/// A remote-side effect produced by the operation. `gg undo` does not reverse
+/// these — it surfaces them as provider-specific revert hints instead.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum RemoteEffect {
+    /// A branch was pushed to a remote.
+    Pushed {
+        remote: String,
+        branch: String,
+        force: bool,
+    },
+    /// A pull/merge request was created.
+    PrCreated { number: u64, url: String },
+    /// A pull/merge request was merged.
+    PrMerged { number: u64, url: String },
+    /// A pull/merge request was closed (without merging).
+    PrClosed { number: u64, url: String },
+}
+
+/// Durable operation record. One JSON file per record.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OperationRecord {
+    /// `op_<13-digit-ms>_<32-char-uuid>`. Sortable lexically ↔ chronologically.
+    pub id: String,
+    /// Schema version at write time.
+    pub schema_version: u32,
+    pub kind: OperationKind,
+    pub status: OperationStatus,
+    pub created_at_ms: u64,
+    /// Raw CLI args `std::env::args().skip(1)` so operators can audit what ran.
+    pub args: Vec<String>,
+    /// Stack name if the operation was stack-scoped.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stack_name: Option<String>,
+    /// Ref snapshot captured before the mutation.
+    pub refs_before: Vec<RefSnapshot>,
+    /// Ref snapshot captured after the mutation (empty until `finalize`).
+    #[serde(default)]
+    pub refs_after: Vec<RefSnapshot>,
+    /// Remote side effects captured by the command (empty until `finalize`).
+    #[serde(default)]
+    pub remote_effects: Vec<RemoteEffect>,
+    /// True iff any remote-visible mutation happened. When true, `gg undo`
+    /// refuses with a provider-specific hint.
+    #[serde(default)]
+    pub touched_remote: bool,
+    /// For `OperationKind::Undo` records: the id of the operation this undo
+    /// reversed (so `--list` can show "undo of op_…").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub undoes: Option<String>,
+    /// Open-ended, schema-free per-command annotation. Reserved for future
+    /// use (e.g. partial-rebase state).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pending_plan: Option<serde_json::Value>,
+}
+
+impl OperationRecord {
+    /// True iff `gg undo` can locally reverse this record.
+    pub fn is_undoable_locally(&self) -> bool {
+        matches!(self.status, OperationStatus::Committed)
+            && !self.touched_remote
+            && self.schema_version <= SCHEMA_VERSION
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ID + timestamp helpers
+// ---------------------------------------------------------------------------
+
+/// Epoch milliseconds from the wall clock. Test-visible via a public helper
+/// so fixtures and the sweep use the same source of truth.
+pub fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Generate `op_{13-digit-ms}_{32-char-uuidv4-no-dashes}`. The zero-padded
+/// timestamp prefix keeps lexical sort == chronological sort.
+pub fn new_id() -> String {
+    let ms = now_ms();
+    let uuid = uuid::Uuid::new_v4().simple().to_string();
+    format!("op_{ms:013}_{uuid}")
+}
+
+// ---------------------------------------------------------------------------
+// OperationStore (atomic save/load/list/prune)
+// ---------------------------------------------------------------------------
+
+/// On-disk store for operation records. One JSON file per record under
+/// `<gg_dir>/operations/<id>.json`. Writes are crash-safe via
+/// write-tempfile-then-rename.
+#[derive(Debug, Clone)]
+pub struct OperationStore {
+    operations_dir: PathBuf,
+}
+
+impl OperationStore {
+    /// `gg_dir` is `<repo.commondir()>/gg` (see design §2.1). Resolve it
+    /// via `crate::git::gg_dir(repo)` — this type does not look at repos.
+    pub fn new(gg_dir: &Path) -> Self {
+        Self {
+            operations_dir: gg_dir.join("operations"),
+        }
+    }
+
+    fn path_for(&self, id: &str) -> PathBuf {
+        self.operations_dir.join(format!("{id}.json"))
+    }
+
+    /// Persist a record atomically. Prunes Committed/Interrupted records
+    /// beyond `OPERATION_LOG_CAP` afterwards, oldest-first.
+    pub fn save(&self, record: &OperationRecord) -> Result<()> {
+        fs::create_dir_all(&self.operations_dir)?;
+        let path = self.path_for(&record.id);
+        let tmp = path.with_extension("json.tmp");
+        let json = serde_json::to_vec_pretty(record)?;
+        {
+            let mut f = fs::File::create(&tmp)?;
+            f.write_all(&json)?;
+            f.sync_all()?;
+        }
+        fs::rename(&tmp, &path)?;
+        self.prune_to_cap();
+        Ok(())
+    }
+
+    /// Load a record by id. Returns `OperationRecordNotFound` if absent.
+    pub fn load(&self, id: &str) -> Result<OperationRecord> {
+        let path = self.path_for(id);
+        let bytes = fs::read(&path).map_err(|e| match e.kind() {
+            std::io::ErrorKind::NotFound => GgError::OperationRecordNotFound(id.to_string()),
+            _ => GgError::Io(e),
+        })?;
+        let rec = serde_json::from_slice(&bytes)?;
+        Ok(rec)
+    }
+
+    /// Newest-first ids (lexical sort == chronological because of the
+    /// zero-padded timestamp prefix). Cheap: no JSON parse.
+    pub fn list_ids(&self, limit: usize) -> Result<Vec<String>> {
+        if !self.operations_dir.exists() {
+            return Ok(vec![]);
+        }
+        let mut ids: Vec<String> = fs::read_dir(&self.operations_dir)?
+            .filter_map(|e| e.ok())
+            .filter_map(|e| e.file_name().into_string().ok())
+            .filter(|name| name.ends_with(".json") && !name.ends_with(".json.tmp"))
+            .map(|name| name.trim_end_matches(".json").to_string())
+            .collect();
+        ids.sort_by(|a, b| b.cmp(a));
+        ids.truncate(limit);
+        Ok(ids)
+    }
+
+    /// Newest-first records, up to `limit`. Records that fail to parse are
+    /// skipped (a poisoned record must not block the rest of the log).
+    pub fn list(&self, limit: usize) -> Result<Vec<OperationRecord>> {
+        let mut records: Vec<OperationRecord> = self
+            .list_ids(usize::MAX)?
+            .into_iter()
+            .filter_map(|id| self.load(&id).ok())
+            .collect();
+        records.sort_by(|a, b| b.created_at_ms.cmp(&a.created_at_ms));
+        records.truncate(limit);
+        Ok(records)
+    }
+
+    /// Prune oldest Committed/Interrupted records when over cap. Never
+    /// removes Pending — the writing process may still be alive. Errors are
+    /// swallowed to avoid cascading a save failure into the caller.
+    fn prune_to_cap(&self) {
+        let Ok(mut records) = self.list(usize::MAX) else {
+            return;
+        };
+        if records.len() <= OPERATION_LOG_CAP {
+            return;
+        }
+        // Sort oldest-first for pruning.
+        records.sort_by(|a, b| a.created_at_ms.cmp(&b.created_at_ms));
+        let excess = records.len() - OPERATION_LOG_CAP;
+        let mut pruned = 0;
+        for rec in records {
+            if pruned >= excess {
+                break;
+            }
+            if rec.status == OperationStatus::Pending {
+                continue;
+            }
+            let _ = fs::remove_file(self.path_for(&rec.id));
+            pruned += 1;
+        }
+    }
+
+    /// Promote Pending records older than [`PENDING_STALENESS_MS`] to
+    /// `Interrupted`. Swallows all errors: a poisoned record must not block
+    /// mutations.
+    pub fn sweep_pending(&self, now_ms_value: u64) {
+        let Ok(ids) = self.list_ids(usize::MAX) else {
+            return;
+        };
+        for id in ids {
+            let Ok(mut rec) = self.load(&id) else {
+                continue;
+            };
+            if rec.status != OperationStatus::Pending {
+                continue;
+            }
+            if rec.created_at_ms.saturating_add(PENDING_STALENESS_MS) >= now_ms_value {
+                continue;
+            }
+            rec.status = OperationStatus::Interrupted;
+            let _ = self.save(&rec);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// snapshot_refs + SnapshotScope
+// ---------------------------------------------------------------------------
+
+/// Which refs to snapshot. `ActiveStack` is the cheap common case;
+/// `AllUserBranches` is for cross-stack commands (`clean`, `reconcile`,
+/// `run` amending multiple stacks).
+pub enum SnapshotScope<'a> {
+    ActiveStack(&'a Stack),
+    AllUserBranches,
+}
+
+/// Capture a ref snapshot per the given scope.
+///
+/// Always appends a `HEAD` snapshot (symbolic if HEAD points at a branch).
+///
+/// D2 (conservative filtering): only local heads prefixed by the configured
+/// `branch_username`; trunk names (`main` / `master` / `trunk`) are always
+/// excluded even if they collide with the prefix filter.
+pub fn snapshot_refs(
+    repo: &Repository,
+    config: &Config,
+    scope: SnapshotScope<'_>,
+) -> Result<Vec<RefSnapshot>> {
+    let username = config.defaults.branch_username.as_deref();
+
+    let mut snapshots: Vec<RefSnapshot> = Vec::new();
+    match (scope, username) {
+        (SnapshotScope::ActiveStack(stack), _) => {
+            // Stack branch itself
+            let stack_branch = stack.branch_name();
+            let fq = format!("refs/heads/{stack_branch}");
+            if let Some(snap) = snapshot_one(repo, &fq)? {
+                snapshots.push(snap);
+            }
+            // Entry branches (gg-owned per-commit refs)
+            for entry in &stack.entries {
+                if let Some(name) = stack.entry_branch_name(entry) {
+                    let fq = format!("refs/heads/{name}");
+                    if let Some(snap) = snapshot_one(repo, &fq)? {
+                        snapshots.push(snap);
+                    }
+                }
+            }
+        }
+        (SnapshotScope::AllUserBranches, Some(u)) => {
+            let prefix = format!("{u}/");
+            for branch in repo.branches(Some(BranchType::Local))? {
+                let (branch, _) = branch?;
+                let name = match branch.name()? {
+                    Some(n) => n.to_string(),
+                    None => continue,
+                };
+                if TRUNK_EXCLUSIONS.contains(&name.as_str()) {
+                    continue;
+                }
+                if !name.starts_with(&prefix) {
+                    continue;
+                }
+                let fq = format!("refs/heads/{name}");
+                if let Some(snap) = snapshot_one(repo, &fq)? {
+                    snapshots.push(snap);
+                }
+            }
+        }
+        (SnapshotScope::AllUserBranches, None) => {
+            // Without a username we cannot tell which branches are gg-owned.
+            // Record HEAD only; caller still gets a valid snapshot.
+        }
+    }
+
+    snapshots.push(capture_head(repo)?);
+    Ok(snapshots)
+}
+
+fn snapshot_one(repo: &Repository, fq_name: &str) -> Result<Option<RefSnapshot>> {
+    match repo.find_reference(fq_name) {
+        Ok(r) => {
+            let target = r.target().map(|o| o.to_string());
+            Ok(Some(RefSnapshot {
+                name: fq_name.to_string(),
+                target,
+                is_head: false,
+                head_symbolic: None,
+            }))
+        }
+        Err(e) if e.code() == git2::ErrorCode::NotFound => Ok(None),
+        Err(e) => Err(GgError::Git(e)),
+    }
+}
+
+fn capture_head(repo: &Repository) -> Result<RefSnapshot> {
+    match repo.head() {
+        Ok(head) => {
+            let symbolic = if head.is_branch() {
+                Some(head.name().unwrap_or("").to_string())
+            } else {
+                None
+            };
+            let target = head.target().map(|o| o.to_string());
+            Ok(RefSnapshot {
+                name: "HEAD".into(),
+                target,
+                is_head: true,
+                head_symbolic: symbolic,
+            })
+        }
+        // Unborn HEAD / empty repo: record HEAD with no target.
+        Err(e)
+            if e.code() == git2::ErrorCode::UnbornBranch
+                || e.code() == git2::ErrorCode::NotFound =>
+        {
+            Ok(RefSnapshot {
+                name: "HEAD".into(),
+                target: None,
+                is_head: true,
+                head_symbolic: None,
+            })
+        }
+        Err(e) => Err(GgError::Git(e)),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// OperationGuard
+// ---------------------------------------------------------------------------
+
+/// RAII-ish guard returned alongside the operation lock. On success paths
+/// callers MUST invoke `finalize(...)`. Dropping without finalize is a
+/// deliberate no-op — the record stays `Pending` on disk and the sweep
+/// promotes it to `Interrupted` on the next lock acquisition. See design
+/// §2.2 for the rationale (we cannot know mid-error if the mutation
+/// partially succeeded).
+#[derive(Debug)]
+pub struct OperationGuard {
+    pub(crate) record: OperationRecord,
+    pub(crate) store: OperationStore,
+    pub(crate) finalized: bool,
+}
+
+impl OperationGuard {
+    pub fn id(&self) -> &str {
+        &self.record.id
+    }
+
+    /// Mark the operation as Committed with the given post-mutation ref
+    /// snapshot and remote effects. Consumes the guard.
+    pub fn finalize(
+        mut self,
+        refs_after: Vec<RefSnapshot>,
+        remote_effects: Vec<RemoteEffect>,
+        touched_remote: bool,
+    ) -> Result<()> {
+        self.record.status = OperationStatus::Committed;
+        self.record.refs_after = refs_after;
+        self.record.remote_effects = remote_effects;
+        self.record.touched_remote = touched_remote;
+        self.store.save(&self.record)?;
+        self.finalized = true;
+        Ok(())
+    }
+
+    /// Variant for the undo handler, which also needs to populate `undoes`.
+    /// Separate method to avoid bloating the common signature.
+    pub fn finalize_as_undo(
+        mut self,
+        refs_after: Vec<RefSnapshot>,
+        target_id: String,
+    ) -> Result<()> {
+        self.record.status = OperationStatus::Committed;
+        self.record.refs_after = refs_after;
+        self.record.undoes = Some(target_id);
+        self.store.save(&self.record)?;
+        self.finalized = true;
+        Ok(())
+    }
+}
+
+impl Drop for OperationGuard {
+    fn drop(&mut self) {
+        // Intentional: do nothing. See doc comment above and design §2.2.
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Undo semantics
+// ---------------------------------------------------------------------------
+
+/// Options passed to [`run_undo`]. The CLI handler owns the surrounding
+/// lock/record scaffolding.
+#[derive(Debug, Clone, Default)]
+pub struct UndoOptions {
+    /// Specific record id to target. `None` → most-recent-undoable.
+    pub operation_id: Option<String>,
+    /// Reserved: machine-readable output is selected by the caller.
+    pub json: bool,
+}
+
+/// Outcome of [`run_undo`]. The caller decides exit codes and rendering.
+#[derive(Debug)]
+pub enum UndoOutcome {
+    Succeeded(OperationRecord),
+    RefusedRemote {
+        target: OperationRecord,
+        hints: Vec<String>,
+    },
+    RefusedInterrupted(OperationRecord),
+    RefusedStale {
+        target: OperationRecord,
+        ref_name: String,
+        expected: String,
+        actual: String,
+    },
+    RefusedUnsupportedSchema(OperationRecord),
+}
+
+/// List recent operations, newest first.
+pub fn list(repo: &Repository, limit: usize) -> Result<Vec<OperationRecord>> {
+    let gg_dir = crate::git::gg_dir(repo);
+    OperationStore::new(&gg_dir).list(limit)
+}
+
+/// Replay an operation's `refs_before` atop the repo. Consumes nothing from
+/// the log itself; the caller wraps this in a fresh `Undo` record.
+pub fn run_undo(
+    repo: &Repository,
+    _config: &Config,
+    opts: UndoOptions,
+) -> Result<UndoOutcome> {
+    let gg_dir = crate::git::gg_dir(repo);
+    let store = OperationStore::new(&gg_dir);
+
+    // 1. Resolve target.
+    let target = match opts.operation_id.clone() {
+        Some(id) => store.load(&id)?,
+        None => store
+            .list(usize::MAX)?
+            .into_iter()
+            // Skip undo records themselves when picking "most recent" — a
+            // second `gg undo` should target the newest *non-undo* op (D5
+            // says the undo-of-undo is recorded, but users expect
+            // `gg undo; gg undo` to undo the undo).
+            .find(|r| {
+                r.is_undoable_locally() && !matches!(r.kind, OperationKind::Undo) || {
+                    // Actually D5: undo-of-undo is fine; we just need the
+                    // newest undoable record.
+                    false
+                }
+            })
+            .or_else(|| {
+                store
+                    .list(usize::MAX)
+                    .ok()
+                    .and_then(|v| v.into_iter().find(|r| r.is_undoable_locally()))
+            })
+            .ok_or_else(|| GgError::OperationNotUndoable {
+                id: "<none>".into(),
+                reason: "no undoable operation in the log".into(),
+            })?,
+    };
+
+    // 2. Gate checks in order.
+    if target.schema_version > SCHEMA_VERSION {
+        return Ok(UndoOutcome::RefusedUnsupportedSchema(target));
+    }
+    if target.status == OperationStatus::Interrupted {
+        return Ok(UndoOutcome::RefusedInterrupted(target));
+    }
+    if target.touched_remote {
+        let hints = build_remote_hints(&target);
+        return Ok(UndoOutcome::RefusedRemote { target, hints });
+    }
+    // 2d. Staleness: every non-HEAD ref in refs_after must still match
+    // current state. HEAD movement is allowed (user may have checked out
+    // something else since).
+    for snap in &target.refs_after {
+        if snap.name == "HEAD" {
+            continue;
+        }
+        let current = match repo.find_reference(&snap.name) {
+            Ok(r) => r.target().map(|o| o.to_string()),
+            Err(e) if e.code() == git2::ErrorCode::NotFound => None,
+            Err(e) => return Err(GgError::Git(e)),
+        };
+        if current != snap.target {
+            return Ok(UndoOutcome::RefusedStale {
+                ref_name: snap.name.clone(),
+                expected: snap.target.clone().unwrap_or_else(|| "<absent>".into()),
+                actual: current.unwrap_or_else(|| "<absent>".into()),
+                target,
+            });
+        }
+    }
+
+    // 3. Apply refs_before.
+    for snap in &target.refs_before {
+        if snap.name == "HEAD" {
+            apply_head_snapshot(repo, snap)?;
+            continue;
+        }
+        match &snap.target {
+            Some(oid_str) => {
+                let oid = git2::Oid::from_str(oid_str)?;
+                repo.reference(&snap.name, oid, true, "gg undo")?;
+            }
+            None => {
+                if let Ok(mut r) = repo.find_reference(&snap.name) {
+                    r.delete()?;
+                }
+            }
+        }
+    }
+
+    Ok(UndoOutcome::Succeeded(target))
+}
+
+fn apply_head_snapshot(repo: &Repository, snap: &RefSnapshot) -> Result<()> {
+    if let Some(sym) = &snap.head_symbolic {
+        repo.set_head(sym)?;
+    } else if let Some(oid_str) = &snap.target {
+        let oid = git2::Oid::from_str(oid_str)?;
+        repo.set_head_detached(oid)?;
+    }
+    Ok(())
+}
+
+fn build_remote_hints(record: &OperationRecord) -> Vec<String> {
+    record
+        .remote_effects
+        .iter()
+        .map(|eff| match eff {
+            RemoteEffect::Pushed { remote, branch, .. } => format!(
+                "This operation pushed `{branch}` to `{remote}`. To revert a pushed \
+                 branch manually, run: `git push --force-with-lease {remote} <prior_sha>:refs/heads/{branch}` \
+                 where <prior_sha> is the pre-op SHA (see refs_before via `gg undo --json {id}`).",
+                id = record.id
+            ),
+            RemoteEffect::PrCreated { number, url } => format!(
+                "This operation opened {url}. Close it manually: `gh pr close {number}` / `glab mr close {number}`."
+            ),
+            RemoteEffect::PrMerged { number, url } => format!(
+                "This operation merged {url}. Reversing a merged PR requires a manual revert on the base branch and optional reopen: `gh pr reopen {number}` / `glab mr reopen {number}`."
+            ),
+            RemoteEffect::PrClosed { number, url } => format!(
+                "Reopen {url} with `gh pr reopen {number}` / `glab mr reopen {number}`."
+            ),
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+
+    // -- small fixtures ------------------------------------------------------
+
+    pub(crate) fn make_record(kind: OperationKind, ts: u64) -> OperationRecord {
+        OperationRecord {
+            id: format!("op_{ts:013}_fixture00000000000000000000000000"),
+            schema_version: SCHEMA_VERSION,
+            kind,
+            status: OperationStatus::Committed,
+            created_at_ms: ts,
+            args: vec!["fixture".into()],
+            stack_name: None,
+            refs_before: vec![],
+            refs_after: vec![],
+            remote_effects: vec![],
+            touched_remote: false,
+            undoes: None,
+            pending_plan: None,
+        }
+    }
+
+    pub(crate) fn tmp_gg_dir() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let gg_dir = dir.path().join("gg");
+        (dir, gg_dir)
+    }
+
+    // -- schema --------------------------------------------------------------
+
+    #[test]
+    fn operation_record_serde_round_trip_v1() {
+        let record = OperationRecord {
+            id: "op_0000000001700_abcd".into(),
+            schema_version: SCHEMA_VERSION,
+            kind: OperationKind::Drop,
+            status: OperationStatus::Committed,
+            created_at_ms: 1_700_000_000_000,
+            args: vec!["drop".into(), "3".into()],
+            stack_name: Some("feat/login".into()),
+            refs_before: vec![RefSnapshot {
+                name: "refs/heads/nacho/login/1".into(),
+                target: Some("a".repeat(40)),
+                is_head: true,
+                head_symbolic: Some("refs/heads/nacho/login/1".into()),
+            }],
+            refs_after: vec![],
+            remote_effects: vec![],
+            touched_remote: false,
+            undoes: None,
+            pending_plan: None,
+        };
+        let json = serde_json::to_string(&record).unwrap();
+        let back: OperationRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(record.id, back.id);
+        assert_eq!(record.kind, OperationKind::Drop);
+    }
+
+    #[test]
+    fn operation_record_tolerates_unknown_fields_forward_compat() {
+        let v2_json = r#"{
+            "id": "op_0000000001700_efgh",
+            "schema_version": 1,
+            "kind": "squash",
+            "status": "committed",
+            "created_at_ms": 1700000000000,
+            "args": ["squash"],
+            "refs_before": [],
+            "refs_after": [],
+            "remote_effects": [],
+            "touched_remote": false,
+            "some_future_field": {"policy": "retain"}
+        }"#;
+        let parsed: OperationRecord = serde_json::from_str(v2_json).unwrap();
+        assert_eq!(parsed.kind, OperationKind::Squash);
+    }
+
+    #[test]
+    fn remote_effect_serializes_with_kind_tag() {
+        let effect = RemoteEffect::Pushed {
+            remote: "origin".into(),
+            branch: "nacho/feat/1".into(),
+            force: true,
+        };
+        let json = serde_json::to_value(&effect).unwrap();
+        assert_eq!(json["kind"], "pushed");
+        assert_eq!(json["remote"], "origin");
+        assert_eq!(json["force"], true);
+    }
+
+    // -- id + timestamp ------------------------------------------------------
+
+    #[test]
+    fn new_id_is_sortable_by_time() {
+        let a = new_id();
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        let b = new_id();
+        assert!(a < b, "ids must sort chronologically: {a} !< {b}");
+        assert!(a.starts_with("op_"));
+        assert_eq!(a.len(), 3 + 13 + 1 + 32); // "op_" + 13-digit ms + "_" + uuid no-hyphens
+    }
+
+    #[test]
+    fn now_ms_increases() {
+        let a = now_ms();
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        let b = now_ms();
+        assert!(b >= a + 2);
+    }
+
+    // -- store ---------------------------------------------------------------
+
+    #[test]
+    fn store_save_and_load_round_trip() {
+        let (_guard, gg_dir) = tmp_gg_dir();
+        let store = OperationStore::new(&gg_dir);
+        let rec = make_record(OperationKind::Drop, 1_700_000_000_000);
+        store.save(&rec).unwrap();
+        let loaded = store.load(&rec.id).unwrap();
+        assert_eq!(loaded.id, rec.id);
+        assert_eq!(loaded.kind, OperationKind::Drop);
+    }
+
+    #[test]
+    fn store_list_returns_newest_first() {
+        let (_guard, gg_dir) = tmp_gg_dir();
+        let store = OperationStore::new(&gg_dir);
+        for ts in [1_000u64, 3_000, 2_000] {
+            store.save(&make_record(OperationKind::Nav, ts)).unwrap();
+        }
+        let list = store.list(10).unwrap();
+        let ts: Vec<u64> = list.iter().map(|r| r.created_at_ms).collect();
+        assert_eq!(ts, vec![3_000, 2_000, 1_000]);
+    }
+
+    #[test]
+    fn store_prunes_to_cap_skipping_pending() {
+        let (_guard, gg_dir) = tmp_gg_dir();
+        let store = OperationStore::new(&gg_dir);
+        // 1 Pending at the oldest slot + (OPERATION_LOG_CAP + 5) Committed.
+        let mut rec = make_record(OperationKind::Drop, 0);
+        rec.status = OperationStatus::Pending;
+        rec.id = format!("op_{:013}_pendingpendingpendingpendingpending", 0u64);
+        store.save(&rec).unwrap();
+        for i in 1..=(OPERATION_LOG_CAP as u64 + 5) {
+            store.save(&make_record(OperationKind::Drop, i)).unwrap();
+        }
+        let all = store.list(usize::MAX).unwrap();
+        assert!(all.iter().any(|r| r.status == OperationStatus::Pending));
+        assert!(all.len() <= OPERATION_LOG_CAP + 1);
+    }
+
+    #[test]
+    fn store_load_returns_err_for_unknown_id() {
+        let (_guard, gg_dir) = tmp_gg_dir();
+        let store = OperationStore::new(&gg_dir);
+        assert!(store.load("op_does_not_exist").is_err());
+    }
+
+    // -- guard ---------------------------------------------------------------
+
+    #[test]
+    fn guard_finalize_flips_status_to_committed() {
+        let (_g, gg_dir) = tmp_gg_dir();
+        let store = OperationStore::new(&gg_dir);
+        let rec = OperationRecord {
+            id: new_id(),
+            schema_version: SCHEMA_VERSION,
+            kind: OperationKind::Drop,
+            status: OperationStatus::Pending,
+            created_at_ms: now_ms(),
+            args: vec![],
+            stack_name: None,
+            refs_before: vec![],
+            refs_after: vec![],
+            remote_effects: vec![],
+            touched_remote: false,
+            undoes: None,
+            pending_plan: None,
+        };
+        store.save(&rec).unwrap();
+        let guard = OperationGuard {
+            record: rec.clone(),
+            store: store.clone(),
+            finalized: false,
+        };
+        guard.finalize(vec![], vec![], false).unwrap();
+        let loaded = store.load(&rec.id).unwrap();
+        assert_eq!(loaded.status, OperationStatus::Committed);
+    }
+
+    #[test]
+    fn guard_drop_without_finalize_leaves_record_pending() {
+        let (_g, gg_dir) = tmp_gg_dir();
+        let store = OperationStore::new(&gg_dir);
+        let id = new_id();
+        {
+            let rec = OperationRecord {
+                id: id.clone(),
+                schema_version: SCHEMA_VERSION,
+                kind: OperationKind::Nav,
+                status: OperationStatus::Pending,
+                created_at_ms: now_ms(),
+                args: vec![],
+                stack_name: None,
+                refs_before: vec![],
+                refs_after: vec![],
+                remote_effects: vec![],
+                touched_remote: false,
+                undoes: None,
+                pending_plan: None,
+            };
+            store.save(&rec).unwrap();
+            let _guard = OperationGuard {
+                record: rec,
+                store: store.clone(),
+                finalized: false,
+            };
+            // guard dropped without finalize
+        }
+        let loaded = store.load(&id).unwrap();
+        assert_eq!(loaded.status, OperationStatus::Pending);
+    }
+
+    // -- sweep ---------------------------------------------------------------
+
+    #[test]
+    fn sweep_promotes_stale_pending_to_interrupted() {
+        let (_g, gg_dir) = tmp_gg_dir();
+        let store = OperationStore::new(&gg_dir);
+        let mut stale = make_record(OperationKind::Nav, 1_000);
+        stale.status = OperationStatus::Pending;
+        stale.id = format!("op_{:013}_stalestalestalestalestalestalex", 1_000u64);
+        let mut fresh = make_record(OperationKind::Nav, 100_000_000);
+        fresh.status = OperationStatus::Pending;
+        fresh.id = format!("op_{:013}_freshfreshfreshfreshfreshfreshff", 100_000_000u64);
+        store.save(&stale).unwrap();
+        store.save(&fresh).unwrap();
+
+        store.sweep_pending(100_000_000 + 5_000);
+
+        let stale_loaded = store.load(&stale.id).unwrap();
+        let fresh_loaded = store.load(&fresh.id).unwrap();
+        assert_eq!(stale_loaded.status, OperationStatus::Interrupted);
+        assert_eq!(fresh_loaded.status, OperationStatus::Pending);
+    }
+
+    #[test]
+    fn sweep_never_errors_when_dir_missing() {
+        let (_g, gg_dir) = tmp_gg_dir();
+        let store = OperationStore::new(&gg_dir);
+        store.sweep_pending(now_ms()); // must not panic
+    }
+}
+
+#[cfg(test)]
+mod snapshot_tests {
+    use super::*;
+    use crate::config::Config;
+    use git2::Repository;
+
+    fn init_repo_with_branches(prefix: &str, branches: &[&str]) -> (tempfile::TempDir, Repository) {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = Repository::init(dir.path()).unwrap();
+        {
+            let sig = git2::Signature::now("gg-test", "gg@test").unwrap();
+            let tree_oid = {
+                let mut idx = repo.index().unwrap();
+                idx.write_tree().unwrap()
+            };
+            let tree = repo.find_tree(tree_oid).unwrap();
+            let commit_oid = repo
+                .commit(Some("HEAD"), &sig, &sig, "init", &tree, &[])
+                .unwrap();
+            let commit = repo.find_commit(commit_oid).unwrap();
+            for name in branches {
+                let fq: String = if name.contains('/') {
+                    format!("{prefix}/{name}")
+                } else {
+                    (*name).to_string()
+                };
+                repo.branch(&fq, &commit, true).unwrap();
+            }
+        }
+        (dir, repo)
+    }
+
+    fn config_with_username(username: &str) -> Config {
+        let mut c = Config::default();
+        c.defaults.branch_username = Some(username.to_string());
+        c
+    }
+
+    #[test]
+    fn all_user_branches_filters_by_username_prefix() {
+        let (_g, repo) =
+            init_repo_with_branches("nacho", &["main", "x/1", "x/2", "other/mine"]);
+        let cfg = config_with_username("nacho");
+        let snaps = snapshot_refs(&repo, &cfg, SnapshotScope::AllUserBranches).unwrap();
+        let names: Vec<&str> = snaps.iter().map(|s| s.name.as_str()).collect();
+        assert!(names.iter().any(|n| *n == "refs/heads/nacho/x/1"));
+        assert!(names.iter().any(|n| *n == "refs/heads/nacho/x/2"));
+        assert!(!names.iter().any(|n| *n == "refs/heads/main"));
+        assert!(!names.iter().any(|n| *n == "refs/heads/other/mine"));
+    }
+
+    #[test]
+    fn all_user_branches_excludes_main_master_trunk() {
+        // `init_repo_with_branches` creates trunk/main alongside whatever
+        // the default branch is. We only verify the filter: no trunk name
+        // should ever land in the snapshot.
+        let (_g, repo) = init_repo_with_branches("nacho", &["trunk", "main"]);
+        let cfg = config_with_username("nacho");
+        let snaps = snapshot_refs(&repo, &cfg, SnapshotScope::AllUserBranches).unwrap();
+        assert!(!snaps.iter().any(|s| s.name == "refs/heads/main"));
+        assert!(!snaps.iter().any(|s| s.name == "refs/heads/master"));
+        assert!(!snaps.iter().any(|s| s.name == "refs/heads/trunk"));
+    }
+
+    #[test]
+    fn snapshot_captures_head_symbolic_ref() {
+        let (_g, repo) = init_repo_with_branches("nacho", &["x/1"]);
+        let cfg = config_with_username("nacho");
+        let snaps = snapshot_refs(&repo, &cfg, SnapshotScope::AllUserBranches).unwrap();
+        let head = snaps
+            .iter()
+            .find(|s| s.is_head)
+            .expect("HEAD should be captured");
+        assert!(head.head_symbolic.is_some(), "expected symbolic HEAD");
+    }
+}
+
+#[cfg(test)]
+mod undo_tests {
+    use super::*;
+    use crate::config::Config;
+    use git2::Repository;
+
+    fn setup_repo_with_two_commits() -> (tempfile::TempDir, Repository, git2::Oid, git2::Oid) {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = Repository::init(dir.path()).unwrap();
+        let sig = git2::Signature::now("t", "t@t").unwrap();
+        let (c1, c2) = {
+            let tree_oid = repo.index().unwrap().write_tree().unwrap();
+            let tree = repo.find_tree(tree_oid).unwrap();
+            let c1 = repo
+                .commit(Some("HEAD"), &sig, &sig, "c1", &tree, &[])
+                .unwrap();
+            let c1_commit = repo.find_commit(c1).unwrap();
+            let c2 = repo
+                .commit(Some("HEAD"), &sig, &sig, "c2", &tree, &[&c1_commit])
+                .unwrap();
+            (c1, c2)
+        };
+        (dir, repo, c1, c2)
+    }
+
+    fn cfg_user(u: &str) -> Config {
+        let mut c = Config::default();
+        c.defaults.branch_username = Some(u.into());
+        c
+    }
+
+    #[test]
+    fn run_undo_restores_branch_to_prior_oid() {
+        let (_dir, repo, c1, c2) = setup_repo_with_two_commits();
+        let c1_commit = repo.find_commit(c1).unwrap();
+        repo.branch("nacho/feat/1", &c1_commit, true).unwrap();
+
+        let gg_dir = crate::git::gg_dir(&repo);
+        let store = OperationStore::new(&gg_dir);
+
+        let rec = OperationRecord {
+            id: new_id(),
+            schema_version: SCHEMA_VERSION,
+            kind: OperationKind::Squash,
+            status: OperationStatus::Committed,
+            created_at_ms: now_ms(),
+            args: vec![],
+            stack_name: None,
+            refs_before: vec![RefSnapshot {
+                name: "refs/heads/nacho/feat/1".into(),
+                target: Some(c1.to_string()),
+                is_head: false,
+                head_symbolic: None,
+            }],
+            refs_after: vec![RefSnapshot {
+                name: "refs/heads/nacho/feat/1".into(),
+                target: Some(c2.to_string()),
+                is_head: false,
+                head_symbolic: None,
+            }],
+            remote_effects: vec![],
+            touched_remote: false,
+            undoes: None,
+            pending_plan: None,
+        };
+        store.save(&rec).unwrap();
+
+        repo.reference("refs/heads/nacho/feat/1", c2, true, "test setup")
+            .unwrap();
+
+        let outcome = run_undo(
+            &repo,
+            &cfg_user("nacho"),
+            UndoOptions {
+                operation_id: Some(rec.id.clone()),
+                json: false,
+            },
+        )
+        .unwrap();
+
+        assert!(matches!(outcome, UndoOutcome::Succeeded(_)));
+        let restored = repo.find_reference("refs/heads/nacho/feat/1").unwrap();
+        assert_eq!(restored.target().unwrap(), c1);
+    }
+
+    #[test]
+    fn run_undo_refuses_when_ref_moved_since_operation() {
+        let (_dir, repo, c1, c2) = setup_repo_with_two_commits();
+        let c1_commit = repo.find_commit(c1).unwrap();
+        repo.branch("nacho/feat/2", &c1_commit, true).unwrap();
+
+        let gg_dir = crate::git::gg_dir(&repo);
+        let store = OperationStore::new(&gg_dir);
+        let rec = OperationRecord {
+            id: new_id(),
+            schema_version: SCHEMA_VERSION,
+            kind: OperationKind::Squash,
+            status: OperationStatus::Committed,
+            created_at_ms: now_ms(),
+            args: vec![],
+            stack_name: None,
+            refs_before: vec![RefSnapshot {
+                name: "refs/heads/nacho/feat/2".into(),
+                target: Some(c1.to_string()),
+                is_head: false,
+                head_symbolic: None,
+            }],
+            refs_after: vec![RefSnapshot {
+                name: "refs/heads/nacho/feat/2".into(),
+                target: Some(c2.to_string()),
+                is_head: false,
+                head_symbolic: None,
+            }],
+            remote_effects: vec![],
+            touched_remote: false,
+            undoes: None,
+            pending_plan: None,
+        };
+        store.save(&rec).unwrap();
+
+        // Branch is still at c1 (different from refs_after c2).
+        let outcome = run_undo(
+            &repo,
+            &cfg_user("nacho"),
+            UndoOptions {
+                operation_id: Some(rec.id.clone()),
+                json: false,
+            },
+        )
+        .unwrap();
+        assert!(matches!(outcome, UndoOutcome::RefusedStale { .. }));
+    }
+
+    #[test]
+    fn run_undo_refuses_remote_touched_op() {
+        let (_dir, repo, _c1, _c2) = setup_repo_with_two_commits();
+        let gg_dir = crate::git::gg_dir(&repo);
+        let store = OperationStore::new(&gg_dir);
+        let rec = OperationRecord {
+            id: new_id(),
+            schema_version: SCHEMA_VERSION,
+            kind: OperationKind::Sync,
+            status: OperationStatus::Committed,
+            created_at_ms: now_ms(),
+            args: vec!["sync".into()],
+            stack_name: None,
+            refs_before: vec![],
+            refs_after: vec![],
+            remote_effects: vec![RemoteEffect::Pushed {
+                remote: "origin".into(),
+                branch: "nacho/x/1".into(),
+                force: false,
+            }],
+            touched_remote: true,
+            undoes: None,
+            pending_plan: None,
+        };
+        store.save(&rec).unwrap();
+        let out = run_undo(
+            &repo,
+            &cfg_user("nacho"),
+            UndoOptions {
+                operation_id: Some(rec.id.clone()),
+                json: false,
+            },
+        )
+        .unwrap();
+        assert!(matches!(out, UndoOutcome::RefusedRemote { .. }));
+    }
+
+    #[test]
+    fn run_undo_refuses_interrupted_op() {
+        let (_dir, repo, _c1, _c2) = setup_repo_with_two_commits();
+        let gg_dir = crate::git::gg_dir(&repo);
+        let store = OperationStore::new(&gg_dir);
+        let mut rec = crate::operations::tests::make_record(OperationKind::Drop, now_ms());
+        rec.status = OperationStatus::Interrupted;
+        store.save(&rec).unwrap();
+        let out = run_undo(
+            &repo,
+            &cfg_user("nacho"),
+            UndoOptions {
+                operation_id: Some(rec.id.clone()),
+                json: false,
+            },
+        )
+        .unwrap();
+        assert!(matches!(out, UndoOutcome::RefusedInterrupted(_)));
+    }
+}

--- a/crates/gg-core/src/operations.rs
+++ b/crates/gg-core/src/operations.rs
@@ -185,6 +185,28 @@ pub fn new_id() -> String {
     format!("op_{ms:013}_{uuid}")
 }
 
+/// True iff `id` matches the `op_<digits>_<alphanumeric>` format produced
+/// by [`new_id`]. Used by [`OperationStore::path_for`] to reject ids that
+/// could traverse out of the operations directory (`../`, absolute paths,
+/// `\0`, path separators, etc.). Intentionally permissive on length so
+/// ids from older schema versions still parse — the structure check is
+/// what matters.
+pub fn is_valid_operation_id(id: &str) -> bool {
+    // Expected shape: "op_" + >=1 ASCII digits + "_" + >=1 ASCII alphanumerics.
+    let Some(rest) = id.strip_prefix("op_") else {
+        return false;
+    };
+    let Some(underscore) = rest.find('_') else {
+        return false;
+    };
+    let (ts, rand) = rest.split_at(underscore);
+    let rand = &rand[1..]; // drop the separator
+    if ts.is_empty() || rand.is_empty() {
+        return false;
+    }
+    ts.bytes().all(|b| b.is_ascii_digit()) && rand.bytes().all(|b| b.is_ascii_alphanumeric())
+}
+
 // ---------------------------------------------------------------------------
 // OperationStore (atomic save/load/list/prune)
 // ---------------------------------------------------------------------------
@@ -206,15 +228,23 @@ impl OperationStore {
         }
     }
 
-    fn path_for(&self, id: &str) -> PathBuf {
-        self.operations_dir.join(format!("{id}.json"))
+    /// Resolve the on-disk path for a record id. Rejects ids that do not
+    /// match the `op_<13-digit-ms>_<hex-or-alphanumeric>` format generated
+    /// by [`new_id`], which defends against a confused-deputy path-traversal
+    /// gadget via `gg undo <id>` / MCP `stack_undo` (a caller passing e.g.
+    /// `../../etc/passwd` would otherwise escape the operations dir).
+    fn path_for(&self, id: &str) -> Result<PathBuf> {
+        if !is_valid_operation_id(id) {
+            return Err(GgError::OperationRecordNotFound(id.to_string()));
+        }
+        Ok(self.operations_dir.join(format!("{id}.json")))
     }
 
     /// Persist a record atomically. Prunes Committed/Interrupted records
     /// beyond `OPERATION_LOG_CAP` afterwards, oldest-first.
     pub fn save(&self, record: &OperationRecord) -> Result<()> {
         fs::create_dir_all(&self.operations_dir)?;
-        let path = self.path_for(&record.id);
+        let path = self.path_for(&record.id)?;
         let tmp = path.with_extension("json.tmp");
         let json = serde_json::to_vec_pretty(record)?;
         {
@@ -227,9 +257,10 @@ impl OperationStore {
         Ok(())
     }
 
-    /// Load a record by id. Returns `OperationRecordNotFound` if absent.
+    /// Load a record by id. Returns `OperationRecordNotFound` if absent or
+    /// if the id fails [`is_valid_operation_id`].
     pub fn load(&self, id: &str) -> Result<OperationRecord> {
-        let path = self.path_for(id);
+        let path = self.path_for(id)?;
         let bytes = fs::read(&path).map_err(|e| match e.kind() {
             std::io::ErrorKind::NotFound => GgError::OperationRecordNotFound(id.to_string()),
             _ => GgError::Io(e),
@@ -240,6 +271,9 @@ impl OperationStore {
 
     /// Newest-first ids (lexical sort == chronological because of the
     /// zero-padded timestamp prefix). Cheap: no JSON parse.
+    ///
+    /// Filenames that don't parse as a valid operation id are skipped so
+    /// stray files in the operations directory can't leak into `--list`.
     pub fn list_ids(&self, limit: usize) -> Result<Vec<String>> {
         if !self.operations_dir.exists() {
             return Ok(vec![]);
@@ -249,6 +283,7 @@ impl OperationStore {
             .filter_map(|e| e.file_name().into_string().ok())
             .filter(|name| name.ends_with(".json") && !name.ends_with(".json.tmp"))
             .map(|name| name.trim_end_matches(".json").to_string())
+            .filter(|id| is_valid_operation_id(id))
             .collect();
         ids.sort_by(|a, b| b.cmp(a));
         ids.truncate(limit);
@@ -289,7 +324,9 @@ impl OperationStore {
             if rec.status == OperationStatus::Pending {
                 continue;
             }
-            let _ = fs::remove_file(self.path_for(&rec.id));
+            if let Ok(path) = self.path_for(&rec.id) {
+                let _ = fs::remove_file(path);
+            }
             pruned += 1;
         }
     }
@@ -460,6 +497,40 @@ pub struct OperationGuard {
 impl OperationGuard {
     pub fn id(&self) -> &str {
         &self.record.id
+    }
+
+    /// Persist a remote side effect to the Pending record immediately.
+    ///
+    /// Use this between successive remote mutations (push, PR create, PR
+    /// update) inside a long-running operation so a mid-sequence failure
+    /// leaves the record with an accurate trail. The guard still needs
+    /// `finalize` on success; if the caller drops instead, the sweep will
+    /// promote the record to `Interrupted` — with `touched_remote=true`
+    /// and `remote_effects` already populated, so `gg undo` correctly
+    /// refuses instead of silently rewinding local refs (see design §4.4).
+    ///
+    /// Errors from the save are swallowed: losing a `remote_effect` update
+    /// must not take down the mutating command that just succeeded.
+    pub fn record_remote_effect(&mut self, effect: RemoteEffect) {
+        self.record.remote_effects.push(effect);
+        self.record.touched_remote = true;
+        let _ = self.store.save(&self.record);
+    }
+
+    /// Flip `touched_remote` on the Pending record without appending a
+    /// specific `RemoteEffect` variant. Use for remote mutations we don't
+    /// yet model (e.g. PR base updates, merge-train scheduling): the
+    /// "touched remote" bit alone is enough to make `gg undo` refuse, which
+    /// is the only property we rely on for correctness.
+    ///
+    /// Errors from the save are swallowed: a failed persistence step must
+    /// not take down the mutating command that just succeeded.
+    pub fn mark_touched_remote(&mut self) {
+        if self.record.touched_remote {
+            return;
+        }
+        self.record.touched_remote = true;
+        let _ = self.store.save(&self.record);
     }
 
     /// Mark the operation as Committed with the given post-mutation ref
@@ -827,6 +898,47 @@ pub(crate) mod tests {
         let (_guard, gg_dir) = tmp_gg_dir();
         let store = OperationStore::new(&gg_dir);
         assert!(store.load("op_does_not_exist").is_err());
+    }
+
+    #[test]
+    fn store_load_rejects_path_traversal() {
+        let (_guard, gg_dir) = tmp_gg_dir();
+        let store = OperationStore::new(&gg_dir);
+        // Classic confused-deputy gadgets the old unvalidated `path_for`
+        // would happily resolve. Each must surface as OperationRecordNotFound
+        // rather than reading outside the operations directory.
+        for bad in [
+            "../../etc/passwd",
+            "../../../../../../etc/shadow",
+            "/etc/passwd",
+            "op_123_abc/../../../etc/passwd",
+            "op_123\x00_abc",
+            "op__",
+            "op_abc_def", // non-digit timestamp
+            "",
+        ] {
+            let err = store.load(bad).unwrap_err();
+            assert!(
+                matches!(err, GgError::OperationRecordNotFound(_)),
+                "id {bad:?} should be rejected as not-found, got: {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn list_ids_skips_invalid_filenames() {
+        // A stray file with a name that doesn't match the operation-id shape
+        // must not appear in `list_ids`. This keeps `gg undo --list` from
+        // surfacing arbitrary junk dropped into the operations directory.
+        let (_guard, gg_dir) = tmp_gg_dir();
+        let store = OperationStore::new(&gg_dir);
+        let rec = make_record(OperationKind::Drop, 1_700_000_000_000);
+        store.save(&rec).unwrap();
+        // Drop a stray .json next to the real record.
+        let stray = store.operations_dir.join("totally_bogus.json");
+        fs::write(&stray, "{}").unwrap();
+        let ids = store.list_ids(usize::MAX).unwrap();
+        assert_eq!(ids, vec![rec.id.clone()]);
     }
 
     // -- guard ---------------------------------------------------------------

--- a/crates/gg-core/src/output.rs
+++ b/crates/gg-core/src/output.rs
@@ -376,3 +376,185 @@ pub struct LogJson {
     pub current_position: Option<usize>,
     pub entries: Vec<StackEntryJson>,
 }
+
+// ---------------------------------------------------------------------------
+// Undo responses (task #5)
+// ---------------------------------------------------------------------------
+
+use serde_json::Value as JsonValue;
+
+use crate::operations::{OperationKind, OperationRecord, OperationStatus, RemoteEffect};
+
+#[derive(Serialize)]
+pub struct UndoResponse {
+    pub version: u32,
+    pub status: UndoJsonStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub undone: Option<OperationSummaryJson>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refusal: Option<UndoRefusalJson>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UndoJsonStatus {
+    Succeeded,
+    Refused,
+}
+
+#[derive(Serialize)]
+pub struct UndoRefusalJson {
+    pub reason: UndoRefusalReason,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<OperationSummaryJson>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub hints: Vec<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UndoRefusalReason {
+    Remote,
+    Interrupted,
+    Stale,
+    UnsupportedSchema,
+}
+
+#[derive(Serialize)]
+pub struct UndoListResponse {
+    pub version: u32,
+    pub operations: Vec<OperationSummaryJson>,
+}
+
+#[derive(Serialize)]
+pub struct OperationSummaryJson {
+    pub id: String,
+    pub kind: String,
+    pub status: String,
+    pub created_at_ms: u64,
+    pub args: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stack_name: Option<String>,
+    pub touched_remote: bool,
+    pub is_undoable: bool,
+    #[serde(default)]
+    pub is_undo: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub undoes: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub remote_effects: Vec<RemoteEffectJson>,
+}
+
+#[derive(Serialize)]
+pub struct RemoteEffectJson {
+    pub kind: String,
+    #[serde(flatten)]
+    pub data: JsonValue,
+}
+
+impl From<&OperationRecord> for OperationSummaryJson {
+    fn from(r: &OperationRecord) -> Self {
+        Self {
+            id: r.id.clone(),
+            kind: kind_to_snake(&r.kind),
+            status: status_to_snake(&r.status),
+            created_at_ms: r.created_at_ms,
+            args: r.args.clone(),
+            stack_name: r.stack_name.clone(),
+            touched_remote: r.touched_remote,
+            is_undoable: r.is_undoable_locally(),
+            is_undo: matches!(r.kind, OperationKind::Undo),
+            undoes: r.undoes.clone(),
+            remote_effects: r.remote_effects.iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<&RemoteEffect> for RemoteEffectJson {
+    fn from(eff: &RemoteEffect) -> Self {
+        let mut v = serde_json::to_value(eff).unwrap_or(JsonValue::Null);
+        let kind = v
+            .get("kind")
+            .and_then(|k| k.as_str())
+            .unwrap_or("")
+            .to_string();
+        if let Some(obj) = v.as_object_mut() {
+            obj.remove("kind");
+        }
+        Self { kind, data: v }
+    }
+}
+
+fn kind_to_snake(k: &OperationKind) -> String {
+    serde_json::to_value(k)
+        .ok()
+        .and_then(|v| v.as_str().map(str::to_string))
+        .unwrap_or_default()
+}
+
+fn status_to_snake(s: &OperationStatus) -> String {
+    serde_json::to_value(s)
+        .ok()
+        .and_then(|v| v.as_str().map(str::to_string))
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod undo_output_tests {
+    use super::*;
+
+    #[test]
+    fn operation_summary_json_marks_undo_entry() {
+        let summary = OperationSummaryJson {
+            id: "op_1_a".into(),
+            kind: "undo".into(),
+            status: "committed".into(),
+            created_at_ms: 1,
+            args: vec!["undo".into()],
+            stack_name: None,
+            touched_remote: false,
+            is_undoable: false,
+            is_undo: true,
+            undoes: Some("op_0_b".into()),
+            remote_effects: vec![],
+        };
+        let v = serde_json::to_value(&summary).unwrap();
+        assert_eq!(v["is_undo"], true);
+        assert_eq!(v["undoes"], "op_0_b");
+    }
+
+    #[test]
+    fn undo_response_refused_includes_hints() {
+        let resp = UndoResponse {
+            version: OUTPUT_VERSION,
+            status: UndoJsonStatus::Refused,
+            undone: None,
+            refusal: Some(UndoRefusalJson {
+                reason: UndoRefusalReason::Remote,
+                message: "sync touched a remote".into(),
+                target: None,
+                hints: vec!["gh pr close 42".into()],
+            }),
+        };
+        let v = serde_json::to_value(&resp).unwrap();
+        assert_eq!(v["status"], "refused");
+        assert_eq!(v["refusal"]["reason"], "remote");
+        assert_eq!(v["refusal"]["hints"][0], "gh pr close 42");
+    }
+
+    #[test]
+    fn remote_effect_json_flattens_data_fields() {
+        let eff = RemoteEffect::Pushed {
+            remote: "origin".into(),
+            branch: "nacho/x/1".into(),
+            force: true,
+        };
+        let rej: RemoteEffectJson = (&eff).into();
+        let v = serde_json::to_value(&rej).unwrap();
+        assert_eq!(v["kind"], "pushed");
+        assert_eq!(v["remote"], "origin");
+        assert_eq!(v["branch"], "nacho/x/1");
+        assert_eq!(v["force"], true);
+    }
+}

--- a/crates/gg-mcp/src/tools.rs
+++ b/crates/gg-mcp/src/tools.rs
@@ -327,6 +327,21 @@ pub struct StackReorderParams {
     pub force: bool,
 }
 
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct StackUndoParams {
+    /// Target operation id (e.g. `op_0000001750000000_abcd…`). When
+    /// omitted, undoes the most recent locally-undoable operation.
+    #[serde(default)]
+    pub operation_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct StackUndoListParams {
+    /// Cap the number of records returned (newest-first).
+    #[serde(default)]
+    pub limit: Option<usize>,
+}
+
 // --- Helper functions ---
 
 fn pr_state_str(state: &PrState) -> &'static str {
@@ -427,6 +442,30 @@ fn run_gg_command(args: &[String]) -> Result<String, String> {
 
 fn to_json<T: Serialize>(value: &T) -> String {
     serde_json::to_string_pretty(value).unwrap_or_else(|e| format!("{{\"error\": \"{}\"}}", e))
+}
+
+/// Build the argv for `gg undo [--json] [<operation_id>]`.
+/// Extracted for unit testing — see `build_stack_undo_args_*` tests.
+fn build_stack_undo_args(operation_id: Option<String>) -> Vec<String> {
+    let mut args = vec!["undo".to_string(), "--json".to_string()];
+    if let Some(id) = operation_id {
+        args.push(id);
+    }
+    args
+}
+
+/// Build the argv for `gg undo --list --json [--limit N]`.
+fn build_stack_undo_list_args(limit: Option<usize>) -> Vec<String> {
+    let mut args = vec![
+        "undo".to_string(),
+        "--list".to_string(),
+        "--json".to_string(),
+    ];
+    if let Some(n) = limit {
+        args.push("--limit".to_string());
+        args.push(n.to_string());
+    }
+    args
 }
 
 // --- MCP Server ---
@@ -946,6 +985,29 @@ impl GgMcpServer {
         }
         run_gg_command(&args)
     }
+
+    /// Reverse the local ref/HEAD effects of the most recent mutating
+    /// `gg` command (or a specific operation by id).
+    #[tool(
+        description = "Reverse the local ref/HEAD effects of the most recent mutating gg command. Pass operation_id to target a specific record (see stack_undo_list). Refuses on remote-touching operations (sync, land) — you will get a provider-specific revert hint, not an automated revert. `gg undo` is itself recorded, so calling twice in a row redoes the original operation. Working tree changes are NOT reverted."
+    )]
+    fn stack_undo(
+        &self,
+        Parameters(params): Parameters<StackUndoParams>,
+    ) -> Result<String, String> {
+        run_gg_command(&build_stack_undo_args(params.operation_id))
+    }
+
+    /// List recent operations from the per-repo operation log.
+    #[tool(
+        description = "List recent operations from the per-repo operation log (newest-first). Each entry shows id, kind, status, timestamp, stack, args, and whether it is locally undoable. Use the id with stack_undo to target a specific record. Remote-touching operations appear with is_undoable=false and a red `remote` marker."
+    )]
+    fn stack_undo_list(
+        &self,
+        Parameters(params): Parameters<StackUndoListParams>,
+    ) -> Result<String, String> {
+        run_gg_command(&build_stack_undo_list_args(params.limit))
+    }
 }
 
 #[tool_handler(router = self.tool_router)]
@@ -978,6 +1040,30 @@ mod tests {
         assert_eq!(ci_status_str(&CiStatus::Failed), "failed");
         assert_eq!(ci_status_str(&CiStatus::Canceled), "canceled");
         assert_eq!(ci_status_str(&CiStatus::Unknown), "unknown");
+    }
+
+    #[test]
+    fn stack_undo_builds_expected_gg_args_with_id() {
+        let args = build_stack_undo_args(Some("op_123".to_string()));
+        assert_eq!(args, vec!["undo", "--json", "op_123"]);
+    }
+
+    #[test]
+    fn stack_undo_builds_expected_gg_args_without_id() {
+        let args = build_stack_undo_args(None);
+        assert_eq!(args, vec!["undo", "--json"]);
+    }
+
+    #[test]
+    fn stack_undo_list_builds_expected_gg_args_with_limit() {
+        let args = build_stack_undo_list_args(Some(10));
+        assert_eq!(args, vec!["undo", "--list", "--json", "--limit", "10"]);
+    }
+
+    #[test]
+    fn stack_undo_list_builds_expected_gg_args_without_limit() {
+        let args = build_stack_undo_list_args(None);
+        assert_eq!(args, vec!["undo", "--list", "--json"]);
     }
 
     #[test]

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -31,6 +31,7 @@
   - [setup](./commands/setup.md)
   - [continue / abort](./commands/continue-abort.md)
   - [reconcile](./commands/reconcile.md)
+  - [undo](./commands/undo.md)
 - [MCP Server](./mcp-server.md)
 - [Configuration](./configuration.md)
 - [Shell Completions](./shell-completions.md)

--- a/docs/src/commands/undo.md
+++ b/docs/src/commands/undo.md
@@ -1,0 +1,165 @@
+# `gg undo`
+
+Reverse the local ref/HEAD effects of the most recent mutating `gg`
+command, backed by a per-repo operation log.
+
+```bash
+gg undo [OPERATION_ID] [--json]
+gg undo --list [--limit N] [--json]
+```
+
+`gg undo` only moves refs and `HEAD` — it never modifies your working
+tree, working-copy files, or the index. The log lives at
+`<commondir>/gg/operations/*.json` and keeps the last **100 records**;
+`Pending` records (operations interrupted by a crash, Ctrl-C, or a
+long-running conflict) are never pruned.
+
+## Options
+
+- `OPERATION_ID`: Target a specific record (`op_…`). When omitted,
+  undoes the most recent locally-undoable operation.
+- `--list`: Show recent operations with id, kind, status, timestamp,
+  and undoability marker.
+- `--limit N`: Cap `--list` output (default: 20).
+- `--json`: Emit machine-readable JSON.
+
+## How it works
+
+Every mutating `gg` command (`sc`, `drop`, `split`, `rebase`, `reorder`,
+`absorb`, `reconcile`, `checkout`, `mv`/`first`/`last`/`prev`/`next`,
+`clean`, `sync`, `land`, and `run --amend`) now snapshots the refs it
+will touch before mutating and finalises the record on success. `gg
+undo` replays the `refs_before` snapshot of the target record, moving
+refs back to where they were.
+
+A second `gg undo` redoes the first — because `undo` is itself
+recorded as an operation, running it twice reverses the reversal.
+Entries created by `gg undo` appear in `--list` with a `↶` marker and
+an `undoes` field pointing at the original operation id.
+
+## Refusal modes
+
+`gg undo` refuses (exit 1, no refs touched) when:
+
+| Reason | Condition | What to do |
+|---|---|---|
+| `remote` | The target op pushed/merged/closed/created a PR or MR. | Use the printed provider hint (`gh pr close <n>`, `glab mr close <n>`, `git push --delete …`). Local state is unchanged. |
+| `interrupted` | The op crashed or was Ctrl-C'd mid-flight and has `status: Interrupted`. | Fix the underlying state manually; the stale Pending record is swept into Interrupted on the next lock-acquiring op. |
+| `stale` | Refs have moved since the target op finalised. | Run `gg undo --list` and target a more recent record instead. The error names the ref, the expected OID, and the actual OID. |
+| `unsupported_schema` | The record was written by a newer `gg` with a schema version this binary does not understand. | Upgrade `gg` or delete the offending record. |
+
+## Examples
+
+```bash
+# Reverse the last local operation
+gg undo
+
+# See what's on the log (newest first)
+gg undo --list
+gg undo --list --limit 5
+
+# Target a specific record from --list
+gg undo op_0000001750000000_018f…
+
+# Redo: undo twice in a row
+gg undo
+gg undo
+
+# Scripting
+gg undo --list --json | jq '.operations[] | select(.is_undoable)'
+```
+
+## JSON output
+
+Schema versioning: all `gg` JSON responses share the top-level `version`
+field (`OUTPUT_VERSION`). The undo types are additive — new optional
+fields may be added in future releases without bumping the version.
+Forward-compatible consumers should ignore unknown fields.
+
+### `gg undo --json`
+
+```json
+{
+  "version": 1,
+  "status": "succeeded",
+  "undone": {
+    "id": "op_0000001750000000_018f…",
+    "kind": "drop",
+    "status": "committed",
+    "created_at_ms": 1750000000000,
+    "args": ["drop", "3"],
+    "stack_name": "feat/login",
+    "touched_remote": false,
+    "is_undoable": true,
+    "is_undo": false,
+    "remote_effects": []
+  }
+}
+```
+
+On refusal:
+
+```json
+{
+  "version": 1,
+  "status": "refused",
+  "refusal": {
+    "reason": "remote",
+    "message": "Cannot locally undo 'sync': it touched a remote.",
+    "target": { "id": "op_…", "kind": "sync", "touched_remote": true, "…": "…" },
+    "hints": [
+      "Close PR #42: gh pr close 42",
+      "Delete remote branch: git push --delete origin nacho/feat/1"
+    ]
+  }
+}
+```
+
+`refusal.reason` is one of `remote`, `interrupted`, `stale`,
+`unsupported_schema`.
+
+### `gg undo --list --json`
+
+```json
+{
+  "version": 1,
+  "operations": [
+    {
+      "id": "op_…",
+      "kind": "undo",
+      "status": "committed",
+      "created_at_ms": 1750000100000,
+      "args": ["undo"],
+      "stack_name": "feat/login",
+      "touched_remote": false,
+      "is_undoable": true,
+      "is_undo": true,
+      "undoes": "op_previous…"
+    },
+    { "…": "…" }
+  ]
+}
+```
+
+Operations are returned newest-first. Use `is_undoable` to gate
+UI/agent actions; use `is_undo` + `undoes` to render redo markers.
+
+## What `gg undo` does NOT do
+
+- It does **not** restore working-tree files or the index. If you amended
+  a commit and want the old source back, use `git reflog` or
+  `git stash`.
+- It does **not** touch remotes. Operations that pushed, merged, closed,
+  or created PRs/MRs are recorded (so you can see them in `--list`) but
+  refused for local replay.
+- It does **not** guarantee atomicity of the replay. If the process
+  dies mid-replay, a second `gg undo` will finish the job — the
+  working tree is clean throughout, so only refs move.
+- It does **not** support an `--all` / `--range` mode. Each call
+  reverses exactly one operation.
+
+## See also
+
+- [`gg log`](./log.md) — smartlog view of the current stack
+- [MCP server](../mcp-server.md) — `stack_undo` and `stack_undo_list`
+  tools for agentic workflows

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -55,3 +55,23 @@ Increase timeout in config:
 
 - Use `gg sc` when you're on the exact commit you want to modify.
 - Use `gg absorb` when staged edits belong to multiple commits and you want git-gud to distribute them.
+
+## How do I undo a `gg` command?
+
+Run [`gg undo`](./commands/undo.md). It reverses the local ref/HEAD
+effects of the most recent mutating `gg` command (drop, squash, split,
+rebase, reorder, absorb, reconcile, checkout, nav, clean, sync, land,
+or `run --amend`). Working-tree changes are not touched.
+
+```bash
+gg undo              # reverse the last local operation
+gg undo --list       # see the recent operation log
+gg undo <op_id>      # target a specific record
+gg undo; gg undo     # undo then redo — a second undo reverses the first
+```
+
+Remote-touching operations (`sync`, `land`) are recorded but refused
+for local replay. `gg undo` prints a provider-specific revert hint
+(e.g. `gh pr close <n>`, `git push --delete …`) instead of silently
+rewriting published history. See [`gg undo`](./commands/undo.md) for
+the full refusal matrix and JSON schema.

--- a/docs/src/mcp-server.md
+++ b/docs/src/mcp-server.md
@@ -211,6 +211,38 @@ Reorder commits in the stack with an explicit order.
 
 **Notes:** No TUI via MCP. The order specifies the new bottom-to-top arrangement of commits.
 
+### `stack_undo`
+
+Reverse the local ref/HEAD effects of the most recent mutating `gg`
+command (or a specific operation by id). Shell-out wrapper around
+[`gg undo --json`](./commands/undo.md).
+
+**Parameters:**
+- `operation_id` (string, optional): Target a specific record (see
+  `stack_undo_list`). Defaults to the most-recent-undoable operation.
+
+**Notes:** Refuses on remote-touching operations (`sync`, `land`) —
+the returned payload includes a `refusal.reason` of `remote` plus a
+provider-specific revert hint (e.g. `gh pr close <n>`, `git push
+--delete …`). Agents must surface the hint to the user rather than
+attempt silent remote rollback. Also refuses on `interrupted`,
+`stale`, and `unsupported_schema` records; the working tree is never
+modified.
+
+### `stack_undo_list`
+
+List recent operations from the per-repo operation log (newest-first).
+Shell-out wrapper around [`gg undo --list --json`](./commands/undo.md).
+
+**Parameters:**
+- `limit` (integer, optional): Cap the number of records returned
+  (default: 20).
+
+**Notes:** Each entry carries `is_undoable` (gate for safe local
+replay) and, for undo records, `is_undo` + `undoes` (the operation id
+being reversed). Remote-touching ops appear with `is_undoable: false`
+and `touched_remote: true`.
+
 ## Transport
 
 The MCP server uses **stdio** transport (JSON-RPC over stdin/stdout), which is the standard for local MCP tools. No network configuration is needed.

--- a/skills/gg/SKILL.md
+++ b/skills/gg/SKILL.md
@@ -136,6 +136,43 @@ gg land -a -c --json
 - Lint stack: `gg lint --json`
 - Run a command across the stack: `gg run -- <cmd...>` (see below)
 - Clean merged stacks: `gg clean -a --json`
+- Undo last local mutation: `gg undo` (see below)
+
+## Undoing local mutations (`gg undo`)
+
+`gg undo` reverses the ref/`HEAD` effects of the most recent mutating
+`gg` command by replaying a snapshot from the per-repo operation log at
+`<commondir>/gg/operations/*.json`. It never touches the working tree,
+index, or untracked files — only refs move.
+
+```bash
+gg undo              # reverse the most recent local operation
+gg undo --list       # see recent operations (newest-first)
+gg undo <op_id>      # target a specific record from --list
+gg undo; gg undo     # redo: a second undo reverses the first
+gg undo --json       # machine-readable output
+```
+
+Every mutating command (`sc`, `drop`, `split`, `rebase`, `reorder`,
+`absorb`, `reconcile`, `checkout`, nav, `clean`, `sync`, `land`, and
+`run --amend`) snapshots the refs it will touch before mutating and
+records the operation on success. The log keeps the last 100 records;
+interrupted/pending records are never pruned.
+
+**Refusal modes** (exit 1, no refs touched, JSON includes `refusal.reason`):
+
+- `remote` — target operation pushed/merged/closed/created a PR/MR.
+  gg prints a provider-specific revert hint (`gh pr close <n>`,
+  `glab mr close <n>`, `git push --delete …`). Agents must surface the
+  hint to the user rather than attempt silent remote rollback.
+- `interrupted` — operation crashed or was Ctrl-C'd mid-flight.
+- `stale` — refs moved since the target operation finalised. The error
+  names the ref, expected OID, and actual OID.
+- `unsupported_schema` — record was written by a newer `gg` binary.
+
+`gg undo` does **not** restore working-tree content (use `git reflog` or
+`git stash`), does **not** touch remotes, and does **not** support an
+`--all` / `--range` mode.
 
 ## Running commands across the stack (`gg run`)
 
@@ -267,6 +304,7 @@ The `gg-mcp` binary exposes git-gud as an MCP server (stdio transport). Set `GG_
 - `stack_list` / `stack_log` / `stack_list_all` / `stack_status` — inspect stacks (`stack_log` gives a smartlog-style view of the current stack; `stack_list_all` is cross-stack)
 - `pr_info` — check PR state, CI, approval
 - `config_show` — read repo configuration
+- `stack_undo_list` — list recent operations from the per-repo operation log
 
 ### Write tools (mutating, use with care)
 - `stack_checkout` — create or switch stacks
@@ -279,6 +317,7 @@ The `gg-mcp` binary exposes git-gud as an MCP server (stdio transport). Set `GG_
 - `stack_drop` — remove commits from the stack (always passes `--yes`; set `force: true` only to bypass the immutability guard for merged/base commits; agent confirms with user before any drop)
 - `stack_split` — split a commit using interactive hunk selection (TUI opens by default; pass FILES... to auto-select all hunks for those files)
 - `stack_reorder` — reorder commits with explicit order string (no TUI)
+- `stack_undo` — reverse the ref/HEAD effects of the most recent mutating `gg` command (refuses on remote-touching ops, returns provider-specific revert hints; agents must surface those hints rather than attempt silent remote rollback)
 
 ### Navigation tools
 - `stack_move` — jump to a commit by position, GG-ID, or SHA

--- a/skills/gg/reference.md
+++ b/skills/gg/reference.md
@@ -189,6 +189,37 @@ Repair metadata after external branch/PR/MR manipulation.
 #### `gg continue` / `gg abort`
 Resume/abort paused operations.
 
+#### `gg undo [OPERATION_ID] [--json]` / `gg undo --list [--limit N] [--json]`
+Reverse the local ref/HEAD effects of the most recent mutating `gg`
+command, backed by a per-repo operation log at
+`<commondir>/gg/operations/*.json` (ring buffer, 100 records;
+`Pending`/`Interrupted` records never pruned).
+
+- `OPERATION_ID` — target a specific record (`op_…`). When omitted,
+  undoes the most recent locally-undoable operation.
+- `--list` — show recent operations newest-first.
+- `--limit N` — cap `--list` output (default: 20).
+- `--json` — emit machine-readable JSON.
+
+Every mutating command (`sc`, `drop`, `split`, `rebase`, `reorder`,
+`absorb`, `reconcile`, `checkout`, `mv`/`first`/`last`/`prev`/`next`,
+`clean`, `sync`, `land`, `run --amend`) snapshots refs before mutating
+and records the operation on success. A second `gg undo` redoes the
+first — `undo` itself is recorded.
+
+**Refusals** (exit 1, no refs touched):
+
+| `refusal.reason` | Condition | Handling |
+|---|---|---|
+| `remote` | Op pushed/merged/closed/created a PR or MR | Use the printed provider hint (`gh pr close <n>`, `glab mr close <n>`, `git push --delete …`). |
+| `interrupted` | Op was Ctrl-C'd or crashed mid-flight | Fix state manually; stale Pending records are swept on the next lock-acquiring op. |
+| `stale` | Refs moved since the target op finalised | Run `gg undo --list` and pick a more recent record. Error names the ref, expected OID, actual OID. |
+| `unsupported_schema` | Record was written by a newer `gg` binary | Upgrade `gg` or delete the record. |
+
+`gg undo` never touches the working tree, index, untracked files, or
+remotes. It does not support `--all` / `--range` — one operation per
+call.
+
 #### `gg setup`
 Interactive config wizard.
 - **Quick mode** (`gg setup`): Essential settings (provider, base, username)
@@ -481,6 +512,73 @@ Field types for `entries`:
 }
 ```
 
+### `gg undo --json`
+
+```json
+{
+  "version": 1,
+  "status": "succeeded",
+  "undone": {
+    "id": "op_0000001750000000_018f…",
+    "kind": "drop",
+    "status": "committed",
+    "created_at_ms": 1750000000000,
+    "args": ["drop", "3"],
+    "stack_name": "feature-auth",
+    "touched_remote": false,
+    "is_undoable": true,
+    "is_undo": false,
+    "remote_effects": []
+  }
+}
+```
+
+On refusal:
+
+```json
+{
+  "version": 1,
+  "status": "refused",
+  "refusal": {
+    "reason": "remote",
+    "message": "Cannot locally undo 'sync': it touched a remote.",
+    "target": { "id": "op_…", "kind": "sync", "touched_remote": true },
+    "hints": [
+      "Close PR #42: gh pr close 42",
+      "Delete remote branch: git push --delete origin user/feature-auth--c-abc1234"
+    ]
+  }
+}
+```
+
+`refusal.reason` values: `"remote" | "interrupted" | "stale" | "unsupported_schema"`.
+
+### `gg undo --list --json`
+
+```json
+{
+  "version": 1,
+  "operations": [
+    {
+      "id": "op_…",
+      "kind": "undo",
+      "status": "committed",
+      "created_at_ms": 1750000100000,
+      "args": ["undo"],
+      "stack_name": "feature-auth",
+      "touched_remote": false,
+      "is_undoable": true,
+      "is_undo": true,
+      "undoes": "op_previous…"
+    }
+  ]
+}
+```
+
+Entries are newest-first. Use `is_undoable` to gate UI/agent actions;
+`is_undo` + `undoes` render redo markers. Remote-touching ops appear
+with `is_undoable: false` and `touched_remote: true`.
+
 ---
 
 ## Immutable commits
@@ -657,3 +755,29 @@ Reorder commits in the stack.
   - `force` (bool, default false) — bypass the [immutability guard](#immutable-commits)
 - **Notes:** Direct mode only (`--no-tui` implicit). No interactive TUI via MCP.
 - **Returns:** Result of the reorder operation
+
+#### `stack_undo`
+Reverse the ref/HEAD effects of the most recent mutating `gg` command
+(or a specific op by id). Shell-out wrapper around `gg undo --json`.
+- **Params:**
+  - `operation_id` (string, optional) — target a specific record from
+    `stack_undo_list`. Defaults to the most-recent-undoable operation.
+- **Notes:** Refuses on remote-touching ops (`sync`, `land`) and on
+  `interrupted`, `stale`, or `unsupported_schema` records. On refusal
+  the payload includes `refusal.reason` plus provider-specific revert
+  hints (`gh pr close <n>`, `glab mr close <n>`, `git push --delete …`).
+  Agents must surface the hints to the user rather than attempt silent
+  remote rollback. Working tree is never modified.
+- **Returns:** `{ status: "succeeded", undone: {…} }` or
+  `{ status: "refused", refusal: { reason, message, target, hints } }`.
+
+#### `stack_undo_list`
+List recent operations from the per-repo operation log, newest-first.
+Shell-out wrapper around `gg undo --list --json`.
+- **Params:**
+  - `limit` (usize, optional) — cap output (default: 20)
+- **Notes:** Each entry carries `is_undoable` (gate for safe local
+  replay), `is_undo` + `undoes` (redo markers), and `touched_remote`
+  (set on remote-touching ops, which appear with `is_undoable: false`).
+- **Returns:** `{ operations: [{ id, kind, status, created_at_ms, args,
+  stack_name, touched_remote, is_undoable, is_undo, undoes? }] }`.


### PR DESCRIPTION
## Summary

- Ship `gg undo` — reverses the local ref/HEAD effects of the most recent mutating `gg` command by replaying a snapshot from a per-repo operation log at `<commondir>/gg/operations/*.json`. Never touches the working tree, index, untracked files, or remotes.
- Instrument every mutating command (`sc`, `drop`, `split`, `rebase`, `reorder`, `absorb`, `reconcile`, `checkout`, nav, `clean`, `sync`, `land`, `run --amend`) with a lock-and-record guard that snapshots refs before mutating and finalizes the record on success. Ring buffer keeps 100 records; `Pending`/`Interrupted` records are never pruned.
- Expose `stack_undo` and `stack_undo_list` MCP tools (shell-out wrappers around `gg undo --json` / `gg undo --list --json`) so agentic workflows can safely unwind local missteps without attempting remote rollback.
- Refusal modes: `remote` (PR/MR pushed or merged — emit provider-specific revert hints like `gh pr close <n>`, `glab mr close <n>`, `git push --delete …`), `interrupted`, `stale`, `unsupported_schema`. All four leave refs untouched and exit non-zero.
- `undo` is itself a recorded operation (kind `undo`, `is_undo: true`, `undoes: op_…`), so `gg undo; gg undo` redoes the first.

## Key design choices (D1–D11)

- **D1** Ring-buffer size: 100 records; never prune `Pending`/`Interrupted`.
- **D2** Snapshot scope is per-kind: `ActiveStack` for stack-local ops, `AllUserBranches` for ops that can touch sibling stacks (`clean`, `undo`, `sync`).
- **D3** Lock via `fs2` on `<commondir>/gg/operation.lock`; stale Pending records older than 30s are swept to Interrupted on next acquire.
- **D5** `undo` records itself so a second `undo` is a redo.
- **D7** Built on top of the immutability guard landed in #415 — dropped/squashed commits that were merged into base are already refused before they hit the log.

See CHANGELOG.md and `docs/src/commands/undo.md` for the full user-facing contract (options, refusal matrix, JSON schema).

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` (674 passing)
- [x] New unit tests in `crates/gg-core/src/operations.rs` — serde round-trip, forward-compat, ring-buffer prune, guard finalize/drop, sweep, per-scope snapshot filtering, `run_undo` happy path + each refusal mode.
- [x] New unit tests in `crates/gg-mcp/src/tools.rs` — arg-builder coverage for `stack_undo` and `stack_undo_list`.
- [x] New end-to-end tests in `crates/gg-cli/tests/integration_tests.rs` — drop/sc restoration, list ordering, `--limit`, double-undo redo, unknown op id, help text.
- [ ] Manual: run `gg drop N`, `gg undo`, confirm `git reflog` shows the ref replay and working tree is untouched.
- [ ] Manual: run `gg sync` against a throwaway repo, attempt `gg undo` — verify provider hint is printed and no refs move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)