### PR TITLE
feat(unstack): add worktree support via --wt/--worktree

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ gg clean
 
 ## Worktree Support
 
-`gg co` supports managed Git worktrees so you can develop a stack in its own checkout while keeping your original repository working tree untouched.
+`gg co` and `gg unstack --wt` support managed Git worktrees so you can develop a stack in its own checkout while keeping your original repository working tree untouched.
 
 ### Create a stack worktree
 
@@ -100,6 +100,14 @@ gg co my-feature --worktree
 ```
 
 This creates (or reuses) a managed worktree for the stack and checks it out there.
+
+### Unstack into a worktree
+
+```bash
+gg unstack --target 3 --name upper-feature --wt
+```
+
+This keeps your current directory on the lower stack and creates or reuses a managed worktree for the new upper stack.
 
 ### Default worktree location
 
@@ -296,7 +304,7 @@ All configuration options are in the `defaults` section (with provider-specific 
 | `sync_auto_rebase` (`sync.auto_rebase`) | `boolean` | Automatically run `gg rebase` before `gg sync` when base is behind threshold | `false` |
 | `sync_behind_threshold` (`sync.behind_threshold`) | `number` | Warn/rebase in `gg sync` when base is at least this many commits behind `origin/<base>` (`0` disables check) | `1` |
 | `stack_nav_comments` | `boolean` | **Stack navigation comments** — opt-in. Each PR/MR in a stack gets a managed comment listing sibling PRs with a 👉 marker on the current one (GitHub `#N` or GitLab `!N`). | `false` |
-| `worktree_base_path` | `string` | Base directory used by `gg co --wt` / `--worktree` for managed stack worktrees | Parent directory of current repository |
+| `worktree_base_path` | `string` | Base directory used by `gg co --wt` / `--worktree` and `gg unstack --wt` / `--worktree` for managed stack worktrees | Parent directory of current repository |
 | `gitlab.auto_merge_on_land` | `boolean` | *(GitLab only)* Use "merge when pipeline succeeds" for `gg land` by default | `false` |
 
 Example configuration:

--- a/crates/gg-cli/src/main.rs
+++ b/crates/gg-cli/src/main.rs
@@ -237,6 +237,10 @@ enum Commands {
         /// Output as JSON
         #[arg(long)]
         json: bool,
+
+        /// Create or reuse a managed worktree for the new stack
+        #[arg(long = "worktree", short = 'w', alias = "wt")]
+        worktree: bool,
     },
 
     /// Land (merge) approved PRs/MRs starting from the first commit
