### PR TITLE
fix(rebase): allow gg rebase without --force when merged commits drop after base refresh

### DIFF
--- a/crates/gg-core/src/commands/rebase.rs
+++ b/crates/gg-core/src/commands/rebase.rs
@@ -142,7 +142,7 @@ fn prepare_rebase(
             immutability::refresh_mr_state_for_guard(repo, &mut stack);
             let policy = ImmutabilityPolicy::for_stack(repo, &stack)?;
             let report = policy.check_all(&stack);
-            let (report, dropped) = if fetch_succeeded {
+            let (report, dropped) = if fetch_succeeded && target_branch == stack.base {
                 let pre_filter_count = report.entries.len();
                 let filtered = report.without_base_ancestors();
                 let dropped = pre_filter_count - filtered.entries.len();

--- a/crates/gg-core/src/commands/rebase.rs
+++ b/crates/gg-core/src/commands/rebase.rs
@@ -141,6 +141,17 @@ fn prepare_rebase(
             immutability::refresh_mr_state_for_guard(repo, &mut stack);
             let policy = ImmutabilityPolicy::for_stack(repo, &stack)?;
             let report = policy.check_all(&stack);
+            let pre_filter_count = report.entries.len();
+            let report = report.without_base_ancestors();
+            let dropped = pre_filter_count - report.entries.len();
+            if dropped > 0 && !json {
+                println!(
+                    "{} Skipping {} merged commit(s) already on {}",
+                    style("→").cyan(),
+                    dropped,
+                    policy.base_ref()
+                );
+            }
             immutability::guard(report, force)?;
         }
     }

--- a/crates/gg-core/src/commands/rebase.rs
+++ b/crates/gg-core/src/commands/rebase.rs
@@ -93,6 +93,7 @@ fn prepare_rebase(
     // against stale refs can silently pass on a newly-merged commit and
     // then rewrite it after the fetch updates the ref.
     let fetch_result = git::run_git_command(&["fetch", "origin", "--prune"]);
+    let fetch_succeeded = fetch_result.is_ok();
     if let Err(e) = fetch_result {
         if !json {
             println!(
@@ -141,9 +142,14 @@ fn prepare_rebase(
             immutability::refresh_mr_state_for_guard(repo, &mut stack);
             let policy = ImmutabilityPolicy::for_stack(repo, &stack)?;
             let report = policy.check_all(&stack);
-            let pre_filter_count = report.entries.len();
-            let report = report.without_base_ancestors();
-            let dropped = pre_filter_count - report.entries.len();
+            let (report, dropped) = if fetch_succeeded {
+                let pre_filter_count = report.entries.len();
+                let filtered = report.without_base_ancestors();
+                let dropped = pre_filter_count - filtered.entries.len();
+                (filtered, dropped)
+            } else {
+                (report, 0)
+            };
             if dropped > 0 && !json {
                 println!(
                     "{} Skipping {} merged commit(s) already on {}",

--- a/crates/gg-core/src/immutability.rs
+++ b/crates/gg-core/src/immutability.rs
@@ -91,6 +91,29 @@ impl ImmutabilityReport {
         self.entries.is_empty()
     }
 
+    /// Remove entries that have a `BaseAncestor` reason.
+    ///
+    /// If a commit is reachable from `origin/<base>`, `git rebase` skips it
+    /// unconditionally (patch-already-applied detection is SHA-based). So
+    /// base-ancestor entries never need guarding during rebase — even if the
+    /// entry also carries a `MergedPr` reason, the commit won't be rewritten.
+    ///
+    /// Entries with only non-`BaseAncestor` reasons (e.g. squash-merged PRs
+    /// whose SHA isn't on the base) are kept — rebase *would* reapply those.
+    pub fn without_base_ancestors(self) -> Self {
+        Self {
+            entries: self
+                .entries
+                .into_iter()
+                .filter(|e| {
+                    !e.reasons
+                        .iter()
+                        .any(|r| matches!(r, ImmutableReason::BaseAncestor { .. }))
+                })
+                .collect(),
+        }
+    }
+
     /// Format the report as a multi-line string suitable for error messages.
     pub fn format_for_error(&self) -> String {
         let mut out = String::new();
@@ -503,5 +526,96 @@ mod tests {
         let policy = ImmutabilityPolicy::for_stack(&repo, &stack).unwrap();
         let report = policy.check_all(&stack);
         assert_eq!(report.entries.len(), 2);
+    }
+
+    #[test]
+    fn without_base_ancestors_drops_base_only_entries() {
+        let report = ImmutabilityReport {
+            entries: vec![ImmutableEntry {
+                position: 1,
+                short_sha: "aaa".to_string(),
+                title: "merged commit".to_string(),
+                reasons: vec![ImmutableReason::BaseAncestor {
+                    base_ref: "origin/main".to_string(),
+                }],
+            }],
+        };
+        let filtered = report.without_base_ancestors();
+        assert!(filtered.is_clear());
+    }
+
+    #[test]
+    fn without_base_ancestors_keeps_merged_pr_entries() {
+        let report = ImmutabilityReport {
+            entries: vec![ImmutableEntry {
+                position: 1,
+                short_sha: "aaa".to_string(),
+                title: "squash-merged".to_string(),
+                reasons: vec![ImmutableReason::MergedPr { number: Some(42) }],
+            }],
+        };
+        let filtered = report.without_base_ancestors();
+        assert_eq!(filtered.entries.len(), 1);
+    }
+
+    #[test]
+    fn without_base_ancestors_drops_dual_reason_entries() {
+        // If a commit has both MergedPr and BaseAncestor, it IS on the base,
+        // so git rebase will skip it regardless — safe to drop.
+        let report = ImmutabilityReport {
+            entries: vec![ImmutableEntry {
+                position: 1,
+                short_sha: "aaa".to_string(),
+                title: "merged and on base".to_string(),
+                reasons: vec![
+                    ImmutableReason::MergedPr { number: Some(10) },
+                    ImmutableReason::BaseAncestor {
+                        base_ref: "origin/main".to_string(),
+                    },
+                ],
+            }],
+        };
+        let filtered = report.without_base_ancestors();
+        assert!(filtered.is_clear());
+    }
+
+    #[test]
+    fn without_base_ancestors_mixed_stack() {
+        let report = ImmutabilityReport {
+            entries: vec![
+                // Entry 1: base-ancestor only → should be dropped
+                ImmutableEntry {
+                    position: 1,
+                    short_sha: "aaa".to_string(),
+                    title: "on base".to_string(),
+                    reasons: vec![ImmutableReason::BaseAncestor {
+                        base_ref: "origin/main".to_string(),
+                    }],
+                },
+                // Entry 2: merged-pr only → should be kept
+                ImmutableEntry {
+                    position: 2,
+                    short_sha: "bbb".to_string(),
+                    title: "squash-merged".to_string(),
+                    reasons: vec![ImmutableReason::MergedPr { number: Some(99) }],
+                },
+                // Entry 3: both reasons → dropped (BaseAncestor present, rebase skips it)
+                ImmutableEntry {
+                    position: 3,
+                    short_sha: "ccc".to_string(),
+                    title: "merged and on base".to_string(),
+                    reasons: vec![
+                        ImmutableReason::MergedPr { number: Some(100) },
+                        ImmutableReason::BaseAncestor {
+                            base_ref: "origin/main".to_string(),
+                        },
+                    ],
+                },
+            ],
+        };
+        let filtered = report.without_base_ancestors();
+        // Only entry #2 (MergedPr-only, squash-merge) survives.
+        assert_eq!(filtered.entries.len(), 1);
+        assert_eq!(filtered.entries[0].position, 2);
     }
 }

--- a/crates/gg-core/tests/immutability_integration.rs
+++ b/crates/gg-core/tests/immutability_integration.rs
@@ -326,6 +326,23 @@ fn rebase_guard_still_blocks_squash_merged_not_on_base() {
 }
 
 #[test]
+fn rebase_guard_keeps_base_ancestors_when_fetch_was_not_fresh() {
+    let temp = tempfile::tempdir().unwrap();
+    let (repo, oids, _) = make_linear_stack(&temp, 2, 1);
+
+    let stack = build_stack(&oids, &[None, None]);
+    let policy = ImmutabilityPolicy::for_stack(&repo, &stack).unwrap();
+    let report = policy.check_all(&stack);
+
+    assert_eq!(report.entries.len(), 1);
+    assert_eq!(report.entries[0].position, 1);
+
+    // If fetch failed and origin/<base> may be stale, rebase should keep the
+    // original guard behavior instead of silently dropping BaseAncestor entries.
+    assert!(guard(report, false).is_err());
+}
+
+#[test]
 fn falls_back_to_local_base_when_origin_ref_is_missing() {
     let temp = tempfile::tempdir().unwrap();
     let repo_path = temp.path();

--- a/crates/gg-core/tests/immutability_integration.rs
+++ b/crates/gg-core/tests/immutability_integration.rs
@@ -266,6 +266,66 @@ fn refresh_mr_state_for_guard_is_noop_without_provider() {
 }
 
 #[test]
+fn rebase_guard_passes_when_only_immutable_is_base_ancestor() {
+    // Repro for #293: 2-commit stack where bottom is already on origin/main.
+    // After without_base_ancestors(), the guard should pass without --force.
+    let temp = tempfile::tempdir().unwrap();
+    let (repo, oids, _) = make_linear_stack(&temp, 2, 1);
+    // origin/main covers stack commit #1.
+
+    let stack = build_stack(&oids, &[None, None]);
+    let policy = ImmutabilityPolicy::for_stack(&repo, &stack).unwrap();
+
+    let report = policy.check_all(&stack);
+    // Pre-filter: commit #1 is immutable (BaseAncestor).
+    assert_eq!(report.entries.len(), 1);
+    assert_eq!(report.entries[0].position, 1);
+
+    // After filtering, the report should be clear.
+    let filtered = report.without_base_ancestors();
+    assert!(
+        filtered.is_clear(),
+        "expected clear report after filtering base ancestors, got {:?}",
+        filtered
+    );
+
+    // Guard passes without --force.
+    assert!(guard(filtered, false).is_ok());
+}
+
+#[test]
+fn rebase_guard_still_blocks_squash_merged_not_on_base() {
+    // A squash-merged PR whose SHA is NOT on origin/main must still block.
+    // This is the case without_base_ancestors() must preserve.
+    let temp = tempfile::tempdir().unwrap();
+    let (repo, oids, _) = make_linear_stack(&temp, 2, 0);
+    // origin/main at base commit — no stack commits are ancestors.
+
+    // Mark commit #1 as squash-merged (MergedPr only, not BaseAncestor).
+    let stack = build_stack(&oids, &[Some(PrState::Merged), None]);
+    let policy = ImmutabilityPolicy::for_stack(&repo, &stack).unwrap();
+
+    let report = policy.check_all(&stack);
+    assert_eq!(report.entries.len(), 1);
+    assert_eq!(report.entries[0].position, 1);
+    assert!(matches!(
+        report.entries[0].reasons[0],
+        ImmutableReason::MergedPr { .. }
+    ));
+
+    // Filtering should NOT remove this entry (no BaseAncestor reason).
+    let filtered = report.without_base_ancestors();
+    assert_eq!(
+        filtered.entries.len(),
+        1,
+        "squash-merged entry must survive filtering"
+    );
+
+    // Guard rejects without --force.
+    assert!(guard(filtered, false).is_err());
+}
+
+#[test]
 fn falls_back_to_local_base_when_origin_ref_is_missing() {
     let temp = tempfile::tempdir().unwrap();
     let repo_path = temp.path();

--- a/crates/gg-core/tests/immutability_integration.rs
+++ b/crates/gg-core/tests/immutability_integration.rs
@@ -326,6 +326,23 @@ fn rebase_guard_still_blocks_squash_merged_not_on_base() {
 }
 
 #[test]
+fn rebase_guard_keeps_base_ancestors_for_cross_target_rebases() {
+    let temp = tempfile::tempdir().unwrap();
+    let (repo, oids, _) = make_linear_stack(&temp, 2, 1);
+
+    let stack = build_stack(&oids, &[None, None]);
+    let policy = ImmutabilityPolicy::for_stack(&repo, &stack).unwrap();
+    let report = policy.check_all(&stack);
+
+    assert_eq!(report.entries.len(), 1);
+    assert_eq!(report.entries[0].position, 1);
+
+    // Rebasing onto a non-base target must keep BaseAncestor entries, because
+    // the ancestry check was computed against stack.base, not the chosen target.
+    assert!(guard(report, false).is_err());
+}
+
+#[test]
 fn rebase_guard_keeps_base_ancestors_when_fetch_was_not_fresh() {
     let temp = tempfile::tempdir().unwrap();
     let (repo, oids, _) = make_linear_stack(&temp, 2, 1);

--- a/docs/src/commands/rebase.md
+++ b/docs/src/commands/rebase.md
@@ -12,8 +12,10 @@ gg rebase [TARGET]
 
 - `-f, --force` (alias `--ignore-immutable`): Override the immutability guard.
   Rebase rewrites the parent of every commit in the stack; if any commit is
-  merged or already reachable from `origin/<base>`, gg refuses by default to
-  avoid producing local duplicates of upstream history. See
+  merged (via squash-merge), gg refuses by default to avoid producing local
+  duplicates of upstream history. Commits already reachable from
+  `origin/<base>` are silently skipped — `git rebase` drops them automatically,
+  so `--force` is not required. See
   [Core concepts · Immutable commits](../core-concepts.md#immutable-commits).
 
 ## Examples

--- a/docs/src/core-concepts.md
+++ b/docs/src/core-concepts.md
@@ -71,7 +71,10 @@ refuse to touch the following by default:
   local commit.
 - **Base-ancestor commits.** Any commit already reachable from `origin/<base>`
   via plain merge or rebase falls in the same bucket. When no `origin/<base>`
-  ref exists, gg falls back to the local base branch.
+  ref exists, gg falls back to the local base branch. **Exception:** `gg rebase`
+  silently skips base-ancestor commits instead of blocking, because `git rebase`
+  naturally drops them. An info line (`→ Skipping N merged commit(s) already on
+  <base>`) is printed when this happens.
 
 Running one of those commands on an immutable target prints a clear error like:
 

--- a/skills/gg/SKILL.md
+++ b/skills/gg/SKILL.md
@@ -122,7 +122,7 @@ gg land -a -c --json
 5. If sync warns stack is behind base, run `gg rebase` first.
 6. Prefer `gg absorb -s` for multi-commit edits.
 7. **Never use `git add -A` blindly.** Review `git status` first and only stage intended files. Use `git add <specific-files>` to avoid leaking secrets, env files, or unrelated changes.
-8. **Respect the immutability guard.** Rewrite-style commands (`gg sc`, `gg absorb`, `gg reorder`/`gg arrange`, `gg split`, `gg drop`, `gg rebase`, `gg restack`) refuse to rewrite merged PRs/MRs or commits already on the base branch. If the command exits with `ImmutableTargets`, surface the listed commits and reasons to the user and get explicit confirmation before retrying with `-f` / `--force` (alias `--ignore-immutable`).
+8. **Respect the immutability guard.** Rewrite-style commands (`gg sc`, `gg absorb`, `gg reorder`/`gg arrange`, `gg split`, `gg drop`, `gg rebase`, `gg restack`) refuse to rewrite merged PRs/MRs or commits already on the base branch, except that `gg rebase` silently skips base-ancestor commits that naturally drop out when rebasing onto the refreshed base. If a command exits with `ImmutableTargets`, surface the listed commits and reasons to the user and get explicit confirmation before retrying with `-f` / `--force` (alias `--ignore-immutable`).
 
 ## Common operations
 
@@ -251,9 +251,7 @@ gg refuses by default to rewrite commits that look "already published":
   a fallback).
 
 The guard protects `gg sc`, `gg absorb`, `gg reorder` / `gg arrange`,
-`gg split`, `gg drop`, `gg rebase`, and `gg restack`. When it fires, the command exits
-with an `ImmutableTargets` error listing every affected position, short
-SHA, title, and reason (e.g. `merged as !123`, `already in origin/main`).
+`gg split`, `gg drop`, `gg rebase`, and `gg restack`. `gg rebase` is a special case: commits already reachable from the refreshed base are silently skipped because `git rebase` would drop them naturally instead of rewriting them. For the remaining commands, or for non-base-ancestor immutable commits during `gg rebase`, the command exits with an `ImmutableTargets` error listing every affected position, short SHA, title, and reason (e.g. `merged as !123`, `already in origin/main`).
 
 To bypass it intentionally, pass `-f` / `--force` (long alias
 `--ignore-immutable`). Always surface the listed commits and reasons to the

--- a/skills/gg/reference.md
+++ b/skills/gg/reference.md
@@ -667,7 +667,12 @@ Notes for agents:
 
 - Before offering `--force`, surface the guard output to the user and get
   explicit confirmation — bypassing is a footgun.
-- `gg rebase` and `gg sync`'s internal auto-rebase only consider a commit a
+- `gg rebase` silently skips base-ancestor commits (printing
+  `→ Skipping N merged commit(s) already on <base>`) instead of blocking,
+  because `git rebase` naturally drops patches already applied upstream.
+  The guard still blocks squash-merged PRs (`MergedPr` reason without
+  `BaseAncestor`) since those would be replayed as duplicates.
+- `gg sync`'s internal auto-rebase only considers a commit a
   base ancestor **after** the remote ref is fetched, so the guard reflects
   freshly-updated state rather than stale local refs.
 - `gg sync`'s other paths (push, PR create/update) are not guarded; only


### PR DESCRIPTION
## Summary

- **Fixes #293**: `gg rebase` no longer demands `--force` when the only immutable commits in the stack are base ancestors that git rebase would naturally skip
- Adds `ImmutabilityReport::without_base_ancestors()` to filter entries whose presence includes a `BaseAncestor` reason (commit is reachable from `origin/<base>`)
- Squash-merged PRs (MergedPr-only, SHA not on base) still correctly block rebase without `--force`

## Changes

| File | Change |
|------|--------|
| `immutability.rs` | New `without_base_ancestors()` method + 4 unit tests |
| `rebase.rs` | Wire filter between `check_all()` and `guard()` + info line |
| `immutability_integration.rs` | 2 integration tests (repro + squash-merge still blocks) |

## Test plan

- [x] `cargo fmt --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all-features` passes (723 tests)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)