### PR TITLE
feat: add gg inbox command for multi-stack triage view

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,8 @@ gg clean
 | `gg run [OPTIONS] -- <CMD>...` | Run an arbitrary command on each commit (read-only, `--amend`, `--discard`, `--jobs N`) |
 | `gg reconcile` | Reconcile stacks that were pushed without using `gg sync` |
 | `gg reconcile --dry-run` | Show what reconcile would do without making changes |
+| `gg inbox` | Show actionable triage view across all stacks |
+| `gg inbox --json` | Output inbox as JSON for tooling/MCP |
 | `gg restack` | Repair stack ancestry after manual history changes (amend, cherry-pick, rebase) |
 | `gg restack --dry-run` | Show what restack would do without making changes |
 | `gg continue` | Continue after resolving conflicts |

--- a/crates/gg-cli/src/main.rs
+++ b/crates/gg-cli/src/main.rs
@@ -410,6 +410,18 @@ enum Commands {
         json: bool,
     },
 
+    /// Show actionable triage view across all stacks
+    #[command(name = "inbox")]
+    Inbox {
+        /// Include merged/clean items (default: only actionable items)
+        #[arg(short, long)]
+        all: bool,
+
+        /// Output structured JSON
+        #[arg(long)]
+        json: bool,
+    },
+
     /// Undo the last local-only gg operation (see `gg undo --list`)
     #[command(name = "undo")]
     Undo {
@@ -691,6 +703,7 @@ fn main() {
             }),
             json,
         ),