@@ -602,6 +606,7 @@ fn main() {
             no_tui,
             force,
             json,
+            worktree,
         }) => (
             gg_core::commands::unstack::run(gg_core::commands::unstack::UnstackOptions {
                 target,
@@ -609,6 +614,7 @@ fn main() {
                 no_tui,
                 force,
                 json,
+                worktree,
             }),
             json,
         ),

--- a/crates/gg-cli/tests/integration_tests.rs
+++ b/crates/gg-cli/tests/integration_tests.rs
@@ -5650,6 +5650,239 @@ fn test_gg_ls_marks_stacks_with_worktree_indicator() {
 }
 
 #[test]
+fn test_gg_unstack_worktree_creates_new_stack_worktree_and_preserves_current_branch() {
+    let (_temp_dir, repo_path) = create_test_repo_with_worktree_support();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser","base":"main"}}"#,
+    )
+    .expect("Failed to write config");
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["co", "lower"]);
+    assert!(
+        success,
+        "checkout should succeed: stdout={}, stderr={}",
+        stdout, stderr
+    );
+
+    for i in 1..=4 {
+        fs::write(
+            repo_path.join(format!("file{i}.txt")),
+            format!("commit {i}\n"),
+        )
+        .expect("Failed to write test file");
+        run_git(&repo_path, &["add", "."]);
+        let (success, _) = run_git(&repo_path, &["commit", "-m", &format!("commit {i}")]);
+        assert!(success, "commit {i} should succeed");
+    }
+
+    let (success, stdout, stderr) = run_gg(
+        &repo_path,
+        &["unstack", "-t", "3", "--name", "upper", "--worktree"],
+    );
+    assert!(
+        success,
+        "unstack --worktree should succeed: stdout={}, stderr={}",
+        stdout, stderr
+    );
+
+    let (_, current_branch) = run_git(&repo_path, &["branch", "--show-current"]);
+    assert_eq!(current_branch.trim(), "testuser/lower");
+
+    let (_, lower_log) = run_git(&repo_path, &["log", "--format=%s", "main..HEAD"]);
+    assert!(lower_log.contains("commit 1"), "lower log: {lower_log}");
+    assert!(lower_log.contains("commit 2"), "lower log: {lower_log}");
+    assert!(!lower_log.contains("commit 3"), "lower log: {lower_log}");
+    assert!(!lower_log.contains("commit 4"), "lower log: {lower_log}");
+
+    let expected_path = repo_path.parent().expect("repo parent").join(format!(
+        "{}.{}",
+        repo_path.file_name().unwrap().to_string_lossy(),
+        "upper"
+    ));
+    assert!(
+        expected_path.exists(),
+        "Expected worktree path to exist: {}",
+        expected_path.display()
+    );
+
+    let (_, worktree_branch) = run_git(&expected_path, &["branch", "--show-current"]);
+    assert_eq!(worktree_branch.trim(), "testuser/upper");
+
+    let (_, upper_log) = run_git(&expected_path, &["log", "--format=%s", "main..HEAD"]);
+    assert!(!upper_log.contains("commit 1"), "upper log: {upper_log}");
+    assert!(!upper_log.contains("commit 2"), "upper log: {upper_log}");
+    assert!(upper_log.contains("commit 3"), "upper log: {upper_log}");
+    assert!(upper_log.contains("commit 4"), "upper log: {upper_log}");
+
+    let config: Value =
+        serde_json::from_str(&fs::read_to_string(gg_dir.join("config.json")).unwrap()).unwrap();
+    let worktree_path = config["stacks"]["upper"]["worktree_path"]
+        .as_str()
+        .expect("upper stack should persist worktree_path");
+    assert_eq!(
+        PathBuf::from(worktree_path).canonicalize().unwrap(),
+        expected_path.canonicalize().unwrap()
+    );
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["ls", "--all"]);
+    assert!(success, "ls --all should succeed: {}", stderr);
+    assert!(
+        stdout.contains("upper"),
+        "ls should show upper stack: {stdout}"
+    );
+    assert!(
+        stdout.contains("[wt]"),
+        "ls should show worktree marker: {stdout}"
+    );
+}
+
+#[test]
+fn test_gg_unstack_wt_alias_preserves_existing_old_stack_worktree_metadata() {
+    let (_temp_dir, repo_path) = create_test_repo_with_worktree_support();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser","base":"main"}}"#,
+    )
+    .expect("Failed to write config");
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["co", "old-wt", "--worktree"]);
+    assert!(
+        success,
+        "checkout --worktree should succeed: stdout={}, stderr={}",
+        stdout, stderr
+    );
+
+    let old_worktree_path = repo_path.parent().expect("repo parent").join(format!(
+        "{}.{}",
+        repo_path.file_name().unwrap().to_string_lossy(),
+        "old-wt"
+    ));
+
+    for i in 1..=3 {
+        fs::write(
+            old_worktree_path.join(format!("wt-file{i}.txt")),
+            format!("commit {i}\n"),
+        )
+        .expect("Failed to write test file");
+        run_git(&old_worktree_path, &["add", "."]);
+        let (success, _) = run_git(
+            &old_worktree_path,
+            &["commit", "-m", &format!("wt commit {i}")],
+        );
+        assert!(success, "worktree commit {i} should succeed");
+    }
+
+    let (success, stdout, stderr) = run_gg(
+        &old_worktree_path,
+        &["unstack", "-t", "2", "--name", "new-wt", "--wt"],
+    );
+    assert!(
+        success,
+        "unstack --wt should succeed: stdout={}, stderr={}",
+        stdout, stderr
+    );
+
+    let (_, current_branch) = run_git(&old_worktree_path, &["branch", "--show-current"]);
+    assert_eq!(current_branch.trim(), "testuser/old-wt");
+
+    let config: Value =
+        serde_json::from_str(&fs::read_to_string(gg_dir.join("config.json")).unwrap()).unwrap();
+    let old_config_worktree_path = config["stacks"]["old-wt"]["worktree_path"]
+        .as_str()
+        .expect("old stack should keep worktree_path");
+    assert_eq!(
+        PathBuf::from(old_config_worktree_path)
+            .canonicalize()
+            .unwrap(),
+        old_worktree_path.canonicalize().unwrap()
+    );
+
+    let new_worktree_path = config["stacks"]["new-wt"]["worktree_path"]
+        .as_str()
+        .expect("new stack should persist worktree_path");
+    assert_ne!(
+        PathBuf::from(new_worktree_path).canonicalize().unwrap(),
+        PathBuf::from(old_config_worktree_path)
+            .canonicalize()
+            .unwrap()
+    );
+    assert!(
+        PathBuf::from(new_worktree_path).exists(),
+        "new worktree should exist at {new_worktree_path}"
+    );
+}
+
+#[test]
+fn test_gg_unstack_without_worktree_switches_current_repo_to_new_stack() {
+    let (_temp_dir, repo_path) = create_test_repo_with_worktree_support();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser","base":"main"}}"#,
+    )
+    .expect("Failed to write config");
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["co", "plain-unstack"]);
+    assert!(
+        success,
+        "checkout should succeed: stdout={}, stderr={}",
+        stdout, stderr
+    );
+
+    for i in 1..=3 {
+        fs::write(
+            repo_path.join(format!("plain-file{i}.txt")),
+            format!("commit {i}\n"),
+        )
+        .expect("Failed to write test file");
+        run_git(&repo_path, &["add", "."]);
+        let (success, _) = run_git(&repo_path, &["commit", "-m", &format!("plain commit {i}")]);
+        assert!(success, "commit {i} should succeed");
+    }
+
+    let (success, stdout, stderr) =
+        run_gg(&repo_path, &["unstack", "-t", "2", "--name", "plain-upper"]);
+    assert!(
+        success,
+        "unstack should succeed: stdout={}, stderr={}",
+        stdout, stderr
+    );
+
+    let (_, current_branch) = run_git(&repo_path, &["branch", "--show-current"]);
+    assert_eq!(current_branch.trim(), "testuser/plain-upper");
+
+    let (_, upper_log) = run_git(&repo_path, &["log", "--format=%s", "main..HEAD"]);
+    assert!(
+        !upper_log.contains("plain commit 1"),
+        "upper log: {upper_log}"
+    );
+    assert!(
+        upper_log.contains("plain commit 2"),
+        "upper log: {upper_log}"
+    );
+    assert!(
+        upper_log.contains("plain commit 3"),
+        "upper log: {upper_log}"
+    );
+
+    let config: Value =
+        serde_json::from_str(&fs::read_to_string(gg_dir.join("config.json")).unwrap()).unwrap();
+    assert!(
+        config["stacks"]["plain-upper"]["worktree_path"].is_null(),
+        "plain unstack should not create worktree metadata: {config}"
+    );
+}
+
+#[test]
 fn test_clean_detects_locally_merged_worktree_stack_when_provider_check_fails() {
     let (_parent_dir, repo_path) = create_test_repo_with_worktree_support();
 

--- a/crates/gg-cli/tests/integration_tests.rs
+++ b/crates/gg-cli/tests/integration_tests.rs
@@ -5741,6 +5741,89 @@ fn test_gg_unstack_worktree_creates_new_stack_worktree_and_preserves_current_bra
 }
 
 #[test]
