### PR TITLE
fix: detect provider defaults from remote host

### DIFF
--- a/crates/gg-core/src/commands/setup.rs
+++ b/crates/gg-core/src/commands/setup.rs
@@ -300,13 +300,10 @@ fn prompt_provider(
         .and_then(|r| r.url().map(|s| s.to_string()));
 
     let detected_default = remote_url.as_ref().and_then(|url| {
-        if url.contains("github.com") {
-            Some(0usize) // GitHub
-        } else if url.to_lowercase().contains("gitlab") {
-            Some(1usize) // GitLab (any domain containing "gitlab")
-        } else {
-            None
-        }
+        git::detect_remote_provider_from_url(url).map(|provider| match provider {
+            git::RemoteProvider::GitHub => 0usize,
+            git::RemoteProvider::GitLab => 1usize,
+        })
     });
 
     let providers = &["GitHub", "GitLab"];

--- a/crates/gg-core/src/git.rs
+++ b/crates/gg-core/src/git.rs
@@ -2232,11 +2232,50 @@ mod tests {
 }
 
 /// Remote provider type
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(dead_code)]
 pub enum RemoteProvider {
     GitHub,
     GitLab,
+}
+
+/// Detect the remote provider based on a remote URL
+#[allow(dead_code)]
+pub fn detect_remote_provider_from_url(url: &str) -> Option<RemoteProvider> {
+    match remote_url_host(url)?.to_ascii_lowercase().as_str() {
+        "github.com" => Some(RemoteProvider::GitHub),
+        "gitlab.com" => Some(RemoteProvider::GitLab),
+        _ => None,
+    }
+}
+
+fn remote_url_host(url: &str) -> Option<&str> {
+    let url = url.trim();
+    if url.is_empty() {
+        return None;
+    }
+
+    let authority = if let Some((_, rest)) = url.split_once("://") {
+        rest.split(['/', '?', '#']).next()?
+    } else if let Some((authority, _)) = url.split_once(':') {
+        authority
+    } else if url.contains('@') {
+        url.split('/').next()?
+    } else {
+        return None;
+    };
+
+    let host_with_port = authority.rsplit('@').next()?;
+    let host = host_with_port
+        .strip_prefix('[')
+        .and_then(|host| host.split_once(']').map(|(host, _)| host))
+        .unwrap_or_else(|| host_with_port.split(':').next().unwrap_or(host_with_port));
+
+    if host.is_empty() {
+        None
+    } else {
+        Some(host)
+    }
 }
 
 /// Detect the remote provider based on the remote URL
@@ -2250,15 +2289,67 @@ pub fn detect_remote_provider(repo: &Repository) -> Result<RemoteProvider> {
         .url()
         .ok_or_else(|| GgError::Other("Origin remote has no URL".to_string()))?;
 
-    if url.contains("github.com") {
-        Ok(RemoteProvider::GitHub)
-    } else if url.contains("gitlab.com") {
-        Ok(RemoteProvider::GitLab)
-    } else {
-        // Default to GitLab for self-hosted instances
-        Err(GgError::Other(format!(
+    detect_remote_provider_from_url(url).ok_or_else(|| {
+        GgError::Other(format!(
             "Could not detect remote provider from URL: {}. Supported: github.com, gitlab.com",
             url
-        )))
+        ))
+    })
+}
+
+#[cfg(test)]
+mod remote_provider_tests {
+    use super::{detect_remote_provider_from_url, RemoteProvider};
+
+    #[test]
+    fn detects_github_remotes() {
+        for url in [
+            "git@github.com:mrmans0n/zjctl.git",
+            "https://github.com/user/repo.git",
+            "ssh://git@github.com/user/repo.git",
+            "git@github.com/user/repo.git",
+            "https://github.com:443/user/repo.git",
+            "GIT@GITHUB.COM:user/repo.git",
+        ] {
+            assert_eq!(
+                detect_remote_provider_from_url(url),
+                Some(RemoteProvider::GitHub),
+                "url: {url}"
+            );
+        }
+    }
+
+    #[test]
+    fn detects_gitlab_remotes() {
+        for url in [
+            "git@gitlab.com:user/repo.git",
+            "https://gitlab.com/user/repo.git",
+            "ssh://git@gitlab.com/user/repo.git",
+            "git@gitlab.com/user/repo.git",
+            "https://gitlab.com:443/user/repo.git",
+            "GIT@GITLAB.COM:user/repo.git",
+        ] {
+            assert_eq!(
+                detect_remote_provider_from_url(url),
+                Some(RemoteProvider::GitLab),
+                "url: {url}"
+            );
+        }
+    }
+
+    #[test]
+    fn ignores_unknown_self_hosted_and_false_positive_remotes() {
+        for url in [
+            "git@custom-host.com:user/repo.git",
+            "https://example.com/user/repo.git",
+            "git@gitlab.mycompany.com:user/repo.git",
+            "https://github.enterprise.local/org/repo.git",
+            "git@notgithub.com:user/repo.git",
+            "https://example.com/github.com/user/repo.git",
+            "https://gitlab.com.example.com/user/repo.git",
+            "",
+        ] {
+            assert_eq!(detect_remote_provider_from_url(url), None, "url: {url}");
+        }
     }
 }

--- a/docs/src/commands/setup.md
+++ b/docs/src/commands/setup.md
@@ -35,7 +35,7 @@ Full mode organizes all settings into logical groups:
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `provider` | select | auto-detect | GitHub or GitLab |
+| `provider` | select | auto-detect | GitHub or GitLab (auto-detects `github.com` and `gitlab.com` remotes; self-hosted instances require manual selection) |
 | `base` | string | auto-detect | Default base branch (main/master/trunk) |
 | `branch_username` | string | from CLI auth | Username for branch naming |
 | `unstaged_action` | select | ask | Action for `gg amend` with unstaged changes |


### PR DESCRIPTION
## Summary

- Fixes `gg setup` incorrectly defaulting to GitLab for GitHub SSH remotes like `git@github.com:user/repo.git`
- Extracts a shared `detect_remote_provider_from_url()` helper so both `gg setup` and runtime `Provider::detect()` use the same URL matching logic
- Uses host-aware matching instead of substring `contains()`, preventing false positives from domains like `notgithub.com`

## Root cause

Setup and runtime had duplicated provider-detection logic that drifted: setup used `url.to_lowercase().contains("gitlab")` (matching any domain with "gitlab"), while runtime checked `url.contains("gitlab.com")`. The shared helper now matches only exact `github.com` / `gitlab.com` hosts.

## Behavioral change

Self-hosted GitLab domains (e.g. `gitlab.mycompany.com`) previously auto-selected GitLab in `gg setup` due to broad `contains("gitlab")` matching. They now return `None`, requiring manual selection. This aligns with documented behavior that self-hosted instances need manual setup.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo test -p gg-core remote_provider` — all new tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test --all-features` — full suite passes

Test coverage includes: GitHub SSH/HTTPS/ssh-url, GitLab equivalents, ports, uppercase hostnames, self-hosted domains, false positives (`notgithub.com`, path-based matches), and empty strings.

Closes #538