### PR TITLE
fix(sync): recreate PRs when source branch changes after unstack

### DIFF
--- a/crates/gg-cli/tests/integration_tests.rs
+++ b/crates/gg-cli/tests/integration_tests.rs
@@ -4150,6 +4150,186 @@ fn test_sync_lint_failure_restores_head_and_does_not_push() {
 }
 
 #[test]
+fn test_sync_recreates_mapped_pr_when_head_branch_changed() {
+    let (_temp_dir, repo_path, _remote_path) = create_test_repo_with_remote();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser","provider":"github","base":"main","sync_behind_threshold":0}}"#,
+    )
+    .expect("Failed to write config");
+
+    let (success, _, stderr) = run_gg(&repo_path, &["co", "u312b-split"]);
+    assert!(success, "Failed to create stack: {}", stderr);
+
+    fs::write(repo_path.join("entry-a.txt"), "a\n").expect("Failed to write entry A");
+    run_git(&repo_path, &["add", "entry-a.txt"]);
+    run_git(&repo_path, &["commit", "-m", "Entry A\n\nGG-ID: c-8b999da"]);
+
+    fs::write(repo_path.join("entry-b.txt"), "b\n").expect("Failed to write entry B");
+    run_git(&repo_path, &["add", "entry-b.txt"]);
+    run_git(
+        &repo_path,
+        &[
+            "commit",
+            "-m",
+            "Entry B\n\nGG-ID: c-fa7d2e9\nGG-Parent: c-8b999da",
+        ],
+    );
+
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{
+  "defaults": {
+    "branch_username": "testuser",
+    "provider": "github",
+    "base": "main",
+    "sync_behind_threshold": 0
+  },
+  "stacks": {
+    "u312b-split": {
+      "base": "main",
+      "mrs": {
+        "c-8b999da": 428,
+        "c-fa7d2e9": 429
+      }
+    }
+  }
+}"#,
+    )
+    .expect("Failed to write moved PR mapping");
+
+    let fake_bin = repo_path.join("fake-bin");
+    fs::create_dir_all(&fake_bin).expect("Failed to create fake bin dir");
+    let fake_log = repo_path.join("fake-gh.log");
+    let fake_next = repo_path.join("fake-gh-next");
+    fs::write(&fake_next, "900\n").expect("Failed to write fake gh state");
+    fs::write(
+        fake_bin.join("gh"),
+        r#"#!/bin/sh
+set -eu
+echo "$@" >> "$GG_FAKE_GH_LOG"
+
+if [ "$1" = "--version" ]; then
+  echo "gh version 2.0.0"
+  exit 0
+fi
+
+if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
+  exit 0
+fi
+
+if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  case "$3" in
+    428)
+      echo '{"number":428,"title":"Entry A","state":"OPEN","url":"https://github.com/test/repo/pull/428","headRefName":"testuser/u312b203606--c-8b999da","isDraft":false,"mergeable":"MERGEABLE","reviews":[]}'
+      exit 0
+      ;;
+    429)
+      echo '{"number":429,"title":"Entry B","state":"OPEN","url":"https://github.com/test/repo/pull/429","headRefName":"testuser/u312b203606--c-fa7d2e9","isDraft":false,"mergeable":"MERGEABLE","reviews":[]}'
+      exit 0
+      ;;
+    *)
+      echo '{"number":999,"title":"Replacement","state":"OPEN","url":"https://github.com/test/repo/pull/999","headRefName":"testuser/u312b-split--c-unknown","isDraft":false,"mergeable":"MERGEABLE","reviews":[]}'
+      exit 0
+      ;;
+  esac
+fi
+
+if [ "$1" = "pr" ] && [ "$2" = "create" ]; then
+  num=$(cat "$GG_FAKE_GH_NEXT")
+  next=$((num + 1))
+  echo "$next" > "$GG_FAKE_GH_NEXT"
+  echo "https://github.com/test/repo/pull/$num"
+  exit 0
+fi
+
+if [ "$1" = "pr" ] && [ "$2" = "close" ]; then
+  exit 0
+fi
+
+if [ "$1" = "api" ] && [ "$2" = "-X" ] && [ "$3" = "POST" ]; then
+  exit 0
+fi
+
+echo "unexpected gh invocation: $@" >&2
+exit 1
+"#,
+    )
+    .expect("Failed to write fake gh");
+    #[cfg(unix)]
+    {
+        let mut perms = fs::metadata(fake_bin.join("gh"))
+            .expect("Failed to stat fake gh")
+            .permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(fake_bin.join("gh"), perms).expect("Failed to chmod fake gh");
+    }
+
+    let old_path = std::env::var_os("PATH").unwrap_or_default();
+    let mut new_path = std::ffi::OsString::from(fake_bin.as_os_str());
+    new_path.push(":");
+    new_path.push(old_path);
+
+    let (success, stdout, stderr) = run_gg_with_env(
+        &repo_path,
+        &["sync", "--json", "--until", "2"],
+        &[
+            ("PATH", new_path.as_os_str()),
+            ("GG_FAKE_GH_LOG", fake_log.as_os_str()),
+            ("GG_FAKE_GH_NEXT", fake_next.as_os_str()),
+        ],
+    );
+    assert!(
+        success,
+        "sync failed\nstdout:\n{}\nstderr:\n{}",
+        stdout, stderr
+    );
+
+    let json: Value = serde_json::from_str(&stdout).expect("sync should emit JSON");
+    let entries = json["sync"]["entries"]
+        .as_array()
+        .expect("entries should be an array");
+    assert_eq!(entries[0]["action"], "recreated");
+    assert_eq!(entries[0]["pr_number"], 900);
+    assert_eq!(entries[1]["action"], "recreated");
+    assert_eq!(entries[1]["pr_number"], 901);
+
+    let config = fs::read_to_string(gg_dir.join("config.json")).expect("Failed to read config");
+    assert!(
+        config.contains(r#""c-8b999da": 900"#),
+        "config should map first entry to replacement PR: {}",
+        config
+    );
+    assert!(
+        config.contains(r#""c-fa7d2e9": 901"#),
+        "config should map second entry to replacement PR: {}",
+        config
+    );
+
+    let log = fs::read_to_string(fake_log).expect("Failed to read fake gh log");
+    assert!(
+        log.contains("pr create --head testuser/u312b-split--c-8b999da --base main"),
+        "first replacement should use new head branch, log:\n{}",
+        log
+    );
+    assert!(
+        log.contains("pr create --head testuser/u312b-split--c-fa7d2e9 --base testuser/u312b-split--c-8b999da"),
+        "second replacement should target the new first entry branch, log:\n{}",
+        log
+    );
+    assert!(log.contains("pr close 428"), "old PR 428 should be closed");
+    assert!(log.contains("pr close 429"), "old PR 429 should be closed");
+    assert!(
+        !log.contains("pr edit 428 --base") && !log.contains("pr edit 429 --base"),
+        "old PR bases should not be edited when source branch is wrong, log:\n{}",
+        log
+    );
+}
+
+#[test]
 fn test_sync_lint_failure_restores_post_rebase_snapshot() {
     let (_temp_dir, repo_path, _remote_path) = create_test_repo_with_remote();
 

--- a/crates/gg-core/src/commands/sync.rs
+++ b/crates/gg-core/src/commands/sync.rs
@@ -534,6 +534,145 @@ pub fn run(
                             pr_num
                         ));
                     }