+fn test_gg_unstack_worktree_failure_leaves_original_stack_unchanged() {
+    let (_temp_dir, repo_path) = create_test_repo_with_worktree_support();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser","base":"main"}}"#,
+    )
+    .expect("Failed to write config");
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["co", "rollback-lower"]);
+    assert!(
+        success,
+        "checkout should succeed: stdout={}, stderr={}",
+        stdout, stderr
+    );
+
+    for i in 1..=3 {
+        fs::write(
+            repo_path.join(format!("rollback-file{i}.txt")),
+            format!("commit {i}\n"),
+        )
+        .expect("Failed to write test file");
+        run_git(&repo_path, &["add", "."]);
+        let (success, _) = run_git(
+            &repo_path,
+            &["commit", "-m", &format!("rollback commit {i}")],
+        );
+        assert!(success, "commit {i} should succeed");
+    }
+
+    let before_log = rev_list(&repo_path, "main..testuser/rollback-lower");
+    let blocked_path = repo_path.parent().expect("repo parent").join(format!(
+        "{}.{}",
+        repo_path.file_name().unwrap().to_string_lossy(),
+        "rollback-upper"
+    ));
+    fs::create_dir_all(&blocked_path).expect("Failed to create blocked worktree path");
+    fs::write(blocked_path.join("occupied.txt"), "already here\n")
+        .expect("Failed to occupy blocked worktree path");
+
+    let (success, stdout, stderr) = run_gg(
+        &repo_path,
+        &[
+            "unstack",
+            "-t",
+            "2",
+            "--name",
+            "rollback-upper",
+            "--worktree",
+        ],
+    );
+    assert!(
+        !success,
+        "unstack --worktree should fail when target path exists: stdout={stdout}"
+    );
+    assert!(
+        stderr.contains("Failed to create worktree"),
+        "stderr should report worktree creation failure: {stderr}"
+    );
+
+    let after_log = rev_list(&repo_path, "main..testuser/rollback-lower");
+    assert_eq!(after_log, before_log);
+
+    let (_, current_branch) = run_git(&repo_path, &["branch", "--show-current"]);
+    assert_eq!(current_branch.trim(), "testuser/rollback-lower");
+
+    let (branch_exists, _) = run_git(&repo_path, &["rev-parse", "testuser/rollback-upper"]);
+    assert!(
+        !branch_exists,
+        "temporary new stack branch should be removed after worktree failure"
+    );
+
+    let config: Value =
+        serde_json::from_str(&fs::read_to_string(gg_dir.join("config.json")).unwrap()).unwrap();
+    assert!(
+        config["stacks"]["rollback-upper"].is_null(),
+        "failed unstack should not persist new stack config: {config}"
+    );
+}
+
+#[test]
 fn test_gg_unstack_wt_alias_preserves_existing_old_stack_worktree_metadata() {
     let (_temp_dir, repo_path) = create_test_repo_with_worktree_support();
 

--- a/crates/gg-core/src/commands/checkout.rs
+++ b/crates/gg-core/src/commands/checkout.rs
@@ -288,7 +288,7 @@ pub fn run(stack_name: Option<String>, base: Option<String>, use_worktree: bool)
     Ok(())
 }
 
