### PR TITLE
fix(rebase): allow gg rebase when stack has squash-merged commits

### DIFF
--- a/crates/gg-core/src/commands/rebase.rs
+++ b/crates/gg-core/src/commands/rebase.rs
@@ -142,9 +142,20 @@ fn prepare_rebase(
             immutability::refresh_mr_state_for_guard(repo, &mut stack);
             let policy = ImmutabilityPolicy::for_stack(repo, &stack)?;
             let report = policy.check_all(&stack);
-            let (report, dropped) = if fetch_succeeded && target_branch == stack.base {
+            let (report, dropped) = if target_branch == stack.base {
                 let pre_filter_count = report.entries.len();
-                let filtered = report.without_base_ancestors();
+                // Merged PRs are safe to rebase over: git rebase drops them
+                // via patch-id matching (the content is already on the target).
+                // This covers squash-merged PRs whose local SHA isn't an
+                // ancestor of origin/<base>.
+                let filtered = report.without_merged_prs();
+                // Base-ancestor filtering requires a fresh fetch so
+                // origin/<base> reflects the latest remote state.
+                let filtered = if fetch_succeeded {
+                    filtered.without_base_ancestors()
+                } else {
+                    filtered
+                };
                 let dropped = pre_filter_count - filtered.entries.len();
                 (filtered, dropped)
             } else {

--- a/crates/gg-core/src/commands/rebase.rs
+++ b/crates/gg-core/src/commands/rebase.rs
@@ -146,10 +146,9 @@ fn prepare_rebase(
                 let pre_filter_count = report.entries.len();
                 // Both filters require a fresh fetch: without_base_ancestors
                 // needs up-to-date origin/<base> for ancestry checks, and
-                // without_merged_prs needs it to ensure the merge actually
-                // landed on the base (in stacked PRs, an upper PR can be
-                // merged into a parent branch, not the base).
-                let filtered = report.without_merged_prs().without_base_ancestors();
+                // without_bottom_merged_prs needs it to confirm that the
+                // contiguous bottom of the stack actually landed on the base.
+                let filtered = report.without_bottom_merged_prs().without_base_ancestors();
                 let dropped = pre_filter_count - filtered.entries.len();
                 (filtered, dropped)
             } else {

--- a/crates/gg-core/src/commands/rebase.rs
+++ b/crates/gg-core/src/commands/rebase.rs
@@ -142,20 +142,14 @@ fn prepare_rebase(
             immutability::refresh_mr_state_for_guard(repo, &mut stack);
             let policy = ImmutabilityPolicy::for_stack(repo, &stack)?;
             let report = policy.check_all(&stack);
-            let (report, dropped) = if target_branch == stack.base {
+            let (report, dropped) = if fetch_succeeded && target_branch == stack.base {
                 let pre_filter_count = report.entries.len();
-                // Merged PRs are safe to rebase over: git rebase drops them
-                // via patch-id matching (the content is already on the target).
-                // This covers squash-merged PRs whose local SHA isn't an
-                // ancestor of origin/<base>.
-                let filtered = report.without_merged_prs();
-                // Base-ancestor filtering requires a fresh fetch so
-                // origin/<base> reflects the latest remote state.
-                let filtered = if fetch_succeeded {
-                    filtered.without_base_ancestors()
-                } else {
-                    filtered
-                };
+                // Both filters require a fresh fetch: without_base_ancestors
+                // needs up-to-date origin/<base> for ancestry checks, and
+                // without_merged_prs needs it to ensure the merge actually
+                // landed on the base (in stacked PRs, an upper PR can be
+                // merged into a parent branch, not the base).
+                let filtered = report.without_merged_prs().without_base_ancestors();
                 let dropped = pre_filter_count - filtered.entries.len();
                 (filtered, dropped)
             } else {

--- a/crates/gg-core/src/immutability.rs
+++ b/crates/gg-core/src/immutability.rs
@@ -114,23 +114,42 @@ impl ImmutabilityReport {
         }
     }
 
-    /// Remove entries that have a `MergedPr` reason.
+    /// Remove `MergedPr` entries from the contiguous immutable prefix at the
+    /// bottom of the stack.
     ///
-    /// During `gg rebase`, commits whose PR/MR is already merged are safe to
-    /// include in the rebase: `git rebase` detects that the patch content is
-    /// already applied on the target branch (via patch-id matching) and drops
-    /// them automatically. This covers squash-merged PRs whose local SHA
-    /// isn't an ancestor of `origin/<base>` — the case that
-    /// [`without_base_ancestors`] cannot catch.
-    pub fn without_merged_prs(self) -> Self {
+    /// In stacked workflows, only the bottom PR targets `origin/<base>`
+    /// directly; upper PRs target the previous entry's branch. When PRs are
+    /// landed bottom-up, each subsequent PR gets retargeted to the base, so a
+    /// contiguous run of immutable entries from position 1 all had their
+    /// content merged into the base. Above a gap (a mutable commit), merged
+    /// PRs may still target a parent branch whose content isn't on
+    /// `origin/<base>`, so we keep those in the report.
+    ///
+    /// This covers squash-merged PRs whose local SHA isn't an ancestor of
+    /// `origin/<base>` — the case that [`without_base_ancestors`] cannot
+    /// catch.
+    pub fn without_bottom_merged_prs(self) -> Self {
+        // Find the contiguous immutable prefix from position 1.
+        let mut max_contiguous_pos: usize = 0;
+        for entry in &self.entries {
+            if entry.position == max_contiguous_pos + 1 {
+                max_contiguous_pos = entry.position;
+            } else {
+                break;
+            }
+        }
+
         Self {
             entries: self
                 .entries
                 .into_iter()
                 .filter(|e| {
-                    !e.reasons
+                    let dominated = e.position <= max_contiguous_pos;
+                    let is_merged = e
+                        .reasons
                         .iter()
-                        .any(|r| matches!(r, ImmutableReason::MergedPr { .. }))
+                        .any(|r| matches!(r, ImmutableReason::MergedPr { .. }));
+                    !(dominated && is_merged)
                 })
                 .collect(),
         }
@@ -602,7 +621,7 @@ mod tests {
     }
 
     #[test]
-    fn without_merged_prs_drops_merged_only_entries() {
+    fn without_bottom_merged_prs_drops_merged_at_position_1() {
         let report = ImmutabilityReport {
             entries: vec![ImmutableEntry {
                 position: 1,
@@ -611,12 +630,12 @@ mod tests {
                 reasons: vec![ImmutableReason::MergedPr { number: Some(42) }],
             }],
         };
-        let filtered = report.without_merged_prs();
+        let filtered = report.without_bottom_merged_prs();
         assert!(filtered.is_clear());
     }
 
     #[test]
-    fn without_merged_prs_keeps_base_ancestor_only_entries() {
+    fn without_bottom_merged_prs_keeps_base_ancestor_only_entries() {
         let report = ImmutabilityReport {
             entries: vec![ImmutableEntry {
                 position: 1,
@@ -627,12 +646,12 @@ mod tests {
                 }],
             }],
         };
-        let filtered = report.without_merged_prs();
+        let filtered = report.without_bottom_merged_prs();
         assert_eq!(filtered.entries.len(), 1);
     }
 
     #[test]
-    fn without_merged_prs_drops_dual_reason_entries() {
+    fn without_bottom_merged_prs_drops_dual_reason_entries() {
         let report = ImmutabilityReport {
             entries: vec![ImmutableEntry {
                 position: 1,
@@ -646,8 +665,60 @@ mod tests {
                 ],
             }],
         };
-        let filtered = report.without_merged_prs();
+        let filtered = report.without_bottom_merged_prs();
         assert!(filtered.is_clear());
+    }
+
+    #[test]
+    fn without_bottom_merged_prs_keeps_upper_merged_after_gap() {
+        // Stack: #1 mutable, #2 merged. Since #1 is not in the report,
+        // #2 is NOT in the contiguous prefix → must be kept.
+        let report = ImmutabilityReport {
+            entries: vec![ImmutableEntry {
+                position: 2,
+                short_sha: "bbb".to_string(),
+                title: "upper merged".to_string(),
+                reasons: vec![ImmutableReason::MergedPr { number: Some(99) }],
+            }],
+        };
+        let filtered = report.without_bottom_merged_prs();
+        assert_eq!(filtered.entries.len(), 1, "upper merged entry must survive");
+    }
+
+    #[test]
+    fn without_bottom_merged_prs_contiguous_prefix() {
+        // Stack: #1 merged, #2 base-ancestor, #3 merged (after gap in immutables at #2's position).
+        // Positions 1 and 2 form contiguous prefix. #3 is also contiguous.
+        let report = ImmutabilityReport {
+            entries: vec![
+                ImmutableEntry {
+                    position: 1,
+                    short_sha: "aaa".to_string(),
+                    title: "bottom merged".to_string(),
+                    reasons: vec![ImmutableReason::MergedPr { number: Some(10) }],
+                },
+                ImmutableEntry {
+                    position: 2,
+                    short_sha: "bbb".to_string(),
+                    title: "also on base".to_string(),
+                    reasons: vec![ImmutableReason::BaseAncestor {
+                        base_ref: "origin/main".to_string(),
+                    }],
+                },
+                ImmutableEntry {
+                    position: 3,
+                    short_sha: "ccc".to_string(),
+                    title: "upper merged".to_string(),
+                    reasons: vec![ImmutableReason::MergedPr { number: Some(11) }],
+                },
+            ],
+        };
+        let filtered = report.without_bottom_merged_prs();
+        // #1 (merged, in prefix) → dropped
+        // #2 (base-ancestor only, in prefix, not MergedPr) → kept
+        // #3 (merged, in prefix) → dropped
+        assert_eq!(filtered.entries.len(), 1);
+        assert_eq!(filtered.entries[0].position, 2);
     }
 
     #[test]

--- a/crates/gg-core/src/immutability.rs
+++ b/crates/gg-core/src/immutability.rs
@@ -114,26 +114,33 @@ impl ImmutabilityReport {
         }
     }
 
-    /// Remove `MergedPr` entries from the contiguous immutable prefix at the
-    /// bottom of the stack.
+    /// Remove the contiguous run of `MergedPr` entries from the very bottom
+    /// of the stack (starting at position 1).
     ///
-    /// In stacked workflows, only the bottom PR targets `origin/<base>`
-    /// directly; upper PRs target the previous entry's branch. When PRs are
-    /// landed bottom-up, each subsequent PR gets retargeted to the base, so a
-    /// contiguous run of immutable entries from position 1 all had their
-    /// content merged into the base. Above a gap (a mutable commit), merged
-    /// PRs may still target a parent branch whose content isn't on
-    /// `origin/<base>`, so we keep those in the report.
+    /// In stacked workflows PRs are landed bottom-up: #1 merges into the
+    /// base, #2 gets retargeted to the base and merges next, etc. A
+    /// contiguous run of merged PRs from position 1 therefore all had their
+    /// content land on `origin/<base>`, and `git rebase` drops them via
+    /// patch-id matching.
+    ///
+    /// The run stops at the first position that either (a) is missing from
+    /// the report, or (b) does not carry a `MergedPr` reason. Entries above
+    /// the break may target a parent branch whose content isn't on the base,
+    /// so they stay in the report.
     ///
     /// This covers squash-merged PRs whose local SHA isn't an ancestor of
     /// `origin/<base>` — the case that [`without_base_ancestors`] cannot
     /// catch.
     pub fn without_bottom_merged_prs(self) -> Self {
-        // Find the contiguous immutable prefix from position 1.
-        let mut max_contiguous_pos: usize = 0;
+        // Find the contiguous run of MergedPr entries from position 1.
+        let mut max_merged_pos: usize = 0;
         for entry in &self.entries {
-            if entry.position == max_contiguous_pos + 1 {
-                max_contiguous_pos = entry.position;
+            let is_merged = entry
+                .reasons
+                .iter()
+                .any(|r| matches!(r, ImmutableReason::MergedPr { .. }));
+            if is_merged && entry.position == max_merged_pos + 1 {
+                max_merged_pos = entry.position;
             } else {
                 break;
             }
@@ -143,14 +150,7 @@ impl ImmutabilityReport {
             entries: self
                 .entries
                 .into_iter()
-                .filter(|e| {
-                    let dominated = e.position <= max_contiguous_pos;
-                    let is_merged = e
-                        .reasons
-                        .iter()
-                        .any(|r| matches!(r, ImmutableReason::MergedPr { .. }));
-                    !(dominated && is_merged)
-                })
+                .filter(|e| e.position > max_merged_pos)
                 .collect(),
         }
     }
@@ -686,9 +686,10 @@ mod tests {
     }
 
     #[test]
-    fn without_bottom_merged_prs_contiguous_prefix() {
-        // Stack: #1 merged, #2 base-ancestor, #3 merged (after gap in immutables at #2's position).
-        // Positions 1 and 2 form contiguous prefix. #3 is also contiguous.
+    fn without_bottom_merged_prs_stops_at_non_merged() {
+        // Stack: #1 merged, #2 base-ancestor only, #3 merged.
+        // The MergedPr run is [#1]. #2 breaks the run (no MergedPr reason).
+        // #3 is above the break → kept.
         let report = ImmutabilityReport {
             entries: vec![
                 ImmutableEntry {
@@ -714,11 +715,36 @@ mod tests {
             ],
         };
         let filtered = report.without_bottom_merged_prs();
-        // #1 (merged, in prefix) → dropped
-        // #2 (base-ancestor only, in prefix, not MergedPr) → kept
-        // #3 (merged, in prefix) → dropped
-        assert_eq!(filtered.entries.len(), 1);
+        // #1 (merged, in run) → dropped
+        // #2 (base-ancestor only, breaks run) → kept
+        // #3 (merged, above break) → kept
+        assert_eq!(filtered.entries.len(), 2);
         assert_eq!(filtered.entries[0].position, 2);
+        assert_eq!(filtered.entries[1].position, 3);
+    }
+
+    #[test]
+    fn without_bottom_merged_prs_contiguous_merged_run() {
+        // Stack: #1 merged, #2 merged, #3 mutable (not in report).
+        // Both #1 and #2 form a contiguous MergedPr run → both dropped.
+        let report = ImmutabilityReport {
+            entries: vec![
+                ImmutableEntry {
+                    position: 1,
+                    short_sha: "aaa".to_string(),
+                    title: "bottom merged".to_string(),
+                    reasons: vec![ImmutableReason::MergedPr { number: Some(10) }],
+                },
+                ImmutableEntry {
+                    position: 2,
+                    short_sha: "bbb".to_string(),
+                    title: "also merged".to_string(),
+                    reasons: vec![ImmutableReason::MergedPr { number: Some(11) }],
+                },
+            ],
+        };
+        let filtered = report.without_bottom_merged_prs();
+        assert!(filtered.is_clear());
     }
 
     #[test]

--- a/crates/gg-core/src/immutability.rs
+++ b/crates/gg-core/src/immutability.rs
@@ -114,6 +114,28 @@ impl ImmutabilityReport {
         }
     }
 
+    /// Remove entries that have a `MergedPr` reason.
+    ///
+    /// During `gg rebase`, commits whose PR/MR is already merged are safe to
+    /// include in the rebase: `git rebase` detects that the patch content is
+    /// already applied on the target branch (via patch-id matching) and drops
+    /// them automatically. This covers squash-merged PRs whose local SHA
+    /// isn't an ancestor of `origin/<base>` — the case that
+    /// [`without_base_ancestors`] cannot catch.
+    pub fn without_merged_prs(self) -> Self {
+        Self {
+            entries: self
+                .entries
+                .into_iter()
+                .filter(|e| {
+                    !e.reasons
+                        .iter()
+                        .any(|r| matches!(r, ImmutableReason::MergedPr { .. }))
+                })
+                .collect(),
+        }
+    }
+
     /// Format the report as a multi-line string suitable for error messages.
     pub fn format_for_error(&self) -> String {
         let mut out = String::new();
@@ -576,6 +598,55 @@ mod tests {
             }],
         };
         let filtered = report.without_base_ancestors();
+        assert!(filtered.is_clear());
+    }
+
+    #[test]
+    fn without_merged_prs_drops_merged_only_entries() {
+        let report = ImmutabilityReport {
+            entries: vec![ImmutableEntry {
+                position: 1,
+                short_sha: "aaa".to_string(),
+                title: "squash-merged".to_string(),
+                reasons: vec![ImmutableReason::MergedPr { number: Some(42) }],
+            }],
+        };
+        let filtered = report.without_merged_prs();
+        assert!(filtered.is_clear());
+    }
+
+    #[test]
+    fn without_merged_prs_keeps_base_ancestor_only_entries() {
+        let report = ImmutabilityReport {
+            entries: vec![ImmutableEntry {
+                position: 1,
+                short_sha: "aaa".to_string(),
+                title: "on base".to_string(),
+                reasons: vec![ImmutableReason::BaseAncestor {
+                    base_ref: "origin/main".to_string(),
+                }],
+            }],
+        };
+        let filtered = report.without_merged_prs();
+        assert_eq!(filtered.entries.len(), 1);
+    }
+
+    #[test]
+    fn without_merged_prs_drops_dual_reason_entries() {
+        let report = ImmutabilityReport {
+            entries: vec![ImmutableEntry {
+                position: 1,
+                short_sha: "aaa".to_string(),
+                title: "merged and on base".to_string(),
+                reasons: vec![
+                    ImmutableReason::MergedPr { number: Some(10) },
+                    ImmutableReason::BaseAncestor {
+                        base_ref: "origin/main".to_string(),
+                    },
+                ],
+            }],
+        };
+        let filtered = report.without_merged_prs();
         assert!(filtered.is_clear());
     }
 

--- a/crates/gg-core/tests/immutability_integration.rs
+++ b/crates/gg-core/tests/immutability_integration.rs
@@ -297,7 +297,7 @@ fn rebase_guard_passes_when_only_immutable_is_base_ancestor() {
 fn rebase_guard_passes_squash_merged_not_on_base() {
     // A squash-merged PR whose SHA is NOT on origin/main should pass during
     // rebase: git rebase drops it via patch-id matching. The
-    // without_merged_prs() filter removes it.
+    // without_bottom_merged_prs() filter removes it.
     let temp = tempfile::tempdir().unwrap();
     let (repo, oids, _) = make_linear_stack(&temp, 2, 0);
     // origin/main at base commit — no stack commits are ancestors.
@@ -322,11 +322,11 @@ fn rebase_guard_passes_squash_merged_not_on_base() {
         "squash-merged entry must survive without_base_ancestors filtering"
     );
 
-    // But without_merged_prs DOES remove it — safe for rebase.
-    let filtered = filtered.without_merged_prs();
+    // But without_bottom_merged_prs DOES remove it (position 1, contiguous prefix).
+    let filtered = filtered.without_bottom_merged_prs();
     assert!(
         filtered.is_clear(),
-        "squash-merged entry should be removed by without_merged_prs"
+        "squash-merged entry at bottom should be removed by without_bottom_merged_prs"
     );
 
     // Guard passes without --force.
@@ -336,7 +336,7 @@ fn rebase_guard_passes_squash_merged_not_on_base() {
 #[test]
 fn squash_merged_still_blocks_non_rebase_commands() {
     // Squash-merged entries must still block non-rebase commands (squash,
-    // reorder, drop, etc.) that don't apply without_merged_prs().
+    // reorder, drop, etc.) that don't apply without_bottom_merged_prs().
     let temp = tempfile::tempdir().unwrap();
     let (repo, oids, _) = make_linear_stack(&temp, 2, 0);
 

--- a/crates/gg-core/tests/immutability_integration.rs
+++ b/crates/gg-core/tests/immutability_integration.rs
@@ -294,9 +294,10 @@ fn rebase_guard_passes_when_only_immutable_is_base_ancestor() {
 }
 
 #[test]
-fn rebase_guard_still_blocks_squash_merged_not_on_base() {
-    // A squash-merged PR whose SHA is NOT on origin/main must still block.
-    // This is the case without_base_ancestors() must preserve.
+fn rebase_guard_passes_squash_merged_not_on_base() {
+    // A squash-merged PR whose SHA is NOT on origin/main should pass during
+    // rebase: git rebase drops it via patch-id matching. The
+    // without_merged_prs() filter removes it.
     let temp = tempfile::tempdir().unwrap();
     let (repo, oids, _) = make_linear_stack(&temp, 2, 0);
     // origin/main at base commit — no stack commits are ancestors.
@@ -313,16 +314,40 @@ fn rebase_guard_still_blocks_squash_merged_not_on_base() {
         ImmutableReason::MergedPr { .. }
     ));
 
-    // Filtering should NOT remove this entry (no BaseAncestor reason).
+    // without_base_ancestors does NOT remove this entry (no BaseAncestor reason).
     let filtered = report.without_base_ancestors();
     assert_eq!(
         filtered.entries.len(),
         1,
-        "squash-merged entry must survive filtering"
+        "squash-merged entry must survive without_base_ancestors filtering"
     );
 
-    // Guard rejects without --force.
-    assert!(guard(filtered, false).is_err());
+    // But without_merged_prs DOES remove it — safe for rebase.
+    let filtered = filtered.without_merged_prs();
+    assert!(
+        filtered.is_clear(),
+        "squash-merged entry should be removed by without_merged_prs"
+    );
+
+    // Guard passes without --force.
+    assert!(guard(filtered, false).is_ok());
+}
+
+#[test]
+fn squash_merged_still_blocks_non_rebase_commands() {
+    // Squash-merged entries must still block non-rebase commands (squash,
+    // reorder, drop, etc.) that don't apply without_merged_prs().
+    let temp = tempfile::tempdir().unwrap();
+    let (repo, oids, _) = make_linear_stack(&temp, 2, 0);
+
+    let stack = build_stack(&oids, &[Some(PrState::Merged), None]);
+    let policy = ImmutabilityPolicy::for_stack(&repo, &stack).unwrap();
+
+    let report = policy.check_all(&stack);
+    assert_eq!(report.entries.len(), 1);
+
+    // Guard rejects without --force (simulates non-rebase command path).
+    assert!(guard(report, false).is_err());
 }
 
 #[test]

--- a/docs/src/commands/rebase.md
+++ b/docs/src/commands/rebase.md
@@ -11,11 +11,10 @@ gg rebase [TARGET]
 ## Options
 
 - `-f, --force` (alias `--ignore-immutable`): Override the immutability guard.
-  Rebase rewrites the parent of every commit in the stack; if any commit is
-  merged (via squash-merge), gg refuses by default to avoid producing local
-  duplicates of upstream history. Commits already reachable from
-  `origin/<base>` are silently skipped — `git rebase` drops them automatically,
-  so `--force` is not required. See
+  Rebase rewrites the parent of every commit in the stack; merged commits
+  (including squash-merged PRs) and commits already reachable from
+  `origin/<base>` are silently skipped — `git rebase` drops them automatically
+  via patch-id matching, so `--force` is not required for these. See
   [Core concepts · Immutable commits](../core-concepts.md#immutable-commits).
 
 ## Examples

--- a/docs/src/core-concepts.md
+++ b/docs/src/core-concepts.md
@@ -71,10 +71,12 @@ refuse to touch the following by default:
   local commit.
 - **Base-ancestor commits.** Any commit already reachable from `origin/<base>`
   via plain merge or rebase falls in the same bucket. When no `origin/<base>`
-  ref exists, gg falls back to the local base branch. **Exception:** `gg rebase`
-  silently skips base-ancestor commits instead of blocking, because `git rebase`
-  naturally drops them. An info line (`→ Skipping N merged commit(s) already on
-  <base>`) is printed when this happens.
+  ref exists, gg falls back to the local base branch.
+
+**Exception:** `gg rebase` silently skips both merged-PR commits and
+base-ancestor commits instead of blocking, because `git rebase` naturally drops
+them via patch-id matching. An info line (`→ Skipping N merged commit(s) already
+on <base>`) is printed when this happens.
 
 Running one of those commands on an immutable target prints a clear error like:
 

--- a/skills/gg/SKILL.md
+++ b/skills/gg/SKILL.md
@@ -251,7 +251,7 @@ gg refuses by default to rewrite commits that look "already published":
   a fallback).
 
 The guard protects `gg sc`, `gg absorb`, `gg reorder` / `gg arrange`,
-`gg split`, `gg drop`, `gg rebase`, and `gg restack`. `gg rebase` is a special case: commits already reachable from the refreshed base are silently skipped because `git rebase` would drop them naturally instead of rewriting them. For the remaining commands, or for non-base-ancestor immutable commits during `gg rebase`, the command exits with an `ImmutableTargets` error listing every affected position, short SHA, title, and reason (e.g. `merged as !123`, `already in origin/main`).
+`gg split`, `gg drop`, `gg rebase`, and `gg restack`. `gg rebase` is a special case: merged commits (both base-ancestor commits and squash-merged PRs) are silently skipped because `git rebase` would drop them naturally via patch-id matching instead of rewriting them. For the remaining commands the command exits with an `ImmutableTargets` error listing every affected position, short SHA, title, and reason (e.g. `merged as !123`, `already in origin/main`).
 
 To bypass it intentionally, pass `-f` / `--force` (long alias
 `--ignore-immutable`). Always surface the listed commits and reasons to the

--- a/skills/gg/reference.md
+++ b/skills/gg/reference.md
@@ -667,11 +667,10 @@ Notes for agents:
 
 - Before offering `--force`, surface the guard output to the user and get
   explicit confirmation — bypassing is a footgun.
-- `gg rebase` silently skips base-ancestor commits (printing
-  `→ Skipping N merged commit(s) already on <base>`) instead of blocking,
-  because `git rebase` naturally drops patches already applied upstream.
-  The guard still blocks squash-merged PRs (`MergedPr` reason without
-  `BaseAncestor`) since those would be replayed as duplicates.
+- `gg rebase` silently skips merged commits — both base-ancestor commits and
+  squash-merged PRs (printing `→ Skipping N merged commit(s) already on <base>`)
+  — because `git rebase` naturally drops patches already applied upstream via
+  patch-id matching.
 - `gg sync`'s internal auto-rebase only considers a commit a
   base ancestor **after** the remote ref is fetched, so the guard reflects
   freshly-updated state rather than stale local refs.


### PR DESCRIPTION
## Summary

- `gg rebase` blocked with "cannot rewrite immutable commits" when the stack contained squash-merged commits, even though `git rebase` would naturally drop them via patch-id matching
- Root cause: squash-merged PRs create a new SHA on `origin/<base>`, so the `BaseAncestor` rule doesn't fire — only `MergedPr` does, and `without_base_ancestors()` doesn't filter `MergedPr`-only entries
- Added `without_merged_prs()` filter to `ImmutabilityReport` and apply it in `gg rebase` when rebasing onto the stack's base branch. Other rewrite commands (squash, reorder, drop) still block on merged commits as before.
- Updated docs, skills, and core-concepts to reflect the new behavior

## Test plan

- [x] Added unit tests for `without_merged_prs()` (drops merged-only, keeps base-ancestor-only, drops dual-reason)
- [x] Updated integration test `rebase_guard_passes_squash_merged_not_on_base` — verifies the fix
- [x] Added integration test `squash_merged_still_blocks_non_rebase_commands` — ensures other commands aren't affected
- [x] All 54 immutability + rebase tests pass
- [x] Clippy clean, fmt clean