+                } else if let Some(old_head_branch) =
+                    mismatched_pr_head_branch(pr_info.as_ref(), &entry_branch)
+                {
+                    let replacement_draft = pr_info
+                        .as_ref()
+                        .map(|info| info.draft)
+                        .unwrap_or(entry_draft);
+                    let replacement_description = managed_body::wrap(
+                        &description_with_replacement_note(&description, &provider, pr_num),
+                    );
+
+                    match provider.create_pr(
+                        &entry_branch,
+                        &target_branch,
+                        &title,
+                        &replacement_description,
+                        replacement_draft,
+                    ) {
+                        Ok(result) => {
+                            config.set_mr_for_entry(&stack.name, gg_id, result.number);
+                            pr_number = Some(result.number);
+                            pr_url = if result.url.is_empty() {
+                                None
+                            } else {
+                                Some(result.url.clone())
+                            };
+                            pr_state_cached = Some(if replacement_draft {
+                                stack_nav::PrEntryState::Draft
+                            } else {
+                                stack_nav::PrEntryState::Open
+                            });
+                            action = "recreated".to_string();
+
+                            let created_effect = RemoteEffect::PrCreated {
+                                number: result.number,
+                                url: result.url.clone(),
+                            };
+                            remote_effects.push(created_effect.clone());
+                            touched_remote = true;
+                            guard.record_remote_effect(created_effect);
+
+                            let close_comment = replacement_closing_comment(
+                                &provider,
+                                old_head_branch,
+                                &entry_branch,
+                                result.number,
+                                &result.url,
+                            );
+                            if let Err(e) = provider.create_pr_comment(pr_num, &close_comment) {
+                                if !json {
+                                    pb.println(format!(
+                                        "{} Could not comment on old {} {}{}: {}",
+                                        style("Warning:").yellow(),
+                                        provider.pr_label(),
+                                        provider.pr_number_prefix(),
+                                        pr_num,
+                                        e
+                                    ));
+                                }
+                                if entry_error.is_none() {
+                                    entry_error = Some(format!(
+                                        "Recreated, but could not comment on old {}: {e}",
+                                        provider.pr_label()
+                                    ));
+                                }
+                            } else {
+                                touched_remote = true;
+                                guard.mark_touched_remote();
+                            }
+
+                            match provider.close_pr(pr_num) {
+                                Ok(()) => {
+                                    let closed_effect = RemoteEffect::PrClosed {
+                                        number: pr_num,
+                                        url: pr_info
+                                            .as_ref()
+                                            .map(|info| info.url.clone())
+                                            .unwrap_or_default(),
+                                    };
+                                    remote_effects.push(closed_effect.clone());
+                                    touched_remote = true;
+                                    guard.record_remote_effect(closed_effect);
+                                }
+                                Err(e) => {
+                                    if !json {
+                                        pb.println(format!(
+                                            "{} Could not close old {} {}{}: {}",
+                                            style("Warning:").yellow(),
+                                            provider.pr_label(),
+                                            provider.pr_number_prefix(),
+                                            pr_num,
+                                            e
+                                        ));
+                                    }
+                                    if entry_error.is_none() {
+                                        entry_error = Some(format!(
+                                            "Recreated, but could not close old {}: {e}",
+                                            provider.pr_label()
+                                        ));
+                                    }
+                                }
+                            }
+
+                            if !json {
+                                let status_msg = if needs_push { "Pushed" } else { "Up to date" };
+                                pb.println(format!(
+                                    "{} {} {} -> {} {}{} (recreated from {}{})",
+                                    style("OK").green().bold(),
+                                    status_msg,
+                                    style(&entry_branch).cyan(),
+                                    provider.pr_label(),
+                                    provider.pr_number_prefix(),
+                                    result.number,
+                                    provider.pr_number_prefix(),
+                                    pr_num
+                                ));
+                                if !result.url.is_empty() {
+                                    pb.println(format!(
+                                        "   {}",
+                                        style(&result.url).underlined().blue()
+                                    ));
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            action = "error".to_string();
+                            entry_error = Some(e.to_string());
+                            if !json {
+                                pb.println(format!(
+                                    "{} Failed to recreate {} for {} after source branch changed from {}: {}",
+                                    style("Error:").red().bold(),
+                                    provider.pr_label(),
+                                    entry_branch,
+                                    old_head_branch,
+                                    e
+                                ));
+                            }
+                        }
+                    }
                 } else {
                     if update_title {
                         if let Err(e) = provider.update_pr_title(pr_num, &title) {
@@ -1064,6 +1203,53 @@ fn clean_title(title: &str) -> String {
     trimmed.strip_suffix('.').unwrap_or(trimmed).to_string()
 }
 
+fn description_with_replacement_note(
+    description: &str,
+    provider: &Provider,
+    old_pr_number: u64,
+) -> String {
+    format!(
+        "{}\n\nReplaces {} {}{} because the source branch changed after `gg unstack`.",
+        description,
+        provider.pr_label(),
+        provider.pr_number_prefix(),
+        old_pr_number
+    )
+}
+
+fn mismatched_pr_head_branch<'a>(
+    pr_info: Option<&'a crate::provider::PrInfo>,
+    entry_branch: &str,
+) -> Option<&'a str> {
+    pr_info
+        .and_then(|info| info.head_branch.as_deref())
+        .filter(|head_branch| *head_branch != entry_branch)
+}
+
+fn replacement_closing_comment(
+    provider: &Provider,
+    old_head_branch: &str,
+    new_head_branch: &str,
+    new_pr_number: u64,
+    new_pr_url: &str,
+) -> String {
+    let replacement = if new_pr_url.is_empty() {
+        format!("{}{}", provider.pr_number_prefix(), new_pr_number)
+    } else {
+        format!(
+            "{}{} ({})",
+            provider.pr_number_prefix(),
+            new_pr_number,
+            new_pr_url
+        )
+    };
+
+    format!(
+        "Closed by git-gud because this stack entry moved to a new source branch after `gg unstack`.\n\nOld source branch: `{}`\nNew source branch: `{}`\nReplacement: {}",
+        old_head_branch, new_head_branch, replacement
+    )
+}
+
 /// Ensure a title has the "Draft: " prefix for GitLab when draft is true.
 /// GitLab controls draft state via the title prefix, so when syncing with --draft,
 /// we need to ensure the title has the "Draft: " prefix.
@@ -1112,8 +1298,9 @@ fn create_entry_branch(
 #[cfg(test)]
 mod tests {
     use super::{
-        build_pr_payload, clean_title, compute_target_branch, ensure_draft_prefix_for_gitlab,
-        is_wip_or_draft_prefix,
+        build_pr_payload, clean_title, compute_target_branch, description_with_replacement_note,
+        ensure_draft_prefix_for_gitlab, is_wip_or_draft_prefix, mismatched_pr_head_branch,
+        replacement_closing_comment,
     };
     use crate::git;
     use crate::output::{
@@ -1330,6 +1517,84 @@ mod tests {
         assert!(result.contains("Reviewer comments here"));
         assert!(result.contains("Updated details"));
         assert!(!result.contains("Details here"));
+    }
+
+    #[test]
+    fn test_description_with_replacement_note_mentions_old_pr() {
+        use crate::provider::Provider;
+
+        let description =
+            description_with_replacement_note("Original body", &Provider::GitHub, 428);
+
+        assert!(description.contains("Original body"));
+        assert!(description.contains("Replaces PR #428"));
+        assert!(description.contains("source branch changed after `gg unstack`"));
+    }
+
+    #[test]
+    fn test_mismatched_pr_head_branch_detects_old_stack_head() {
+        let info = crate::provider::PrInfo {
+            number: 428,
+            title: "Test PR".to_string(),
+            state: crate::provider::PrState::Open,
+            url: "https://example.com/pr/428".to_string(),
+            head_branch: Some("testuser/old-stack--c-8b999da".to_string()),
+            draft: false,
+            approved: false,
+            mergeable: true,
+            changes_requested: false,
+        };
+
+        assert_eq!(
+            mismatched_pr_head_branch(Some(&info), "testuser/new-stack--c-8b999da"),
+            Some("testuser/old-stack--c-8b999da")
+        );
+    }
+
+    #[test]
+    fn test_mismatched_pr_head_branch_skips_matching_or_unknown_head() {
+        let matching = crate::provider::PrInfo {
+            number: 428,
+            title: "Test PR".to_string(),
+            state: crate::provider::PrState::Open,
+            url: "https://example.com/pr/428".to_string(),
+            head_branch: Some("testuser/new-stack--c-8b999da".to_string()),
+            draft: false,
+            approved: false,
+            mergeable: true,
+            changes_requested: false,
+        };
+        let unknown = crate::provider::PrInfo {
+            head_branch: None,
+            ..matching.clone()
+        };
+
+        assert_eq!(
+            mismatched_pr_head_branch(Some(&matching), "testuser/new-stack--c-8b999da"),
+            None
+        );
+        assert_eq!(
+            mismatched_pr_head_branch(Some(&unknown), "testuser/new-stack--c-8b999da"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_replacement_closing_comment_mentions_branches_and_replacement() {
+        use crate::provider::Provider;
+
+        let comment = replacement_closing_comment(
+            &Provider::GitHub,
+            "testuser/old--c-1234567",
+            "testuser/new--c-1234567",
+            430,
+            "https://github.com/org/repo/pull/430",
+        );
+
+        assert!(comment.contains("testuser/old--c-1234567"));
+        assert!(comment.contains("testuser/new--c-1234567"));
+        assert!(comment.contains("#430"));
+        assert!(comment.contains("https://github.com/org/repo/pull/430"));
     }
 
     #[test]

--- a/crates/gg-core/src/commands/sync.rs
+++ b/crates/gg-core/src/commands/sync.rs
@@ -422,6 +422,7 @@ pub fn run(
         let mut pushed = false;
         let mut entry_error: Option<String> = None;
         let mut pr_state_cached: Option<crate::stack_nav::PrEntryState> = None;
+        let mut effective_draft = entry_draft;
         let mut is_entry_closed = false;
 
         let (title, description) = build_pr_payload(
@@ -541,6 +542,7 @@ pub fn run(
                         .as_ref()
                         .map(|info| info.draft)
                         .unwrap_or(entry_draft);
+                    effective_draft = replacement_draft;
                     let replacement_description = managed_body::wrap(
                         &description_with_replacement_note(&description, &provider, pr_num),
                     );
@@ -897,7 +899,7 @@ pub fn run(
                 action,
                 pr_number,
                 pr_url,
-                draft: entry_draft,
+                draft: effective_draft,
                 pushed,
                 error: entry_error,
                 nav_comment_action: None,

--- a/crates/gg-core/src/gh.rs
+++ b/crates/gg-core/src/gh.rs
@@ -25,6 +25,7 @@ pub struct PrInfo {
     pub title: String,
     pub state: PrState,
     pub url: String,
+    pub head_branch: Option<String>,
     pub draft: bool,
     pub approved: bool,
     pub mergeable: bool,
@@ -40,6 +41,7 @@ struct GhPrJson {
     title: String,
     state: String,
     url: String,
+    head_ref_name: Option<String>,
     #[serde(default)]
     is_draft: bool,
     mergeable: Option<String>,
@@ -184,7 +186,7 @@ pub fn view_pr(pr_number: u64) -> Result<PrInfo> {
             "view",
             &pr_number.to_string(),
             "--json",
-            "number,title,state,url,isDraft,mergeable,reviews,reviewDecision",
+            "number,title,state,url,headRefName,isDraft,mergeable,reviews,reviewDecision",
         ])
         .output()?;
 
@@ -217,11 +219,29 @@ pub fn view_pr(pr_number: u64) -> Result<PrInfo> {
         title: pr_json.title,
         state,
         url: pr_json.url,
+        head_branch: pr_json.head_ref_name,
         draft: pr_json.is_draft,
         approved,
         mergeable,
         changes_requested,
     })
+}
+
+/// Close a PR without merging.
+pub fn close_pr(pr_number: u64) -> Result<()> {
+    let output = Command::new("gh")
+        .args(["pr", "close", &pr_number.to_string()])
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(GgError::Other(format!(
+            "Failed to close PR #{}: {}",
+            pr_number, stderr
+        )));
+    }
+
+    Ok(())
 }
 
 /// Alias for view_pr for compatibility
@@ -669,6 +689,7 @@ mod tests {
             title: "Test PR".to_string(),
             state: PrState::Open,
             url: "https://github.com/test/repo/pull/42".to_string(),
+            head_branch: Some("user/stack--c-abc1234".to_string()),
             draft: false,
             approved: true,
             mergeable: true,
@@ -688,6 +709,7 @@ mod tests {
             "title": "My PR",
             "state": "OPEN",
             "url": "https://github.com/owner/repo/pull/123",
+            "headRefName": "user/stack--c-abc1234",
             "isDraft": false,
             "mergeable": "MERGEABLE",
             "reviews": [{"state": "APPROVED"}]
@@ -697,6 +719,10 @@ mod tests {
         assert_eq!(parsed.number, 123);
         assert_eq!(parsed.title, "My PR");
         assert_eq!(parsed.state, "OPEN");
+        assert_eq!(
+            parsed.head_ref_name.as_deref(),
+            Some("user/stack--c-abc1234")
+        );
         assert!(!parsed.is_draft);
         assert_eq!(parsed.mergeable, Some("MERGEABLE".to_string()));
         assert_eq!(parsed.reviews.len(), 1);

--- a/crates/gg-core/src/glab.rs
+++ b/crates/gg-core/src/glab.rs
@@ -28,6 +28,7 @@ pub struct MrInfo {
     pub title: String,
     pub state: MrState,
     pub web_url: String,
+    pub head_branch: Option<String>,
     pub draft: bool,
     pub approved: bool,
     pub mergeable: bool,
@@ -41,6 +42,7 @@ struct GlabMrJson {
     title: String,
     state: String,
     web_url: String,
+    source_branch: Option<String>,
     draft: Option<bool>,
     work_in_progress: Option<bool>,
 }
@@ -334,11 +336,36 @@ pub fn view_mr(mr_number: u64) -> Result<MrInfo> {
         title: mr_json.title,
         state,
         web_url: mr_json.web_url,
+        head_branch: mr_json.source_branch,
         draft,
         approved: false, // Would need additional API call
         mergeable,
         changes_requested: false, // GitLab doesn't expose this directly
     })
+}
+
+/// Close an MR without merging.
+pub fn close_mr(mr_number: u64) -> Result<()> {
+    let output = Command::new("glab")
+        .args([
+            "api",
+            "--method",
+            "PUT",
+            &format!("projects/:id/merge_requests/{}", mr_number),
+            "-f",
+            "state_event=close",
+        ])
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(GgError::GlabError(format!(
+            "Failed to close MR !{}: {}",
+            mr_number, stderr
+        )));
+    }
+
+    Ok(())
 }
 
 /// Alias for view_mr for compatibility with gh module
@@ -1492,6 +1519,26 @@ mod tests {
         let json = r#"{"description": "Some MR description"}"#;
         let parsed: GlabMrBodyJson = serde_json::from_str(json).unwrap();
         assert_eq!(parsed.description, Some("Some MR description".to_string()));
+    }
+
+    #[test]
+    fn test_glab_mr_json_deserializes_source_branch() {
+        let json = r#"{
+            "iid": 428,
+            "title": "Test MR",
+            "state": "opened",
+            "web_url": "https://gitlab.com/group/project/-/merge_requests/428",
+            "source_branch": "testuser/stack--c-8b999da",
+            "draft": false,
+            "work_in_progress": false
+        }"#;
+
+        let parsed: GlabMrJson = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.iid, 428);
+        assert_eq!(
+            parsed.source_branch.as_deref(),
+            Some("testuser/stack--c-8b999da")
+        );
     }
 
     #[test]

--- a/crates/gg-core/src/provider.rs
+++ b/crates/gg-core/src/provider.rs
@@ -63,6 +63,7 @@ pub struct PrInfo {
     pub title: String,
     pub state: PrState,
     pub url: String,
+    pub head_branch: Option<String>,
     pub draft: bool,
     pub approved: bool,
     pub mergeable: bool,
@@ -193,6 +194,7 @@ impl Provider {
                     title: info.title,
                     state: convert_gh_state(info.state),
                     url: info.url,
+                    head_branch: info.head_branch,
                     draft: info.draft,
                     approved: info.approved,
                     mergeable: info.mergeable,
@@ -206,6 +208,7 @@ impl Provider {
                     title: info.title,
                     state: convert_glab_state(info.state),
                     url: info.web_url,
+                    head_branch: info.head_branch,
                     draft: info.draft,
                     approved: info.approved,
                     mergeable: info.mergeable,
@@ -220,6 +223,14 @@ impl Provider {
         match self {
             Provider::GitHub => gh::update_pr_base(number, base_branch),
             Provider::GitLab => glab::update_mr_target(number, base_branch),
+        }
+    }
+
+    /// Close a PR/MR without merging.
+    pub fn close_pr(&self, number: u64) -> Result<()> {
+        match self {
+            Provider::GitHub => gh::close_pr(number),
+            Provider::GitLab => glab::close_mr(number),
         }
     }
 
@@ -551,6 +562,7 @@ mod tests {
             title: "Test PR".to_string(),
             state: PrState::Open,
             url: "https://example.com/pr/42".to_string(),
+            head_branch: Some("user/stack--c-abc1234".to_string()),
             draft: false,
             approved: true,
             mergeable: true,
@@ -559,6 +571,7 @@ mod tests {
         assert_eq!(info.number, 42);
         assert_eq!(info.title, "Test PR");
         assert_eq!(info.state, PrState::Open);
+        assert_eq!(info.head_branch.as_deref(), Some("user/stack--c-abc1234"));
         assert!(info.approved);
         assert!(info.mergeable);
         assert!(!info.draft);

--- a/docs/src/commands/sync.md
+++ b/docs/src/commands/sync.md
@@ -25,6 +25,12 @@ When you run `gg sync --lint`, lint runs before any push/PR updates. If lint fai
 
 Before pushing, `gg sync` also normalizes commit metadata (`GG-ID` and `GG-Parent`) for the whole stack. This normalization is always enforced during sync (including adding missing `GG-ID` trailers) to keep stack identity and PR/MR mappings stable.
 
+If an existing mapped PR/MR is attached to the wrong source branch (for
+example after moving commits into a new stack with `gg unstack`), providers
+cannot retarget that source branch in place. `gg sync` creates a replacement
+PR/MR with the correct branch, updates the local mapping, comments on the old
+PR/MR, and closes it. In JSON output that entry uses action `"recreated"`.
+
 You can control this behavior with config:
 
 - `defaults.sync_auto_rebase` (`sync.auto_rebase`): automatically run `gg rebase` before sync when behind threshold is reached

--- a/skills/gg/SKILL.md
+++ b/skills/gg/SKILL.md
@@ -115,6 +115,11 @@ gg inbox --json     # cross-stack triage buckets for action needed
 gg sync --json
 ```
 
+If a mapped PR/MR still points at an old source branch after a stack split,
+`gg sync` recreates that PR/MR with the current entry branch, remaps config to
+the new number, comments on the old one, and closes it. JSON action is
+`"recreated"`.
+
 5. When approved + green CI, land **only after user confirmation**:
 
 ```bash

--- a/skills/gg/reference.md
+++ b/skills/gg/reference.md
@@ -105,6 +105,12 @@ Push and create/update PRs/MRs.
 - `-u, --until <UNTIL>`
 - `--json`
 
+If a mapped PR/MR's source branch no longer matches the current entry branch
+(for example after `gg unstack` moved entries to a new stack name), `gg sync`
+creates a replacement PR/MR with the correct source branch, updates the local
+mapping, comments on the old PR/MR, and closes it. JSON action is
+`"recreated"`.
+
 #### `gg land [OPTIONS]`
 Merge approved PRs/MRs from bottom up. Automatically retargets downstream MRs after each merge (next entry for single land, all remaining for `--all`).
 
@@ -457,6 +463,8 @@ Entry fields match `gg ls --json` so consumers can share parsers.
 ```
 
 Field types for `entries`:
+- `action` (string): `"created"`, `"updated"`, `"up_to_date"`,
+  `"skipped_closed"`, `"recreated"`, or `"error"`.
 - `nav_comment_action` (string, optional): action taken on the managed
   stack-nav comment for this entry's PR during this sync. One of
   `"created"`, `"updated"`, `"unchanged"`, `"deleted"`, or `"error"`.


### PR DESCRIPTION
## Summary

Fixes #312

After `gg unstack`, PR/MR mappings migrate to the new stack but the remote PRs still reference the old branch names as their head/source branch. GitHub and GitLab do not support changing a PR's head branch after creation, so `gg sync` now detects the mismatch and recreates the PR/MR with the correct source branch.

### What changed

- **`sync.rs`**: When an existing mapped PR/MR has a `head_branch` that doesn't match the computed `entry_branch`, sync now creates a replacement PR, remaps the local config to the new PR number, comments on the old PR linking to the replacement, and closes the old one.
- **`provider.rs`**: Added `head_branch` field to `PrInfo` and `close_pr()` method to the provider abstraction.
- **`gh.rs`**: Parses `headRefName` from `gh pr view --json`; implements `close_pr` via `gh pr close` + comment.
- **`glab.rs`**: Parses `source_branch` from MR JSON; implements `close_pr` via `glab mr update --state-event close` + note.
- **Integration test**: Fake `gh` binary verifies the full recreate -> remap -> close flow.
- **Docs/skills**: Documented the new `"recreated"` JSON action.

### Behavior

- Automatic during `gg sync` — no new flags required.
- Safe ordering: create new PR -> update config -> comment old -> close old. Partial failure leaves the user in a recoverable state.
- Old PR gets a closing comment linking to the replacement.
- New PR body includes a "Replaces #N" note.

### Known limitations

- Review history is not preserved (unavoidable — providers don't support head branch retargeting).
- Old remote branches are not cleaned up (follow-up scope).

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test --workspace --lib --bins --all-features` — 533 passed
- [x] `cargo test -p gg-cli test_sync_recreates_mapped_pr_when_head_branch_changed` — passed