-fn ensure_stack_worktree(
+pub(crate) fn ensure_stack_worktree(
     repo: &git2::Repository,
     config: &mut Config,
     stack_name: &str,

--- a/crates/gg-core/src/commands/unstack.rs
+++ b/crates/gg-core/src/commands/unstack.rs
@@ -115,6 +115,28 @@ pub fn run(options: UnstackOptions) -> Result<()> {
     // Create the new stack by rebasing upper commits onto base
     let new_tip = rebase_upper_stack(&repo, &stack_obj, &new_branch, split_position)?;
 
+    // In worktree mode, create the managed worktree before mutating the
+    // original stack branch or config. If worktree creation fails, the
+    // original stack is still intact and only the temporary new branch needs
+    // cleanup.
+    let precreated_worktree_path = if options.worktree {
+        git::checkout_branch(&repo, &original_branch)?;
+        match super::checkout::ensure_stack_worktree(
+            &repo,
+            &mut config,
+            &new_stack_name,
+            &new_branch,
+        ) {
+            Ok(path) => Some(path),
+            Err(err) => {
+                cleanup_failed_worktree_unstack(&repo, &original_branch, &new_branch)?;
+                return Err(err);
+            }
+        }
+    } else {
+        None
+    };
+
     // Move the original stack branch down to the lower tip
     set_branch_target(
         &repo,
@@ -140,6 +162,11 @@ pub fn run(options: UnstackOptions) -> Result<()> {
         options.worktree,
     );
 
+    if let Some(path) = &precreated_worktree_path {
+        config.get_or_create_stack(&new_stack_name).worktree_path =
+            Some(path.to_string_lossy().to_string());
+    }
+
     // Delete old entry branches for moved entries
     let deleted_entry_branches = delete_old_entry_branches(&repo, &stack_obj, split_position)?;
 
@@ -150,25 +177,16 @@ pub fn run(options: UnstackOptions) -> Result<()> {
     let lower_stack = Stack::load(&repo, &config)?;
     git::normalize_stack_metadata(&repo, &lower_stack)?;
 
-    // Normalize metadata on the new (upper) stack and leave HEAD there
-    git::checkout_branch(&repo, &new_branch)?;
-    let upper_stack = Stack::load(&repo, &config)?;
-    git::normalize_stack_metadata(&repo, &upper_stack)?;
-
-    // Handle worktree mode: checkout old stack branch, create worktree for new stack
-    let worktree_path = if options.worktree {
-        // Switch back to the original (lower) stack in the current worktree
-        git::checkout_branch(&repo, &original_branch)?;
-        // Create or reuse a managed worktree for the new upper stack
-        let path = super::checkout::ensure_stack_worktree(
-            &repo,
-            &mut config,
-            &new_stack_name,
-            &new_branch,
-        )?;
-        config.save(repo.commondir())?;
+    let worktree_path = if let Some(path) = &precreated_worktree_path {
+        let upper_repo = Repository::open(path)?;
+        let upper_stack = Stack::load(&upper_repo, &config)?;
+        git::normalize_stack_metadata(&upper_repo, &upper_stack)?;
         Some(path.to_string_lossy().to_string())
     } else {
+        // Normalize metadata on the new (upper) stack and leave HEAD there.
+        git::checkout_branch(&repo, &new_branch)?;
+        let upper_stack = Stack::load(&repo, &config)?;
+        git::normalize_stack_metadata(&repo, &upper_stack)?;
         None
     };
 
@@ -465,6 +483,25 @@ fn cleanup_failed_unstack_rebase(
         branch.delete().map_err(|e| {
             GgError::Other(format!(
                 "Rebase failed, and cleanup could not delete temporary branch '{}': {}",
+                new_branch, e
+            ))
+        })?;
+    }
+
+    Ok(())
+}
+
+fn cleanup_failed_worktree_unstack(
+    repo: &Repository,
+    original_branch: &str,
+    new_branch: &str,
+) -> Result<()> {
+    git::checkout_branch(repo, original_branch)?;
+
+    if let Ok(mut branch) = repo.find_branch(new_branch, BranchType::Local) {
+        branch.delete().map_err(|e| {
+            GgError::Other(format!(
+                "Worktree creation failed, and cleanup could not delete temporary branch '{}': {}",
                 new_branch, e
             ))
         })?;

--- a/crates/gg-core/src/commands/unstack.rs
+++ b/crates/gg-core/src/commands/unstack.rs
@@ -34,6 +34,8 @@ pub struct UnstackOptions {
     pub force: bool,
     /// Output as JSON.
     pub json: bool,
+    /// Create or reuse a managed worktree for the new stack.
+    pub worktree: bool,
 }
 
 /// Run the unstack command.
@@ -135,6 +137,7 @@ pub fn run(options: UnstackOptions) -> Result<()> {
         &original_stack,
         &new_stack_name,
         &moved_entries,
+        options.worktree,
     );
 
     // Delete old entry branches for moved entries
@@ -151,6 +154,23 @@ pub fn run(options: UnstackOptions) -> Result<()> {
     git::checkout_branch(&repo, &new_branch)?;
     let upper_stack = Stack::load(&repo, &config)?;
     git::normalize_stack_metadata(&repo, &upper_stack)?;
+
+    // Handle worktree mode: checkout old stack branch, create worktree for new stack
+    let worktree_path = if options.worktree {
+        // Switch back to the original (lower) stack in the current worktree
+        git::checkout_branch(&repo, &original_branch)?;
+        // Create or reuse a managed worktree for the new upper stack
+        let path = super::checkout::ensure_stack_worktree(
+            &repo,
+            &mut config,
+            &new_stack_name,
+            &new_branch,
+        )?;
+        config.save(repo.commondir())?;
+        Some(path.to_string_lossy().to_string())
+    } else {
+        None
+    };
 
     // Finalize the operation record
     guard.finalize_with_scope(
@@ -175,8 +195,33 @@ pub fn run(options: UnstackOptions) -> Result<()> {
                 deleted_entry_branches,
                 migrated_review_mappings,
                 sync_required,
+                worktree_path,
             },
         });
+    } else if let Some(path) = &worktree_path {
+        println!(
+            "{} Unstacked {} at position #{}",
+            style("OK").green().bold(),
+            style(&original_stack).cyan(),
+            split_position
+        );
+        println!(
+            "  {}: {} entries",
+            style(&original_stack).cyan(),
+            split_position - 1
+        );
+        println!(
+            "  {}: {} entries (worktree: {})",
+            style(&new_stack_name).cyan(),
+            stack_obj.len() - split_position + 1,
+            style(path).yellow()
+        );
+        if sync_required {
+            println!(
+                "\n{} Run `gg sync` to push the new stack and update PR/MR targets.",
+                style("hint:").yellow()
+            );
+        }
     } else {
         println!(
             "{} Unstacked {} at position #{}",
@@ -438,10 +483,14 @@ fn migrate_config(
     original_stack: &str,
     new_stack: &str,
     moved_entries: &[UnstackEntryJson],
+    worktree_mode: bool,
 ) -> usize {
     let original_base = config
         .get_stack(original_stack)
         .and_then(|s| s.base.clone());
+    let original_worktree_path = config
+        .get_stack(original_stack)
+        .and_then(|s| s.worktree_path.clone());
 
     let mut new_config = StackConfig {
         base: original_base,
@@ -455,6 +504,19 @@ fn migrate_config(
         if let Some(mr) = config.get_mr_for_entry(original_stack, gg_id) {
             new_config.mrs.insert(gg_id.clone(), mr);
             config.remove_mr_for_entry(original_stack, gg_id);
+        }
+    }
+
+    // In worktree mode, the current worktree stays with the old (lower) stack,
+    // so preserve the old worktree_path on it. The new stack gets its worktree
+    // assigned later by ensure_stack_worktree.
+    // In normal mode, HEAD moves to the new stack, so migrate the worktree_path.
+    if !worktree_mode {
+        if let Some(wt_path) = original_worktree_path {
+            new_config.worktree_path = Some(wt_path);
+            if let Some(old_stack) = config.stacks.get_mut(original_stack) {
+                old_stack.worktree_path = None;
+            }
         }
     }
 
@@ -503,6 +565,7 @@ mod tests {
         assert!(!opts.no_tui);
         assert!(!opts.force);
         assert!(!opts.json);
+        assert!(!opts.worktree);
     }
 
     fn temp_repo() -> (tempfile::TempDir, Repository) {
@@ -598,7 +661,7 @@ mod tests {
             gg_id: Some("c-abc1234".to_string()),
         }];
 
-        let migrated = migrate_config(&mut config, "feature", "feature-2", &moved_entries);
+        let migrated = migrate_config(&mut config, "feature", "feature-2", &moved_entries, false);
 
         assert_eq!(migrated, 1);
         assert_eq!(config.get_stack("feature-2").unwrap().base, None);

--- a/crates/gg-core/src/output.rs
+++ b/crates/gg-core/src/output.rs
@@ -498,6 +498,8 @@ pub struct UnstackResultJson {
     pub deleted_entry_branches: Vec<String>,
     pub migrated_review_mappings: usize,
     pub sync_required: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub worktree_path: Option<String>,
 }
 
 #[derive(Serialize)]

--- a/docs/src/commands/unstack.md
+++ b/docs/src/commands/unstack.md
@@ -3,7 +3,7 @@
 Split the current stack into two independent stacks.
 
 ```bash
-gg unstack [--target <TARGET>] [--name <STACK_NAME>] [--no-tui] [-f] [--json]
+gg unstack [--target <TARGET>] [--name <STACK_NAME>] [--no-tui] [-f] [--json] [-w]
 ```
 
 The selected entry becomes the root of a new stack, and all entries above it
@@ -26,6 +26,9 @@ gg unstack --target c-abc1234 --name auth-followup --no-tui
 
 # Machine-readable output
 gg unstack --target 3 --json --no-tui
+
+# Put the new upper stack in a managed worktree
+gg unstack --target 3 --name upper-auth --wt
 ```
 
 ## Behavior
@@ -55,6 +58,10 @@ local entry branches under the old stack name are removed for moved entries.
 If moved entries had review mappings, run `gg sync` afterwards to recreate or
 update review branches for the new stack.
 
+Without `--worktree`, the current directory switches to the new upper stack.
+With `--worktree`, the current directory stays on the lower stack and the new
+upper stack is checked out in its managed worktree.
+
 ## Options
 
 - `--target <TARGET>`: first entry for the new stack. Accepts a 1-indexed
@@ -65,6 +72,8 @@ update review branches for the new stack.
   scripts and tests.
 - `-f, --force`: bypass the immutability guard for merged/base commits.
 - `--json`: emit structured JSON.
+- `-w, --worktree`: create or reuse a managed worktree for the new stack
+  (`--wt` also works).
 
 Position `1` is rejected because it would leave the original stack empty. The
 last position is allowed and creates a one-entry new stack.

--- a/docs/src/worktrees.md
+++ b/docs/src/worktrees.md
@@ -13,7 +13,7 @@ gg co my-feature --worktree
 ## Unstack into a worktree
 
 ```bash
-gg unstack 3 --name upper-feature --wt
+gg unstack --target 3 --name upper-feature --wt
 ```
 
 This keeps your current directory on the lower stack and creates or reuses a managed worktree for the new upper stack.

--- a/docs/src/worktrees.md
+++ b/docs/src/worktrees.md
@@ -1,6 +1,6 @@
 # Worktrees
 
-`gg co` supports managed worktrees.
+`gg co` and `gg unstack` support managed worktrees.
 
 ## Create a stack worktree
 
@@ -9,6 +9,14 @@ gg co my-feature --wt
 # or
 gg co my-feature --worktree
 ```
+
+## Unstack into a worktree
+
+```bash
+gg unstack 3 --name upper-feature --wt
+```
+
+This keeps your current directory on the lower stack and creates or reuses a managed worktree for the new upper stack.
 
 ## Default location
 

--- a/skills/gg/SKILL.md
+++ b/skills/gg/SKILL.md
@@ -87,6 +87,13 @@ Store shared defaults in `~/.config/gg/config.json` that apply to all repos. Loc
 gg co -w feature-auth
 ```
 
+When splitting an existing stack into lower and upper stacks, prefer a managed
+worktree for the new upper stack:
+
+```bash
+gg unstack 3 --name feature-auth-followup --wt
+```
+
 2. Commit logical changes:
 
 ```bash

--- a/skills/gg/SKILL.md
+++ b/skills/gg/SKILL.md
@@ -91,7 +91,7 @@ When splitting an existing stack into lower and upper stacks, prefer a managed
 worktree for the new upper stack:
 
 ```bash
-gg unstack 3 --name feature-auth-followup --wt
+gg unstack --target 3 --name feature-auth-followup --wt
 ```
 
 2. Commit logical changes:

--- a/skills/gg/reference.md
+++ b/skills/gg/reference.md
@@ -59,15 +59,6 @@ Create/switch stack, optionally worktree-backed.
 - `-b, --base <BASE>`
 - `-w, --worktree`
 
-#### `gg unstack [OPTIONS] [TARGET]`
-Move the upper part of the current stack to a new stack. With `--worktree`,
-the current directory stays on the lower stack and the new upper stack is
-opened in a managed worktree.
-
-- `-n, --name <NAME>`
-- `-w, --worktree` / `--wt`
-- `--json`
-
 #### `gg ls [OPTIONS]`
 List current/all/remote stacks.
 
@@ -186,6 +177,7 @@ Split the current stack into two independent stacks. The selected entry and its 
 
 - `-t, --target <TARGET>` — first entry for the new stack (position, SHA, or GG-ID)
 - `-n, --name <STACK_NAME>` — explicit new stack name (default: `<old-stack>-2`, incrementing)
+- `-w, --worktree` / `--wt` — create the new upper stack in a managed worktree; current directory stays on the lower stack
 - `--no-tui` — disable the interactive picker; requires `--target`
 - `-f, --force` (alias: `--ignore-immutable`) — bypass the [immutability guard](#immutable-commits)
 - `--json`
@@ -554,6 +546,33 @@ Field types for `entries`:
   }
 }
 ```
+
+### `gg unstack --json`
+
+```json
+{
+  "version": 1,
+  "unstack": {
+    "original_stack": "my-feature",
+    "new_stack": "my-feature-2",
+    "split_position": 3,
+    "remaining_entries": [
+      { "position": 1, "sha": "abc1234", "title": "First commit", "gg_id": "c-abc1234" }
+    ],
+    "moved_entries": [
+      { "position": 3, "sha": "def5678", "title": "Third commit", "gg_id": "c-def5678" }
+    ],
+    "deleted_entry_branches": ["testuser/my-feature/3"],
+    "migrated_review_mappings": 1,
+    "sync_required": true,
+    "worktree_path": "/path/to/repo.my-feature-2"
+  }
+}
+```
+
+Field types:
+- `worktree_path`: `string | null` — present only when `--worktree` was used
+- `gg_id`: `string | null`
 
 ### `gg restack --json`
 

--- a/skills/gg/reference.md
+++ b/skills/gg/reference.md
@@ -59,6 +59,15 @@ Create/switch stack, optionally worktree-backed.
 - `-b, --base <BASE>`
 - `-w, --worktree`
 
+#### `gg unstack [OPTIONS] [TARGET]`
+Move the upper part of the current stack to a new stack. With `--worktree`,
+the current directory stays on the lower stack and the new upper stack is
+opened in a managed worktree.
+
+- `-n, --name <NAME>`
+- `-w, --worktree` / `--wt`
+- `--json`
+
 #### `gg ls [OPTIONS]`
 List current/all/remote stacks.
 


### PR DESCRIPTION
## Summary

Adds `--wt` / `--worktree` flag to `gg unstack`, matching `gg co --worktree` conventions:

- New upper stack is created in a managed worktree (`../<repo>.<new-stack>`)
- Current directory stays on the old lower stack
- Config persists `worktree_path` under the new stack; `gg ls` shows `[wt]` marker
- Without the flag, existing behavior is unchanged

Closes #311

## Changes

- **`crates/gg-core/src/commands/unstack.rs`** — New module (355 lines): stack split, rebase, metadata normalization, worktree-aware config migration
- **`crates/gg-cli/src/main.rs`** — Added `-w`/`--worktree`/`--wt` flag to `Commands::Unstack`
- **`crates/gg-core/src/commands/checkout.rs`** — `ensure_stack_worktree` changed to `pub(crate)`
- **`crates/gg-core/src/operations.rs`** — Registered `OperationKind::Unstack`
- **Integration tests** — 3 new tests: worktree flow, `--wt` alias, non-worktree default
- **Docs** — `unstack.md`, `worktrees.md`, skill/reference updates

## Known TODO

- Immutability guard not yet wired (`--force`/`--ignore-immutable` accepted but guard not called) — tracked for follow-up

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test --test integration_tests test_gg_unstack -- --nocapture` — 3 passed
- [x] `cargo test --workspace --lib --bins --all-features` — 528 passed