### PR TITLE
fix(inbox): use provider-specific PR/MR labels

### DIFF
--- a/crates/gg-cli/tests/integration_tests.rs
+++ b/crates/gg-cli/tests/integration_tests.rs
@@ -422,6 +422,68 @@ fn test_gg_inbox_json_handles_same_stack_name_across_usernames() {
     }
 }
 
+fn create_repo_with_inbox_item(provider: &str, mr_number: u64) -> (TempDir, PathBuf) {
+    let (temp_dir, repo_path) = create_test_repo();
+
+    run_git(&repo_path, &["checkout", "-b", "testuser/inbox-copy"]);
+    fs::write(repo_path.join("inbox.txt"), "inbox item").expect("Failed to write inbox file");
+    run_git(&repo_path, &["add", "."]);
+    run_git(
+        &repo_path,
+        &["commit", "-m", "Inbox item\n\nGG-ID: c-abc1234"],
+    );
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        format!(
+            r#"{{"defaults":{{"branch_username":"testuser","provider":"{provider}"}},"stacks":{{"inbox-copy":{{"base":"main","mrs":{{"c-abc1234":{mr_number}}}}}}}}}"#
+        ),
+    )
+    .expect("Failed to write config");
+
+    (temp_dir, repo_path)
+}
+
+#[test]
+fn test_gg_inbox_human_uses_gitlab_mr_label() {
+    let (_temp_dir, repo_path) = create_repo_with_inbox_item("gitlab", 42);
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["inbox"]);
+    assert!(success, "gg inbox failed: {}", stderr);
+
+    assert!(
+        stderr.contains("Refreshing MR status"),
+        "stderr should use MR wording for GitLab, got: {stderr}"
+    );
+    assert!(
+        stdout.contains("MR !42"),
+        "stdout should use MR !number for GitLab, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("PR #42"),
+        "stdout should not use GitHub PR wording for GitLab, got: {stdout}"
+    );
+}
+
+#[test]
+fn test_gg_inbox_human_uses_github_pr_label() {
+    let (_temp_dir, repo_path) = create_repo_with_inbox_item("github", 43);
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["inbox"]);
+    assert!(success, "gg inbox failed: {}", stderr);
+
+    assert!(
+        stderr.contains("Refreshing PR status"),
+        "stderr should use PR wording for GitHub, got: {stderr}"
+    );
+    assert!(
+        stdout.contains("PR #43"),
+        "stdout should use PR #number for GitHub, got: {stdout}"
+    );
+}
+
 #[test]
 fn test_gg_clean_json_requires_all() {
     let (_temp_dir, repo_path) = create_test_repo();

--- a/crates/gg-core/src/commands/inbox.rs
+++ b/crates/gg-core/src/commands/inbox.rs
@@ -42,7 +42,7 @@ pub struct BucketInput {
     pub behind_base: bool,
 }
 
-/// Classify a PR into an action bucket.
+/// Classify a PR/MR into an action bucket.
 ///
 /// Priority order (first match wins):
 /// 1. Merged → Merged
@@ -131,7 +131,7 @@ struct StackLoadError {
     error: String,
 }
 
-/// Internal item representing one triaged PR.
+/// Internal item representing one triaged PR/MR.
 struct InboxItem {
     stack_name: String,
     position: usize,
@@ -139,6 +139,8 @@ struct InboxItem {
     title: String,
     mr_number: u64,
     mr_url: String,
+    mr_label: &'static str,
+    mr_number_prefix: &'static str,
     bucket: ActionBucket,
     ci_status: Option<CiStatus>,
     behind_base: Option<usize>,
@@ -243,8 +245,17 @@ pub fn run(all: bool, json: bool) -> Result<()> {
         return Ok(());
     }
 
+    let detected_provider = Provider::detect(&repo).ok();
+    let mr_label = detected_provider
+        .as_ref()
+        .map(Provider::pr_label)
+        .unwrap_or("PR/MR");
+
     if !json {
-        eprint!("{}", style("Refreshing PR status...").dim());
+        eprint!(
+            "{}",
+            style(format!("Refreshing {mr_label} status...")).dim()
+        );
     }
 
     let mut items: Vec<InboxItem> = Vec::new();
@@ -283,12 +294,12 @@ pub fn run(all: bool, json: bool) -> Result<()> {
         }
 
         let provider = if entries.iter().any(|entry| entry.mr_number.is_some()) {
-            Provider::detect(&repo).ok()
+            detected_provider
         } else {
             None
         };
 
-        // Refresh MR info from provider and cache URLs (T9 optimization)
+        // Refresh PR/MR info from provider and cache URLs (T9 optimization)
         let mut mr_urls: HashMap<u64, String> = HashMap::new();
         for entry in &mut entries {
             if let (Some(pr_num), Some(provider)) = (entry.mr_number, provider) {
@@ -318,7 +329,7 @@ pub fn run(all: bool, json: bool) -> Result<()> {
                 .ok()
                 .filter(|&b| b > 0);
 
-        // Bucket each entry with a PR
+        // Bucket each entry with a PR/MR
         for entry in &entries {
             if let Some(mr_num) = entry.mr_number {
                 let mr_url = mr_urls.get(&mr_num).cloned().unwrap_or_default();
@@ -345,6 +356,11 @@ pub fn run(all: bool, json: bool) -> Result<()> {
                         title: entry.title.clone(),
                         mr_number: mr_num,
                         mr_url,
+                        mr_label: provider.as_ref().map(Provider::pr_label).unwrap_or("PR/MR"),
+                        mr_number_prefix: provider
+                            .as_ref()
+                            .map(Provider::pr_number_prefix)
+                            .unwrap_or("#"),
                         bucket: b,
                         ci_status: entry.ci_status.clone(),
                         behind_base: behind,
@@ -436,11 +452,13 @@ fn print_human_output(items: &[InboxItem], stack_errors: &[StackLoadError]) {
             };
 
             println!(
-                "  {} {}  {}  {}  PR #{}{}",
+                "  {} {}  {}  {}  {} {}{}{}",
                 style(format!("{} #{}", item.stack_name, item.position)).dim(),
                 style(&item.short_sha).dim(),
                 item.title,
                 style(format!("stack/{}", item.stack_name)).cyan(),
+                item.mr_label,
+                item.mr_number_prefix,
                 item.mr_number,
                 ci_icon,
             );

--- a/docs/src/commands/inbox.md
+++ b/docs/src/commands/inbox.md
@@ -37,6 +37,10 @@ gg inbox --json
 
 ## Example human output
 
+The labels and number prefixes adapt to the detected provider.
+
+**GitHub:**
+
 ```text
 Inbox (3 items across 2 stacks)
 
@@ -48,6 +52,18 @@ Blocked on CI (1):
 
 Awaiting review (1):
   billing #1  9876abc  Add invoice export  stack/billing  PR #51
+```
+
+**GitLab:**
+
+```text
+Inbox (2 items across 1 stack)
+
+Ready to land (1):
+  auth #2  abc1234  Add login button  stack/auth  MR !41
+
+Awaiting review (1):
+  auth #3  def5678  Add login API  stack/auth  MR !42
 ```
 
 ## JSON

--- a/skills/gg/reference.md
+++ b/skills/gg/reference.md
@@ -77,6 +77,7 @@ badges). Stack-scoped — use `gg ls --all` for cross-stack browsing.
 
 #### `gg inbox [OPTIONS]`
 Cross-stack actionable triage view for local stacks.
+Output adapts to the detected provider: `PR #n` for GitHub, `MR !n` for GitLab.
 
 - `-a, --all` — include merged items too
 - `--json` — emit `InboxResponse` with bucketed entries


### PR DESCRIPTION
## Summary

- `gg inbox` now shows **PR #n** for GitHub and **MR !n** for GitLab, instead of always showing `PR #n`
- Refresh status message also adapts to the provider
- Updated docs and skills reference to reflect provider-specific output

## Test plan

- [x] Integration tests for both GitHub and GitLab provider output
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p gg-core inbox`
- [x] `cargo test -p gg-cli test_gg_inbox`

🤖 Generated with [Claude Code](https://claude.com/claude-code)