+        Some(Commands::Inbox { all, json }) => (gg_core::commands::inbox::run(all, json), json),
         Some(Commands::Undo {
             list,
             operation_id,

--- a/crates/gg-core/src/commands/inbox.rs
+++ b/crates/gg-core/src/commands/inbox.rs
@@ -169,8 +169,9 @@ pub fn run(all: bool, json: bool) -> Result<()> {
         let full_branch = git::format_stack_branch(&username, stack_name);
         let base = config
             .get_base_for_stack(stack_name)
-            .unwrap_or("main")
-            .to_string();
+            .map(|s| s.to_string())
+            .or_else(|| git::find_base_branch(&repo).ok())
+            .unwrap_or_else(|| "main".to_string());
 
         // Get commit OIDs for this stack
         let oids = match git::get_stack_commit_oids(&repo, &base, Some(&full_branch)) {

--- a/crates/gg-core/src/commands/inbox.rs
+++ b/crates/gg-core/src/commands/inbox.rs
@@ -11,7 +11,7 @@ use crate::provider::{CiStatus, PrState, Provider};
 use crate::stack::{self, StackEntry};
 
 /// Action buckets for inbox triage — evaluated in priority order.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ActionBucket {
     ReadyToLand,
@@ -74,8 +74,12 @@ pub fn bucket(input: &BucketInput) -> Option<ActionBucket> {
         return Some(ActionBucket::ChangesRequested);
     }
 
-    if input.approved && matches!(input.ci_status, Some(CiStatus::Success)) && input.mergeable {
-        return Some(ActionBucket::ReadyToLand);
+    if input.approved && input.mergeable {
+        // No CI = treat as green (no branch protection CI requirement)
+        let ci_green = matches!(input.ci_status, Some(CiStatus::Success) | None);
+        if ci_green {
+            return Some(ActionBucket::ReadyToLand);
+        }
     }
 
     if matches!(
@@ -196,10 +200,12 @@ pub fn run(all: bool, json: bool) -> Result<()> {
             }
         }
 
-        // Compute behind_base for this stack
-        let behind =
-            git::count_commits_behind(&repo, &base, &format!("origin/{}", base)).unwrap_or(0);
-        let is_behind_base = behind > 0;
+        // Compute behind_base: how many commits on origin/base are not
+        // reachable from the stack branch (i.e., does the stack need rebasing?)
+        let is_behind_base =
+            git::count_branch_behind_upstream(&repo, &full_branch, &format!("origin/{}", base))
+                .unwrap_or(0)
+                > 0;
 
         // Refresh MR info and bucket each entry
         for entry in &mut entries {
@@ -216,11 +222,6 @@ pub fn run(all: bool, json: bool) -> Result<()> {
                 // Get CI status
                 if let Ok(ci) = provider.get_pr_ci_status(pr_num) {
                     entry.ci_status = Some(ci);
-                }
-
-                // Check approval (overrides view_pr result with reviewDecision)
-                if let Ok(approved) = provider.check_pr_approved(pr_num) {
-                    entry.approved = approved;
                 }
 
                 // Bucket the entry
@@ -474,6 +475,13 @@ mod tests {
             true,
             false,
         );
+        assert_eq!(bucket(&input), Some(ActionBucket::ReadyToLand));
+    }
+
+    #[test]
+    fn ready_to_land_approved_no_ci_mergeable() {
+        // No CI = treat as green (no branch protection CI requirement)
+        let input = make_input(PrState::Open, None, true, false, true, false);
         assert_eq!(bucket(&input), Some(ActionBucket::ReadyToLand));
     }
 

--- a/crates/gg-core/src/commands/inbox.rs
+++ b/crates/gg-core/src/commands/inbox.rs
@@ -1,0 +1,638 @@
+//! `gg inbox` - Actionable triage view across all stacks
+
+use console::style;
+use serde::Serialize;
+
+use crate::config::Config;
+use crate::error::Result;
+use crate::git;
+use crate::output::{print_json, OUTPUT_VERSION};
+use crate::provider::{CiStatus, PrState, Provider};
+use crate::stack::{self, StackEntry};
+
+/// Action buckets for inbox triage — evaluated in priority order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ActionBucket {
+    ReadyToLand,
+    ChangesRequested,
+    BlockedOnCi,
+    AwaitingReview,
+    BehindBase,
+    Draft,
+    Merged,
+}
+
+impl ActionBucket {
+    pub fn label(self) -> &'static str {
+        match self {
+            ActionBucket::ReadyToLand => "Ready to land",
+            ActionBucket::ChangesRequested => "Changes requested",
+            ActionBucket::BlockedOnCi => "Blocked on CI",
+            ActionBucket::AwaitingReview => "Awaiting review",
+            ActionBucket::BehindBase => "Behind base",
+            ActionBucket::Draft => "Draft",
+            ActionBucket::Merged => "Merged",
+        }
+    }
+}
+
+/// Inputs for the bucketing function (decoupled from StackEntry for testability).
+#[derive(Debug)]
+pub struct BucketInput {
+    pub mr_state: PrState,
+    pub ci_status: Option<CiStatus>,
+    pub approved: bool,
+    pub changes_requested: bool,
+    pub mergeable: bool,
+    pub behind_base: bool,
+}
+
+/// Classify a PR into an action bucket.
+///
+/// Priority order (first match wins):
+/// 1. Merged
+/// 2. Closed → None (skip)
+/// 3. Draft
+/// 4. Changes requested
+/// 5. Approved + CI green + mergeable → ReadyToLand
+/// 6. CI failed/running/pending → BlockedOnCi
+/// 7. Behind base → BehindBase
+/// 8. Fallthrough → AwaitingReview
+pub fn bucket(input: &BucketInput) -> Option<ActionBucket> {
+    match input.mr_state {
+        PrState::Merged => return Some(ActionBucket::Merged),
+        PrState::Closed => return None,
+        _ => {}
+    }
+
+    if input.mr_state == PrState::Draft {
+        return Some(ActionBucket::Draft);
+    }
+
+    if input.changes_requested {
+        return Some(ActionBucket::ChangesRequested);
+    }
+
+    if input.approved && matches!(input.ci_status, Some(CiStatus::Success)) && input.mergeable {
+        return Some(ActionBucket::ReadyToLand);
+    }
+
+    if matches!(
+        input.ci_status,
+        Some(CiStatus::Failed) | Some(CiStatus::Running) | Some(CiStatus::Pending)
+    ) {
+        return Some(ActionBucket::BlockedOnCi);
+    }
+
+    if input.behind_base {
+        return Some(ActionBucket::BehindBase);
+    }
+
+    Some(ActionBucket::AwaitingReview)
+}
+
+/// A single item in the inbox view.
+struct InboxItem {
+    stack_name: String,
+    position: usize,
+    short_sha: String,
+    title: String,
+    mr_number: u64,
+    mr_url: String,
+    bucket: ActionBucket,
+    ci_status: Option<CiStatus>,
+}
+
+// --- JSON output types ---
+
+#[derive(Serialize)]
+pub struct InboxResponse {
+    pub version: u32,
+    pub total_items: usize,
+    pub buckets: InboxBucketsJson,
+}
+
+#[derive(Serialize)]
+pub struct InboxBucketsJson {
+    pub ready_to_land: Vec<InboxEntryJson>,
+    pub changes_requested: Vec<InboxEntryJson>,
+    pub blocked_on_ci: Vec<InboxEntryJson>,
+    pub awaiting_review: Vec<InboxEntryJson>,
+    pub behind_base: Vec<InboxEntryJson>,
+    pub draft: Vec<InboxEntryJson>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub merged: Vec<InboxEntryJson>,
+}
+
+#[derive(Serialize)]
+pub struct InboxEntryJson {
+    pub stack_name: String,
+    pub position: usize,
+    pub sha: String,
+    pub title: String,
+    pub pr_number: u64,
+    pub pr_url: String,
+    pub ci_status: Option<String>,
+}
+
+/// Run the inbox command.
+pub fn run(all: bool, json: bool) -> Result<()> {
+    let repo = git::open_repo()?;
+    let git_dir = repo.commondir();
+    let config = Config::load_with_global(git_dir)?;
+    let provider = Provider::detect(&repo)?;
+
+    let username = config
+        .defaults
+        .branch_username
+        .clone()
+        .or_else(|| provider.whoami().ok())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    git::validate_branch_username(&username)?;
+
+    let stack_names = stack::list_all_stacks(&repo, &config, &username)?;
+
+    if !json {
+        eprint!("Refreshing {} status... ", provider.pr_label());
+    }
+
+    let mut items: Vec<InboxItem> = Vec::new();
+
+    for stack_name in &stack_names {
+        // Try to load the stack by resolving its tip ref
+        let full_branch = git::format_stack_branch(&username, stack_name);
+        let base = config
+            .get_base_for_stack(stack_name)
+            .unwrap_or("main")
+            .to_string();
+
+        // Get commit OIDs for this stack
+        let oids = match git::get_stack_commit_oids(&repo, &base, Some(&full_branch)) {
+            Ok(oids) => oids,
+            Err(_) => continue, // Stack branch doesn't exist or can't resolve
+        };
+
+        if oids.is_empty() {
+            continue;
+        }
+
+        // Build stack entries
+        let mut entries: Vec<StackEntry> = Vec::with_capacity(oids.len());
+        for (i, oid) in oids.iter().enumerate() {
+            let commit = repo.find_commit(*oid)?;
+            entries.push(StackEntry::from_commit(&commit, i + 1));
+        }
+
+        // Enrich with MR numbers from config
+        if let Some(stack_config) = config.get_stack(stack_name) {
+            for entry in &mut entries {
+                if let Some(gg_id) = &entry.gg_id {
+                    if let Some(mr_num) = stack_config.mrs.get(gg_id) {
+                        entry.mr_number = Some(*mr_num);
+                    }
+                }
+            }
+        }
+
+        // Compute behind_base for this stack
+        let behind =
+            git::count_commits_behind(&repo, &base, &format!("origin/{}", base)).unwrap_or(0);
+        let is_behind_base = behind > 0;
+
+        // Refresh MR info and bucket each entry
+        for entry in &mut entries {
+            if let Some(pr_num) = entry.mr_number {
+                // Fetch PR info
+                if let Ok(info) = provider.get_pr_info(pr_num) {
+                    entry.mr_state = Some(info.state);
+                    entry.approved = info.approved;
+                    entry.changes_requested = info.changes_requested;
+                    entry.mergeable = info.mergeable;
+                    entry.mr_url = Some(info.url);
+                }
+
+                // Get CI status
+                if let Ok(ci) = provider.get_pr_ci_status(pr_num) {
+                    entry.ci_status = Some(ci);
+                }
+
+                // Check approval (overrides view_pr result with reviewDecision)
+                if let Ok(approved) = provider.check_pr_approved(pr_num) {
+                    entry.approved = approved;
+                }
+
+                // Bucket the entry
+                if let Some(ref mr_state) = entry.mr_state {
+                    let input = BucketInput {
+                        mr_state: mr_state.clone(),
+                        ci_status: entry.ci_status.clone(),
+                        approved: entry.approved,
+                        changes_requested: entry.changes_requested,
+                        mergeable: entry.mergeable,
+                        behind_base: is_behind_base,
+                    };
+
+                    if let Some(b) = bucket(&input) {
+                        // Skip merged items unless --all
+                        if b == ActionBucket::Merged && !all {
+                            continue;
+                        }
+
+                        items.push(InboxItem {
+                            stack_name: stack_name.clone(),
+                            position: entry.position,
+                            short_sha: entry.short_sha.clone(),
+                            title: entry.title.clone(),
+                            mr_number: pr_num,
+                            mr_url: entry.mr_url.clone().unwrap_or_default(),
+                            bucket: b,
+                            ci_status: entry.ci_status.clone(),
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    if !json {
+        eprintln!("{}", style("done").green());
+    }
+
+    if json {
+        print_inbox_json(&items);
+    } else {
+        print_inbox_human(&items, &provider);
+    }
+
+    Ok(())
+}
+
+fn print_inbox_json(items: &[InboxItem]) {
+    let mut buckets = InboxBucketsJson {
+        ready_to_land: Vec::new(),
+        changes_requested: Vec::new(),
+        blocked_on_ci: Vec::new(),
+        awaiting_review: Vec::new(),
+        behind_base: Vec::new(),
+        draft: Vec::new(),
+        merged: Vec::new(),
+    };
+
+    for item in items {
+        let entry = InboxEntryJson {
+            stack_name: item.stack_name.clone(),
+            position: item.position,
+            sha: item.short_sha.clone(),
+            title: item.title.clone(),
+            pr_number: item.mr_number,
+            pr_url: item.mr_url.clone(),
+            ci_status: item.ci_status.as_ref().map(ci_status_str),
+        };
+
+        match item.bucket {
+            ActionBucket::ReadyToLand => buckets.ready_to_land.push(entry),
+            ActionBucket::ChangesRequested => buckets.changes_requested.push(entry),
+            ActionBucket::BlockedOnCi => buckets.blocked_on_ci.push(entry),
+            ActionBucket::AwaitingReview => buckets.awaiting_review.push(entry),
+            ActionBucket::BehindBase => buckets.behind_base.push(entry),
+            ActionBucket::Draft => buckets.draft.push(entry),
+            ActionBucket::Merged => buckets.merged.push(entry),
+        }
+    }
+
+    let response = InboxResponse {
+        version: OUTPUT_VERSION,
+        total_items: items.len(),
+        buckets,
+    };
+
+    print_json(&response);
+}
+
+fn print_inbox_human(items: &[InboxItem], provider: &Provider) {
+    if items.is_empty() {
+        println!(
+            "{}",
+            style("Inbox is empty — nothing needs attention.").dim()
+        );
+        return;
+    }
+
+    // Count unique stacks
+    let mut stack_names: Vec<&str> = items.iter().map(|i| i.stack_name.as_str()).collect();
+    stack_names.sort();
+    stack_names.dedup();
+
+    println!();
+    println!(
+        "{}",
+        style(format!(
+            "Inbox ({} items across {} stacks)",
+            items.len(),
+            stack_names.len()
+        ))
+        .bold()
+    );
+
+    let bucket_order = [
+        ActionBucket::ReadyToLand,
+        ActionBucket::ChangesRequested,
+        ActionBucket::BlockedOnCi,
+        ActionBucket::AwaitingReview,
+        ActionBucket::BehindBase,
+        ActionBucket::Draft,
+        ActionBucket::Merged,
+    ];
+
+    let pr_prefix = provider.pr_number_prefix();
+
+    for &b in &bucket_order {
+        let bucket_items: Vec<&InboxItem> = items.iter().filter(|i| i.bucket == b).collect();
+        if bucket_items.is_empty() {
+            continue;
+        }
+
+        println!();
+        println!("{} ({}):", bucket_style(b, b.label()), bucket_items.len());
+
+        for item in &bucket_items {
+            let ci_icon = match (&item.ci_status, b) {
+                (Some(CiStatus::Running), _) => " ⏳",
+                (Some(CiStatus::Pending), _) => " ⏳",
+                (Some(CiStatus::Failed), _) => " ✗",
+                _ => "",
+            };
+
+            println!(
+                "  {} {}  {}  {}  {}{}",
+                style(&item.stack_name).cyan(),
+                style(format!("#{}", item.position)).dim(),
+                style(&item.short_sha).yellow(),
+                item.title,
+                style(format!("{}{}", pr_prefix, item.mr_number)).blue(),
+                ci_icon,
+            );
+        }
+    }
+
+    println!();
+}
+
+fn bucket_style(bucket: ActionBucket, text: &str) -> console::StyledObject<String> {
+    let s = text.to_string();
+    match bucket {
+        ActionBucket::ReadyToLand => style(s).green().bold(),
+        ActionBucket::ChangesRequested => style(s).red().bold(),
+        ActionBucket::BlockedOnCi => style(s).yellow().bold(),
+        ActionBucket::AwaitingReview => style(s).cyan().bold(),
+        ActionBucket::BehindBase => style(s).magenta().bold(),
+        ActionBucket::Draft => style(s).dim().bold(),
+        ActionBucket::Merged => style(s).dim(),
+    }
+}
+
+fn ci_status_str(status: &CiStatus) -> String {
+    match status {
+        CiStatus::Pending => "pending".to_string(),
+        CiStatus::Running => "running".to_string(),
+        CiStatus::Success => "success".to_string(),
+        CiStatus::Failed => "failed".to_string(),
+        CiStatus::Canceled => "canceled".to_string(),
+        CiStatus::Unknown => "unknown".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_input(
+        state: PrState,
+        ci: Option<CiStatus>,
+        approved: bool,
+        changes_requested: bool,
+        mergeable: bool,
+        behind_base: bool,
+    ) -> BucketInput {
+        BucketInput {
+            mr_state: state,
+            ci_status: ci,
+            approved,
+            changes_requested,
+            mergeable,
+            behind_base,
+        }
+    }
+
+    #[test]
+    fn merged_always_merged() {
+        let input = make_input(
+            PrState::Merged,
+            Some(CiStatus::Failed),
+            true,
+            true,
+            true,
+            true,
+        );
+        assert_eq!(bucket(&input), Some(ActionBucket::Merged));
+    }
+
+    #[test]
+    fn closed_is_skipped() {
+        let input = make_input(PrState::Closed, None, false, false, false, false);
+        assert_eq!(bucket(&input), None);
+    }
+
+    #[test]
+    fn draft_takes_priority_over_changes_requested() {
+        let input = make_input(PrState::Draft, None, false, true, false, false);
+        assert_eq!(bucket(&input), Some(ActionBucket::Draft));
+    }
+
+    #[test]
+    fn changes_requested_takes_priority_over_ready_to_land() {
+        let input = make_input(
+            PrState::Open,
+            Some(CiStatus::Success),
+            true,
+            true,
+            true,
+            false,
+        );
+        assert_eq!(bucket(&input), Some(ActionBucket::ChangesRequested));
+    }
+
+    #[test]
+    fn ready_to_land_requires_approved_ci_green_mergeable() {
+        let input = make_input(
+            PrState::Open,
+            Some(CiStatus::Success),
+            true,
+            false,
+            true,
+            false,
+        );
+        assert_eq!(bucket(&input), Some(ActionBucket::ReadyToLand));
+    }
+
+    #[test]
+    fn not_ready_if_not_approved() {
+        let input = make_input(
+            PrState::Open,
+            Some(CiStatus::Success),
+            false,
+            false,
+            true,
+            false,
+        );
+        // Not approved, CI green → AwaitingReview (no CI blocker)
+        assert_eq!(bucket(&input), Some(ActionBucket::AwaitingReview));
+    }
+
+    #[test]
+    fn not_ready_if_not_mergeable() {
+        let input = make_input(
+            PrState::Open,
+            Some(CiStatus::Success),
+            true,
+            false,
+            false,
+            false,
+        );
+        // Approved, CI green, not mergeable → AwaitingReview
+        assert_eq!(bucket(&input), Some(ActionBucket::AwaitingReview));
+    }
+
+    #[test]
+    fn ci_failed_blocks() {
+        let input = make_input(
+            PrState::Open,
+            Some(CiStatus::Failed),
+            true,
+            false,
+            true,
+            false,
+        );
+        assert_eq!(bucket(&input), Some(ActionBucket::BlockedOnCi));
+    }
+
+    #[test]
+    fn ci_running_blocks() {
+        let input = make_input(
+            PrState::Open,
+            Some(CiStatus::Running),
+            false,
+            false,
+            true,
+            false,
+        );
+        assert_eq!(bucket(&input), Some(ActionBucket::BlockedOnCi));
+    }
+
+    #[test]
+    fn ci_pending_blocks() {
+        let input = make_input(
+            PrState::Open,
+            Some(CiStatus::Pending),
+            false,
+            false,
+            true,
+            false,
+        );
+        assert_eq!(bucket(&input), Some(ActionBucket::BlockedOnCi));
+    }
+
+    #[test]
+    fn behind_base_when_ci_unknown() {
+        let input = make_input(
+            PrState::Open,
+            Some(CiStatus::Unknown),
+            false,
+            false,
+            true,
+            true,
+        );
+        assert_eq!(bucket(&input), Some(ActionBucket::BehindBase));
+    }
+
+    #[test]
+    fn behind_base_when_no_ci() {
+        let input = make_input(PrState::Open, None, false, false, true, true);
+        assert_eq!(bucket(&input), Some(ActionBucket::BehindBase));
+    }
+
+    #[test]
+    fn awaiting_review_fallthrough() {
+        let input = make_input(PrState::Open, None, false, false, true, false);
+        assert_eq!(bucket(&input), Some(ActionBucket::AwaitingReview));
+    }
+
+    #[test]
+    fn ci_failure_takes_priority_over_behind_base() {
+        let input = make_input(
+            PrState::Open,
+            Some(CiStatus::Failed),
+            false,
+            false,
+            true,
+            true,
+        );
+        assert_eq!(bucket(&input), Some(ActionBucket::BlockedOnCi));
+    }
+
+    // JSON serialization tests
+
+    #[test]
+    fn inbox_response_serializes() {
+        let response = InboxResponse {
+            version: OUTPUT_VERSION,
+            total_items: 2,
+            buckets: InboxBucketsJson {
+                ready_to_land: vec![InboxEntryJson {
+                    stack_name: "auth".to_string(),
+                    position: 1,
+                    sha: "abc1234".to_string(),
+                    title: "Add auth".to_string(),
+                    pr_number: 42,
+                    pr_url: "https://github.com/user/repo/pull/42".to_string(),
+                    ci_status: Some("success".to_string()),
+                }],
+                changes_requested: Vec::new(),
+                blocked_on_ci: Vec::new(),
+                awaiting_review: vec![InboxEntryJson {
+                    stack_name: "auth".to_string(),
+                    position: 2,
+                    sha: "def5678".to_string(),
+                    title: "Add middleware".to_string(),
+                    pr_number: 43,
+                    pr_url: "https://github.com/user/repo/pull/43".to_string(),
+                    ci_status: None,
+                }],
+                behind_base: Vec::new(),
+                draft: Vec::new(),
+                merged: Vec::new(),
+            },
+        };
+
+        let value = serde_json::to_value(&response).expect("should serialize");
+        assert_eq!(value["version"], OUTPUT_VERSION);
+        assert_eq!(value["total_items"], 2);
+        assert_eq!(value["buckets"]["ready_to_land"][0]["pr_number"], 42);
+        assert_eq!(value["buckets"]["awaiting_review"][0]["pr_number"], 43);
+        // merged should be omitted when empty
+        assert!(value["buckets"].get("merged").is_none());
+    }
+
+    #[test]
+    fn action_bucket_label() {
+        assert_eq!(ActionBucket::ReadyToLand.label(), "Ready to land");
+        assert_eq!(ActionBucket::ChangesRequested.label(), "Changes requested");
+        assert_eq!(ActionBucket::BlockedOnCi.label(), "Blocked on CI");
+        assert_eq!(ActionBucket::AwaitingReview.label(), "Awaiting review");
+        assert_eq!(ActionBucket::BehindBase.label(), "Behind base");
+        assert_eq!(ActionBucket::Draft.label(), "Draft");
+        assert_eq!(ActionBucket::Merged.label(), "Merged");
+    }
+}

--- a/crates/gg-core/src/commands/land.rs
+++ b/crates/gg-core/src/commands/land.rs
@@ -2362,10 +2362,13 @@ mod tests {
             mr_number: None, // No MR = unsynced
             mr_state: None,
             approved: false,
+            changes_requested: false,
+            mergeable: false,
             ci_status: None,
             position: 1,
             in_merge_train: false,
             merge_train_position: None,
+            mr_url: None,
         };
 
         // Verify it's detected as unsynced
@@ -2381,10 +2384,13 @@ mod tests {
             mr_number: Some(123), // Has MR = synced
             mr_state: Some(crate::provider::PrState::Merged),
             approved: true,
+            changes_requested: false,
+            mergeable: true,
             ci_status: None,
             position: 2,
             in_merge_train: false,
             merge_train_position: None,
+            mr_url: None,
         };
 
         // Verify it's detected as synced
@@ -2418,10 +2424,13 @@ mod tests {
                 mr_number: Some(1),
                 mr_state: Some(crate::provider::PrState::Merged),
                 approved: true,
+                changes_requested: false,
+                mergeable: true,
                 ci_status: None,
                 position: 1,
                 in_merge_train: false,
                 merge_train_position: None,
+                mr_url: None,
             },
             StackEntry {
                 oid: git2::Oid::zero(),
@@ -2432,10 +2441,13 @@ mod tests {
                 mr_number: Some(2),
                 mr_state: Some(crate::provider::PrState::Merged),
                 approved: true,
+                changes_requested: false,
+                mergeable: true,
                 ci_status: None,
                 position: 2,
                 in_merge_train: false,
                 merge_train_position: None,
+                mr_url: None,
             },
             StackEntry {
                 oid: git2::Oid::zero(),
@@ -2446,10 +2458,13 @@ mod tests {
                 mr_number: None, // No MR
                 mr_state: None,
                 approved: false,
+                changes_requested: false,
+                mergeable: false,
                 ci_status: None,
                 position: 3,
                 in_merge_train: false,
                 merge_train_position: None,
+                mr_url: None,
             },
             StackEntry {
                 oid: git2::Oid::zero(),
@@ -2460,10 +2475,13 @@ mod tests {
                 mr_number: None, // No MR
                 mr_state: None,
                 approved: false,
+                changes_requested: false,
+                mergeable: false,
                 ci_status: None,
                 position: 4,
                 in_merge_train: false,
                 merge_train_position: None,
+                mr_url: None,
             },
         ];
 

--- a/crates/gg-core/src/commands/log.rs
+++ b/crates/gg-core/src/commands/log.rs
@@ -265,10 +265,13 @@ mod tests {
             mr_number: None,
             mr_state: None,
             approved: false,
+            changes_requested: false,
+            mergeable: false,
             ci_status: None,
             position,
             in_merge_train: false,
             merge_train_position: None,
+            mr_url: None,
         }
     }
 

--- a/crates/gg-core/src/commands/mod.rs
+++ b/crates/gg-core/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod checkout;
 pub mod clean;
 pub mod completions;
 pub mod drop_cmd;
+pub mod inbox;
 pub mod land;
 pub mod lint;
 pub mod log;

--- a/crates/gg-core/src/commands/reorder.rs
+++ b/crates/gg-core/src/commands/reorder.rs
@@ -441,10 +441,13 @@ mod tests {
             mr_number: None,
             mr_state: None,
             approved: false,
+            changes_requested: false,
+            mergeable: false,
             ci_status: None,
             position: pos,
             in_merge_train: false,
             merge_train_position: None,
+            mr_url: None,
         };
         Stack {
             name: "test".to_string(),

--- a/crates/gg-core/src/gh.rs
+++ b/crates/gg-core/src/gh.rs
@@ -28,6 +28,7 @@ pub struct PrInfo {
     pub draft: bool,
     pub approved: bool,
     pub mergeable: bool,
+    pub changes_requested: bool,
 }
 
 /// JSON response from `gh pr view --json`
@@ -43,6 +44,7 @@ struct GhPrJson {
     mergeable: Option<String>,
     #[serde(default)]
     reviews: Vec<GhReview>,
+    review_decision: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -180,7 +182,7 @@ pub fn view_pr(pr_number: u64) -> Result<PrInfo> {
             "view",
             &pr_number.to_string(),
             "--json",
-            "number,title,state,url,isDraft,mergeable,reviews",
+            "number,title,state,url,isDraft,mergeable,reviews,reviewDecision",
         ])
         .output()?;
 
@@ -203,7 +205,13 @@ pub fn view_pr(pr_number: u64) -> Result<PrInfo> {
         _ => PrState::Open,
     };
 
-    let approved = pr_json.reviews.iter().any(|r| r.state == "APPROVED");
+    let approved = pr_json
+        .review_decision
+        .as_deref()
+        .map(|d| d == "APPROVED")
+        .unwrap_or_else(|| pr_json.reviews.iter().any(|r| r.state == "APPROVED"));
+
+    let changes_requested = pr_json.review_decision.as_deref() == Some("CHANGES_REQUESTED");
 
     let mergeable = pr_json.mergeable.as_deref() == Some("MERGEABLE");
 
@@ -215,6 +223,7 @@ pub fn view_pr(pr_number: u64) -> Result<PrInfo> {
         draft: pr_json.is_draft,
         approved,
         mergeable,
+        changes_requested,
     })
 }
 
@@ -666,12 +675,14 @@ mod tests {
             draft: false,
             approved: true,
             mergeable: true,
+            changes_requested: false,
         };
         assert_eq!(info.number, 42);
         assert_eq!(info.title, "Test PR");
         assert_eq!(info.state, PrState::Open);
         assert!(info.approved);
         assert!(info.mergeable);
+        assert!(!info.changes_requested);
     }
 
     #[test]

--- a/crates/gg-core/src/gh.rs
+++ b/crates/gg-core/src/gh.rs
@@ -205,11 +205,11 @@ pub fn view_pr(pr_number: u64) -> Result<PrInfo> {
         _ => PrState::Open,
     };
 
-    let approved = pr_json
-        .review_decision
-        .as_deref()
-        .map(|d| d == "APPROVED")
-        .unwrap_or_else(|| pr_json.reviews.iter().any(|r| r.state == "APPROVED"));
+    let approved = match pr_json.review_decision.as_deref() {
+        Some("APPROVED") => true,
+        Some(_) => false,
+        None => pr_json.reviews.iter().any(|r| r.state == "APPROVED"),
+    };
 
     let changes_requested = pr_json.review_decision.as_deref() == Some("CHANGES_REQUESTED");
 

--- a/crates/gg-core/src/glab.rs
+++ b/crates/gg-core/src/glab.rs
@@ -31,6 +31,7 @@ pub struct MrInfo {
     pub draft: bool,
     pub approved: bool,
     pub mergeable: bool,
+    pub changes_requested: bool,
 }
 
 /// JSON response from `glab mr view --json`
@@ -336,6 +337,7 @@ pub fn view_mr(mr_number: u64) -> Result<MrInfo> {
         draft,
         approved: false, // Would need additional API call
         mergeable,
+        changes_requested: false, // GitLab doesn't expose this directly; set via check_mr_approved
     })
 }
 

--- a/crates/gg-core/src/glab.rs
+++ b/crates/gg-core/src/glab.rs
@@ -337,7 +337,7 @@ pub fn view_mr(mr_number: u64) -> Result<MrInfo> {
         draft,
         approved: false, // Would need additional API call
         mergeable,
-        changes_requested: false, // GitLab doesn't expose this directly; set via check_mr_approved
+        changes_requested: false, // TODO: GitLab approvals API doesn't directly expose changes_requested
     })
 }
 

--- a/crates/gg-core/src/immutability.rs
+++ b/crates/gg-core/src/immutability.rs
@@ -293,10 +293,13 @@ mod tests {
             mr_number: None,
             mr_state: None,
             approved: false,
+            changes_requested: false,
+            mergeable: false,
             ci_status: None,
             position: pos,
             in_merge_train: false,
             merge_train_position: None,
+            mr_url: None,
         }
     }
 

--- a/crates/gg-core/src/provider.rs
+++ b/crates/gg-core/src/provider.rs
@@ -66,6 +66,7 @@ pub struct PrInfo {
     pub draft: bool,
     pub approved: bool,
     pub mergeable: bool,
+    pub changes_requested: bool,
 }
 
 /// Result of creating a PR/MR
@@ -195,6 +196,7 @@ impl Provider {
                     draft: info.draft,
                     approved: info.approved,
                     mergeable: info.mergeable,
+                    changes_requested: info.changes_requested,
                 })
             }
             Provider::GitLab => {
@@ -207,6 +209,7 @@ impl Provider {
                     draft: info.draft,
                     approved: info.approved,
                     mergeable: info.mergeable,
+                    changes_requested: info.changes_requested,
                 })
             }
         }
@@ -551,6 +554,7 @@ mod tests {
             draft: false,
             approved: true,
             mergeable: true,
+            changes_requested: false,
         };
         assert_eq!(info.number, 42);
         assert_eq!(info.title, "Test PR");
@@ -558,6 +562,7 @@ mod tests {
         assert!(info.approved);
         assert!(info.mergeable);
         assert!(!info.draft);
+        assert!(!info.changes_requested);
     }
 
     #[test]

--- a/crates/gg-core/src/stack.rs
+++ b/crates/gg-core/src/stack.rs
@@ -35,6 +35,10 @@ pub struct StackEntry {
     pub mr_state: Option<PrState>,
     /// Whether the PR is approved
     pub approved: bool,
+    /// Whether changes have been requested on the PR
+    pub changes_requested: bool,
+    /// Whether the PR is mergeable
+    pub mergeable: bool,
     /// CI status
     pub ci_status: Option<CiStatus>,
     /// Position in the stack (1-indexed)
@@ -43,6 +47,8 @@ pub struct StackEntry {
     pub in_merge_train: bool,
     /// Position in merge train if applicable
     pub merge_train_position: Option<usize>,
+    /// PR URL if synced
+    pub mr_url: Option<String>,
 }
 
 impl StackEntry {
@@ -57,10 +63,13 @@ impl StackEntry {
             mr_number: None,
             mr_state: None,
             approved: false,
+            changes_requested: false,
+            mergeable: false,
             ci_status: None,
             position,
             in_merge_train: false,
             merge_train_position: None,
+            mr_url: None,
         }
     }
 
@@ -278,6 +287,9 @@ impl Stack {
                     Ok(info) => {
                         entry.mr_state = Some(info.state);
                         entry.approved = info.approved;
+                        entry.changes_requested = info.changes_requested;
+                        entry.mergeable = info.mergeable;
+                        entry.mr_url = Some(info.url);
                     }
                     Err(_) => {
                         // PR/MR might have been deleted
@@ -450,10 +462,13 @@ mod tests {
             mr_number: None,
             mr_state: None,
             approved: false,
+            changes_requested: false,
+            mergeable: false,
             ci_status: None,
             position: pos,
             in_merge_train: false,
             merge_train_position: None,
+            mr_url: None,
         }
     }
 

--- a/crates/gg-core/tests/immutability_integration.rs
+++ b/crates/gg-core/tests/immutability_integration.rs
@@ -109,6 +109,7 @@ fn build_stack(oids: &[git2::Oid], states: &[Option<PrState>]) -> Stack {
             position: i + 1,
             in_merge_train: false,
             merge_train_position: None,
+            mr_url: None,
         })
         .collect();
 

--- a/crates/gg-core/tests/immutability_integration.rs
+++ b/crates/gg-core/tests/immutability_integration.rs
@@ -103,6 +103,8 @@ fn build_stack(oids: &[git2::Oid], states: &[Option<PrState>]) -> Stack {
             mr_number: state.as_ref().map(|_| (i as u64) + 100),
             mr_state: state.clone(),
             approved: false,
+            changes_requested: false,
+            mergeable: false,
             ci_status: None,
             position: i + 1,
             in_merge_train: false,

--- a/crates/gg-mcp/src/tools.rs
+++ b/crates/gg-mcp/src/tools.rs
@@ -976,6 +976,15 @@ impl GgMcpServer {
         run_gg_command(&args)
     }
 
+    /// Show actionable triage view across all stacks — what's ready to land,
+    /// what needs attention, and what's blocked.
+    #[tool(
+        description = "Show actionable inbox/triage view across all stacks. Returns items grouped by status: ready_to_land, changes_requested, blocked_on_ci, awaiting_review, behind_base, draft."
+    )]
+    fn stack_inbox(&self) -> Result<String, String> {
+        run_gg_command(&["inbox".to_string(), "--json".to_string()])
+    }
+
     /// Reorder commits in the stack with explicit order.
     #[tool(
         description = "Reorder commits in the stack. Order is specified as positions (1-indexed), e.g., '3,1,2' moves commit 3 to bottom, then 1, then 2 on top. No TUI via MCP."

--- a/crates/gg-mcp/src/tools.rs
+++ b/crates/gg-mcp/src/tools.rs
@@ -147,6 +147,13 @@ pub struct StackLogParams {
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct StackInboxParams {
+    /// Include merged/clean items (default: only actionable items)
+    #[serde(default)]
+    pub all: bool,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct PrInfoParams {
     /// PR/MR number to look up
     pub number: u64,
@@ -981,8 +988,15 @@ impl GgMcpServer {
     #[tool(
         description = "Show actionable inbox/triage view across all stacks. Returns items grouped by status: ready_to_land, changes_requested, blocked_on_ci, awaiting_review, behind_base, draft."
     )]
-    fn stack_inbox(&self) -> Result<String, String> {
-        run_gg_command(&["inbox".to_string(), "--json".to_string()])
+    fn stack_inbox(
+        &self,
+        Parameters(params): Parameters<StackInboxParams>,
+    ) -> Result<String, String> {
+        let mut args = vec!["inbox".to_string(), "--json".to_string()];
+        if params.all {
+            args.push("--all".to_string());
+        }
+        run_gg_command(&args)
     }
 
     /// Reorder commits in the stack with explicit order.

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -33,6 +33,7 @@
   - [reconcile](./commands/reconcile.md)
   - [restack](./commands/restack.md)
   - [undo](./commands/undo.md)
+  - [inbox](./commands/inbox.md)
 - [MCP Server](./mcp-server.md)
 - [Configuration](./configuration.md)
 - [Shell Completions](./shell-completions.md)

--- a/docs/src/commands/inbox.md
+++ b/docs/src/commands/inbox.md
@@ -1,0 +1,86 @@
+# `gg inbox`
+
+Show an actionable triage view across all stacks.
+
+`gg inbox` scans every stack, refreshes PR/MR status from the remote, and
+groups entries into action buckets so you can see at a glance what needs
+attention.
+
+```bash
+gg inbox [OPTIONS]
+```
+
+## Options
+
+- `-a, --all`: Include merged items (default: only actionable items).
+- `--json`: Print structured JSON output.
+
+## Action Buckets
+
+Entries are classified in priority order (first match wins):
+
+| Priority | Bucket | Condition |
+|----------|--------|-----------|
+| 1 | **Merged** | PR/MR state is merged (hidden unless `--all`) |
+| 2 | *(skip)* | PR/MR state is closed |
+| 3 | **Draft** | PR/MR is a draft |
+| 4 | **Changes requested** | Review decision is "changes requested" |
+| 5 | **Ready to land** | Approved + CI green + mergeable |
+| 6 | **Blocked on CI** | CI failed, running, or pending |
+| 7 | **Behind base** | Stack needs rebasing onto newer base commits |
+| 8 | **Awaiting review** | Fallthrough — open, not blocked |
+
+## Example output
+
+```text
+Refreshing PR status... done
+
+Inbox (4 items across 2 stacks)
+
+Ready to land (1):
+  auth #1  abc1234  Add config types  PR #278
+
+Changes requested (1):
+  parser #2  def5678  Refactor parser  PR #285
+
+Blocked on CI (1):
+  perf #1  9ab0123  Add caching layer  PR #283  ⏳
+
+Awaiting review (1):
+  parser #1  456cdef  Add parser types  PR #284
+```
+
+## JSON shape
+
+```json
+{
+  "version": 1,
+  "total_items": 4,
+  "buckets": {
+    "ready_to_land": [
+      {
+        "stack_name": "auth",
+        "position": 1,
+        "sha": "abc1234",
+        "title": "Add config types",
+        "pr_number": 278,
+        "pr_url": "https://github.com/user/repo/pull/278",
+        "ci_status": "success"
+      }
+    ],
+    "changes_requested": [],
+    "blocked_on_ci": [],
+    "awaiting_review": [],
+    "behind_base": [],
+    "draft": []
+  }
+}
+```
+
+The `merged` bucket is omitted from JSON when empty. With `--all`, it
+appears as an array of entries.
+
+## See also
+
+- [`gg ls`](./ls.md) — detailed view of a single stack or all stacks.
+- [`gg log`](./log.md) — smartlog view of the current stack.

--- a/skills/gg/SKILL.md
+++ b/skills/gg/SKILL.md
@@ -98,6 +98,7 @@ git commit -m "feat: add input validation"
 ```bash
 gg ls --json        # single-stack details + summary metrics
 gg log --json       # smartlog-style view of the current stack
+gg inbox --json     # actionable triage across all stacks
 ```
 
 4. Publish/update PR/MR chain:
@@ -115,7 +116,7 @@ gg land -a -c --json
 ## Agent operating rules (mandatory)
 
 1. **Never run `gg land` without explicit user confirmation.**
-2. **Always use `--json`** for `gg ls`, `gg sync`, `gg land`, `gg clean -a`, and `gg lint`.
+2. **Always use `--json`** for `gg ls`, `gg log`, `gg inbox`, `gg sync`, `gg land`, `gg clean -a`, and `gg lint`.
 3. **Prefer worktrees** for isolation (`gg co -w <stack>`).
 4. Verify `approved: true` and `ci_status` success before landing. If the user requests `--admin`, skip the approval check (GitHub only — GitLab ignores the flag).
 5. If sync warns stack is behind base, run `gg rebase` first.

--- a/skills/gg/reference.md
+++ b/skills/gg/reference.md
@@ -74,6 +74,14 @@ badges). Stack-scoped — use `gg ls --all` for cross-stack browsing.
 - `--json` (auto-refreshes PR/MR state; shape mirrors `gg ls --json` entries
   under a `log` key)
 
+#### `gg inbox [OPTIONS]`
+Actionable triage across **all** stacks. Refreshes PR/MR status automatically
+and groups entries into buckets: ready to land, changes requested, blocked on
+CI, awaiting review, behind base, draft, merged.
+
+- `-a, --all`: Include merged items (hidden by default)
+- `--json`
+
 #### `gg sync [OPTIONS]`
 Push and create/update PRs/MRs.
 
@@ -621,6 +629,38 @@ Entries are newest-first. Use `is_undoable` to gate UI/agent actions;
 `is_undo` + `undoes` render redo markers. Remote-touching ops appear
 with `is_undoable: false` and `touched_remote: true`.
 
+### `gg inbox --json`
+
+```json
+{
+  "version": 1,
+  "total_items": 4,
+  "buckets": {
+    "ready_to_land": [
+      {
+        "stack_name": "string",
+        "position": 1,
+        "sha": "string",
+        "title": "string",
+        "pr_number": 123,
+        "pr_url": "string",
+        "ci_status": "success"
+      }
+    ],
+    "changes_requested": [],
+    "blocked_on_ci": [],
+    "awaiting_review": [],
+    "behind_base": [],
+    "draft": [],
+    "merged": []
+  }
+}
+```
+
+`ci_status` is one of `"pending"`, `"running"`, `"success"`, `"failed"`,
+`"canceled"`, `"unknown"`, or `null`. The `merged` bucket is omitted when
+empty (via `skip_serializing_if`). With `--all`, merged entries appear.
+
 ---
 
 ## Immutable commits
@@ -804,6 +844,12 @@ Repair stack ancestry drift after manual history changes.
   - `dry_run` (bool, default false) — show plan without making changes
   - `from` (string, optional) — repair only from this position, GG-ID, or SHA upward
 - **Returns:** JSON `RestackResponse` with per-step plan and execution results
+
+#### `stack_inbox`
+Actionable triage view across all stacks — what's ready to land, what needs attention, and what's blocked.
+- **Params:**
+  - `all` (bool, default false) — include merged items
+- **Returns:** JSON `InboxResponse` with `total_items` and `buckets` (ready_to_land, changes_requested, blocked_on_ci, awaiting_review, behind_base, draft, merged)
 
 #### `stack_undo`
 Reverse the ref/HEAD effects of the most recent mutating `gg` command


### PR DESCRIPTION
## Summary

- Adds `gg inbox` command that shows an actionable triage view across all stacks, grouping PRs/MRs into priority-ordered buckets: ready to land, changes requested, blocked on CI, awaiting review, behind base, draft, and merged
- Adds `changes_requested` field to provider model (`PrInfo`) by parsing GitHub's `reviewDecision` field; stubbed as `false` for GitLab
- Adds `changes_requested`, `mergeable`, and `mr_url` fields to `StackEntry`, propagated during `refresh_mr_info()`
- Includes JSON output (`--json`), MCP `stack_inbox` tool, and human-readable grouped rendering
- 17 unit tests covering all bucketing paths and JSON serialization

## Changes since initial review

- **Removed redundant `check_pr_approved()` call** — `get_pr_info()` already parses `reviewDecision`, so the extra API call per PR was unnecessary (I2)
- **Fixed `behind_base` detection** — now uses `count_branch_behind_upstream()` comparing the stack branch against `origin/base`, instead of measuring local base vs remote base divergence (I3)
- **Removed unused `PartialOrd, Ord` derives** from `ActionBucket` (S4)
- **Added docs/skills updates** — `docs/src/commands/inbox.md`, `skills/gg/reference.md` (command + JSON schema + MCP tool), `skills/gg/SKILL.md` (I1)
- **Rebased onto latest main** — resolved conflicts with restack, undo, and log additions

## Test plan

- [x] `cargo test --all-features` — 706 tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all` — clean
- [ ] Manual test: `gg inbox` on a repo with multiple stacks and active PRs
- [ ] Manual test: `gg inbox --json` output parses correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)