### PR TITLE
feat: warn on mismatched stack branch prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,10 @@ PR/MR descriptions created by `gg sync` are wrapped in managed markers (`<!-- gg
 - **Stack branch**: `<username>/<stack-name>` (e.g., `nacho/my-feature`)
 - **Per-commit branches**: `<username>/<stack-name>--<entry-id>` (e.g., `nacho/my-feature--c-abc1234`)
 
+If a stack branch uses a different prefix than `branch_username`, `gg sync`,
+`gg log`, and current-stack `gg ls` warn that discovery and saved PR/MR mappings
+may be inaccurate until the branch is renamed.
+
 ### GG Metadata Trailers
 
 Each commit gets stable metadata trailers that persist across rebases:

--- a/crates/gg-cli/tests/integration_tests.rs
+++ b/crates/gg-cli/tests/integration_tests.rs
@@ -4869,14 +4869,14 @@ fn test_rebase_without_stack_requires_target() {
     run_git(&repo_path, &["add", "."]);
     run_git(&repo_path, &["commit", "-m", "Feature commit"]);
 
-    // Try rebase without target (should fail - not on stack)
+    // Try rebase without target (should fail - not on a stack branch)
     let (success, _stdout, stderr) = run_gg(&repo_path, &["rebase"]);
     assert!(
         !success,
         "Rebase without target should fail when not on a stack"
     );
     assert!(
-        stderr.contains("Not on a stack"),
+        stderr.contains("not a stack branch"),
         "Should indicate not on a stack. Got: {}",
         stderr
     );
@@ -4899,7 +4899,7 @@ fn test_nav_requires_stack() {
     let (success, _stdout, stderr) = run_gg(&repo_path, &["first"]);
     assert!(!success, "Nav first should fail when not on a stack");
     assert!(
-        stderr.contains("Not on a stack"),
+        stderr.contains("not a stack branch"),
         "Should indicate not on a stack. Got: {}",
         stderr
     );
@@ -4907,17 +4907,17 @@ fn test_nav_requires_stack() {
     // Try nav last while not on a stack
     let (success, _stdout, stderr) = run_gg(&repo_path, &["last"]);
     assert!(!success, "Nav last should fail when not on a stack");
-    assert!(stderr.contains("Not on a stack"));
+    assert!(stderr.contains("not a stack branch"));
 
     // Try nav next while not on a stack
     let (success, _stdout, stderr) = run_gg(&repo_path, &["next"]);
     assert!(!success, "Nav next should fail when not on a stack");
-    assert!(stderr.contains("Not on a stack"));
+    assert!(stderr.contains("not a stack branch"));
 
     // Try nav prev while not on a stack
     let (success, _stdout, stderr) = run_gg(&repo_path, &["prev"]);
     assert!(!success, "Nav prev should fail when not on a stack");
-    assert!(stderr.contains("Not on a stack"));
+    assert!(stderr.contains("not a stack branch"));
 }
 
 #[test]
@@ -9619,7 +9619,7 @@ fn test_gg_log_not_on_stack() {
     let (success, stdout, stderr) = run_gg(&repo_path, &["log"]);
     assert!(!success, "gg log off-stack should fail: stdout={stdout}");
     assert!(
-        stderr.contains("Not on a stack"),
+        stderr.contains("not a stack branch"),
         "stderr should explain we are not on a stack: {stderr}"
     );
 

--- a/crates/gg-cli/tests/integration_tests.rs
+++ b/crates/gg-cli/tests/integration_tests.rs
@@ -737,6 +737,38 @@ fn test_gg_ls_shows_commits() {
 }
 
 #[test]
+fn test_gg_ls_warns_on_mismatched_stack_prefix() {
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .expect("Failed to write config");
+
+    let (success, _, stderr) = run_gg(&repo_path, &["co", "wrong-prefix-ls"]);
+    assert!(success, "Failed to create stack: {}", stderr);
+    run_git(&repo_path, &["branch", "-m", "other/wrong-prefix-ls"]);
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["ls"]);
+    assert!(success, "gg ls failed: {}", stderr);
+    assert!(
+        stdout.contains("Warning:"),
+        "warning should appear: {stdout}"
+    );
+    assert!(
+        stdout.contains("configured prefix 'testuser/'"),
+        "configured prefix should appear: {stdout}"
+    );
+    assert!(
+        stdout.contains("git branch -m testuser/wrong-prefix-ls"),
+        "rename hint should appear: {stdout}"
+    );
+}
+
+#[test]
 fn test_gg_ls_json_current_stack() {
     let (_temp_dir, repo_path) = create_test_repo();
 
@@ -779,6 +811,39 @@ fn test_gg_ls_json_current_stack() {
     assert_eq!(entries.len(), 1);
     assert_eq!(entries[0]["position"], 1);
     assert_eq!(entries[0]["title"], "Add file1");
+}
+
+#[test]
+fn test_gg_sync_json_includes_mismatched_stack_prefix_warning() {
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .expect("Failed to write config");
+
+    let (success, _, stderr) = run_gg(&repo_path, &["co", "wrong-prefix-sync"]);
+    assert!(success, "Failed to create stack: {}", stderr);
+    run_git(&repo_path, &["branch", "-m", "other/wrong-prefix-sync"]);
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["sync", "--json"]);
+    assert!(success, "gg sync --json failed: {}", stderr);
+    assert!(
+        stderr.trim().is_empty(),
+        "stderr should be empty in JSON mode: {stderr}"
+    );
+
+    let parsed: Value = serde_json::from_str(&stdout).expect("stdout must be valid JSON");
+    let warnings = parsed["sync"]["warnings"]
+        .as_array()
+        .expect("warnings must be an array");
+    assert_eq!(warnings.len(), 1);
+    let warning = warnings[0].as_str().expect("warning must be a string");
+    assert!(warning.contains("configured prefix 'testuser/'"));
+    assert!(warning.contains("git branch -m testuser/wrong-prefix-sync"));
 }
 
 #[test]
@@ -9214,6 +9279,38 @@ fn test_gg_log_json_shape() {
     assert_eq!(entries[0]["is_current"], false);
 }
 
+#[test]
+fn test_gg_log_warns_on_mismatched_stack_prefix() {
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .expect("Failed to write config");
+
+    let (success, _, stderr) = run_gg(&repo_path, &["co", "wrong-prefix-log"]);
+    assert!(success, "Failed to create stack: {}", stderr);
+    run_git(&repo_path, &["branch", "-m", "other/wrong-prefix-log"]);
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["log"]);
+    assert!(success, "gg log failed: {}", stderr);
+    assert!(
+        stdout.contains("Warning:"),
+        "warning should appear: {stdout}"
+    );
+    assert!(
+        stdout.contains("configured prefix 'testuser/'"),
+        "configured prefix should appear: {stdout}"
+    );
+    assert!(
+        stdout.contains("git branch -m testuser/wrong-prefix-log"),
+        "rename hint should appear: {stdout}"
+    );
+}
+
 // ── Unstack tests ──────────────────────────────────────────────
 
 fn setup_unstack_repo(stack_name: &str, num_commits: usize) -> (TempDir, PathBuf) {
@@ -9532,6 +9629,31 @@ fn test_gg_log_not_on_stack() {
     let parsed: Value = serde_json::from_str(&stdout).expect("stdout must be valid JSON");
     assert_eq!(parsed["version"], 1);
     assert!(parsed["error"].is_string(), "error field must be string");
+}
+
+#[test]
+fn test_stack_command_on_bare_branch_suggests_configured_prefix() {
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .expect("Failed to write config");
+    run_git(&repo_path, &["checkout", "-b", "bare-feature"]);
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["log"]);
+    assert!(!success, "gg log off-stack should fail: stdout={stdout}");
+    assert!(
+        stderr.contains("Current branch 'bare-feature' is not a stack branch"),
+        "stderr should include current branch: {stderr}"
+    );
+    assert!(
+        stderr.contains("git branch -m testuser/bare-feature"),
+        "stderr should include rename hint: {stderr}"
+    );
 }
 
 #[test]

--- a/crates/gg-core/src/commands/log.rs
+++ b/crates/gg-core/src/commands/log.rs
@@ -20,6 +20,16 @@ pub fn run(json: bool, refresh: bool) -> Result<()> {
     let config = Config::load_with_global(git_dir)?;
 
     let mut stack = Stack::load(&repo, &config)?;
+    if !json {
+        if let Some(mismatch) = stack.prefix_mismatch(&config) {
+            println!(
+                "{} {}",
+                style("Warning:").yellow(),
+                mismatch.warning_message()
+            );
+            println!();
+        }
+    }
 
     if should_refresh_mr_info(refresh, json) {
         if refresh {

--- a/crates/gg-core/src/commands/ls.rs
+++ b/crates/gg-core/src/commands/ls.rs
@@ -31,6 +31,17 @@ pub fn run(all: bool, refresh: bool, remote: bool, json: bool) -> Result<()> {
             list_all_stacks(&repo, &config, json)?;
         }
         Some(mut stack) if !all => {
+            if !json {
+                if let Some(mismatch) = stack.prefix_mismatch(&config) {
+                    println!(
+                        "{} {}",
+                        style("Warning:").yellow(),
+                        mismatch.warning_message()
+                    );
+                    println!();
+                }
+            }
+
             if should_refresh_mr_info(refresh, json) {
                 if refresh {
                     let provider = Provider::detect(&repo)?;

--- a/crates/gg-core/src/commands/sync.rs
+++ b/crates/gg-core/src/commands/sync.rs
@@ -234,6 +234,16 @@ pub fn run(
 
     // Load stack early to validate --until
     let initial_stack = Stack::load(&repo, &config)?;
+    let warnings: Vec<String> = initial_stack
+        .prefix_mismatch(&config)
+        .map(|mismatch| mismatch.warning_message())
+        .into_iter()
+        .collect();
+    if !json {
+        for warning in &warnings {
+            println!("{} {}", style("Warning:").yellow(), warning);
+        }
+    }
     if initial_stack.is_empty() {
         if json {
             print_json(&SyncResponse {
@@ -242,7 +252,7 @@ pub fn run(
                     stack: initial_stack.name.clone(),
                     base: initial_stack.base.clone(),
                     rebased_before_sync: false,
-                    warnings: vec![],
+                    warnings,
                     metadata: SyncMetadataJson::default(),
                     entries: vec![],
                 },
@@ -285,8 +295,6 @@ pub fn run(
     // we restore to this post-rebase state rather than silently undoing rebase.
     let sync_start_branch = git::current_branch_name(&repo);
     let sync_start_head = repo.head()?.peel_to_commit()?.id();
-
-    let warnings: Vec<String> = Vec::new();
 
     // Run lint ONCE if requested (before GG-ID addition loop)
     if run_lint {

--- a/crates/gg-core/src/error.rs
+++ b/crates/gg-core/src/error.rs
@@ -23,6 +23,9 @@ pub enum GgError {
     #[error("Not on a stack branch. Use `gg co <stack-name>` to create or switch to a stack.")]
     NotOnStack,
 
+    #[error("{0}")]
+    NotOnStackBranch(String),
+
     #[error("Stack '{0}' not found")]
     StackNotFound(String),
 

--- a/crates/gg-core/src/stack.rs
+++ b/crates/gg-core/src/stack.rs
@@ -111,6 +111,24 @@ pub struct Stack {
     pub current_position: Option<usize>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StackPrefixMismatch {
+    pub current_branch: String,
+    pub actual_prefix: String,
+    pub expected_prefix: String,
+    pub stack_name: String,
+    pub suggested_branch: String,
+}
+
+impl StackPrefixMismatch {
+    pub fn warning_message(&self) -> String {
+        format!(
+            "current branch '{}' does not use the configured prefix '{}/'. Some stack discovery, listing, and saved PR/MR mappings may be inaccurate. Consider renaming it: git branch -m {}",
+            self.current_branch, self.expected_prefix, self.suggested_branch
+        )
+    }
+}
+
 impl Stack {
     /// Load stack from the current branch (or stored stack if in detached HEAD)
     pub fn load(repo: &Repository, config: &Config) -> Result<Self> {
@@ -125,7 +143,9 @@ impl Stack {
             })
             .ok_or(GgError::NotOnStack)?;
 
-        let (username, name) = git::parse_stack_branch(&branch_name).ok_or(GgError::NotOnStack)?;
+        let (username, name) = git::parse_stack_branch(&branch_name).ok_or_else(|| {
+            GgError::NotOnStackBranch(format_not_stack_branch_error(&branch_name, config))
+        })?;
 
         // Determine base branch
         let base = config
@@ -170,6 +190,21 @@ impl Stack {
             base,
             entries,
             current_position,
+        })
+    }
+
+    pub fn prefix_mismatch(&self, config: &Config) -> Option<StackPrefixMismatch> {
+        let expected_prefix = config.defaults.branch_username.as_deref()?;
+        if expected_prefix.is_empty() || expected_prefix == self.username {
+            return None;
+        }
+
+        Some(StackPrefixMismatch {
+            current_branch: self.branch_name(),
+            actual_prefix: self.username.clone(),
+            expected_prefix: expected_prefix.to_string(),
+            stack_name: self.name.clone(),
+            suggested_branch: git::format_stack_branch(expected_prefix, &self.name),
         })
     }
 
@@ -312,6 +347,27 @@ impl Stack {
             }
         }
         Ok(())
+    }
+}
+
+fn format_not_stack_branch_error(branch_name: &str, config: &Config) -> String {
+    if let Some(expected_prefix) = config
+        .defaults
+        .branch_username
+        .as_deref()
+        .filter(|prefix| !prefix.is_empty())
+        .filter(|_| !branch_name.contains('/'))
+    {
+        let suggested_branch = git::format_stack_branch(expected_prefix, branch_name);
+        format!(
+            "Current branch '{}' is not a stack branch. Expected format: '<prefix>/<stack-name>', for example '{}'. Rename it with: git branch -m {}",
+            branch_name, suggested_branch, suggested_branch
+        )
+    } else {
+        format!(
+            "Current branch '{}' is not a stack branch. Expected format: '<prefix>/<stack-name>'. Use `gg co <stack-name>` to create or switch to a stack.",
+            branch_name
+        )
     }
 }
 
@@ -491,5 +547,69 @@ mod tests {
         };
 
         assert_eq!(stack.expected_parent_gg_id(2), Some("c-a"));
+    }
+
+    #[test]
+    fn prefix_mismatch_returns_warning_data_for_wrong_configured_prefix() {
+        let stack = Stack {
+            name: "feature".to_string(),
+            username: "other".to_string(),
+            base: "main".to_string(),
+            entries: vec![],
+            current_position: None,
+        };
+        let mut config = Config::default();
+        config.defaults.branch_username = Some("testuser".to_string());
+
+        let mismatch = stack.prefix_mismatch(&config).expect("should mismatch");
+
+        assert_eq!(mismatch.current_branch, "other/feature");
+        assert_eq!(mismatch.actual_prefix, "other");
+        assert_eq!(mismatch.expected_prefix, "testuser");
+        assert_eq!(mismatch.stack_name, "feature");
+        assert_eq!(mismatch.suggested_branch, "testuser/feature");
+        assert!(mismatch
+            .warning_message()
+            .contains("git branch -m testuser/feature"));
+    }
+
+    #[test]
+    fn prefix_mismatch_is_none_without_configured_prefix() {
+        let stack = Stack {
+            name: "feature".to_string(),
+            username: "other".to_string(),
+            base: "main".to_string(),
+            entries: vec![],
+            current_position: None,
+        };
+
+        assert!(stack.prefix_mismatch(&Config::default()).is_none());
+    }
+
+    #[test]
+    fn prefix_mismatch_is_none_when_prefix_matches() {
+        let stack = Stack {
+            name: "feature".to_string(),
+            username: "testuser".to_string(),
+            base: "main".to_string(),
+            entries: vec![],
+            current_position: None,
+        };
+        let mut config = Config::default();
+        config.defaults.branch_username = Some("testuser".to_string());
+
+        assert!(stack.prefix_mismatch(&config).is_none());
+    }
+
+    #[test]
+    fn non_stack_branch_error_includes_configured_prefix_hint() {
+        let mut config = Config::default();
+        config.defaults.branch_username = Some("testuser".to_string());
+
+        let message = format_not_stack_branch_error("feature", &config);
+
+        assert!(message.contains("Current branch 'feature' is not a stack branch"));
+        assert!(message.contains("testuser/feature"));
+        assert!(message.contains("git branch -m testuser/feature"));
     }
 }

--- a/docs/src/commands/log.md
+++ b/docs/src/commands/log.md
@@ -7,6 +7,11 @@ with each commit's position, short SHA, title, PR/MR state, CI badge, and a
 `<- HEAD` marker on the currently-checked-out commit. For a cross-stack
 overview use [`gg ls --all`](./ls.md).
 
+If the current stack branch has a valid stack shape but uses a different prefix
+than `defaults.branch_username`, `gg log` warns that stack discovery, listing,
+and saved PR/MR mappings may be inaccurate. Rename the branch to the configured
+prefix to keep stack metadata aligned.
+
 ```bash
 gg log [OPTIONS]
 ```

--- a/docs/src/commands/ls.md
+++ b/docs/src/commands/ls.md
@@ -4,6 +4,12 @@ List the current stack, all local stacks, or remote-only stacks.
 
 When the stack base is behind `origin/<base>`, output includes a `↓N` indicator (`N` = commits behind).
 
+When showing the current stack, if the current branch has a valid stack shape
+but uses a different prefix than `defaults.branch_username`, `gg ls` warns that
+stack discovery, listing, and saved PR/MR mappings may be inaccurate. Rename the
+branch to the configured prefix to keep stack metadata aligned. `gg ls --all`
+and `gg ls --remote` do not show this warning.
+
 ```bash
 gg ls [OPTIONS]
 ```

--- a/docs/src/commands/sync.md
+++ b/docs/src/commands/sync.md
@@ -25,6 +25,11 @@ When you run `gg sync --lint`, lint runs before any push/PR updates. If lint fai
 
 Before pushing, `gg sync` also normalizes commit metadata (`GG-ID` and `GG-Parent`) for the whole stack. This normalization is always enforced during sync (including adding missing `GG-ID` trailers) to keep stack identity and PR/MR mappings stable.
 
+If the current stack branch has a valid stack shape but uses a different prefix
+than `defaults.branch_username`, `gg sync` continues and warns that stack
+discovery, listing, and saved PR/MR mappings may be inaccurate. In `--json`
+mode, this message is included in `sync.warnings`.
+
 If an existing mapped PR/MR is attached to the wrong source branch (for
 example after moving commits into a new stack with `gg unstack`), providers
 cannot retarget that source branch in place. `gg sync` creates a replacement

--- a/docs/src/core-concepts.md
+++ b/docs/src/core-concepts.md
@@ -47,6 +47,10 @@ Example:
 - `nacho/user-auth--c-abc1234`
 
 This convention is what makes remote discovery (`gg ls --remote`) and reconciliation possible.
+If a stack-shaped branch uses a different prefix than `defaults.branch_username`,
+commands such as `gg sync`, `gg log`, and `gg ls` warn that discovery and saved
+PR/MR mappings may be inaccurate. Rename the branch to the configured prefix to
+keep stack metadata aligned.
 
 ## PR/MR dependency chains
 

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -16,7 +16,9 @@ glab auth login
 
 ## "Not on a stack branch"
 
-You're on a branch that doesn't match the stack naming scheme.
+You're on a branch that doesn't match the stack naming scheme,
+`<username>/<stack-name>`. If `branch_username` is configured, gg prints a
+rename hint like `git branch -m <username>/<stack-name>`.
 
 ```bash
 gg co <stack-name>

--- a/skills/gg/SKILL.md
+++ b/skills/gg/SKILL.md
@@ -120,6 +120,11 @@ If a mapped PR/MR still points at an old source branch after a stack split,
 the new number, comments on the old one, and closes it. JSON action is
 `"recreated"`.
 
+If `gg sync --json` returns a warning that the stack branch does not use the
+configured prefix, surface it to the user. The command may continue, but stack
+discovery/listing and saved PR/MR mappings can be inaccurate until the branch is
+renamed to match `defaults.branch_username`.
+
 5. When approved + green CI, land **only after user confirmation**:
 
 ```bash

--- a/skills/gg/reference.md
+++ b/skills/gg/reference.md
@@ -462,6 +462,11 @@ Entry fields match `gg ls --json` so consumers can share parsers.
 }
 ```
 
+`sync.warnings` includes non-fatal diagnostics. For example, when the current
+stack branch uses a different prefix than `defaults.branch_username`, `gg sync`
+continues but reports that stack discovery, listing, and saved PR/MR mappings
+may be inaccurate until the branch is renamed.
+
 Field types for `entries`:
 - `action` (string): `"created"`, `"updated"`, `"up_to_date"`,
   `"skipped_closed"`, `"recreated"`, or `"error"`.


### PR DESCRIPTION
## Summary
- warn when stack commands run from a branch whose prefix differs from defaults.branch_username
- include the sync warning in JSON output via sync.warnings
- improve bare non-stack branch diagnostics with an actionable rename hint
- update docs and gg skill reference

## Validation
- cargo fmt --all
- focused gg-core unit tests
- focused gg-cli integration tests
- cargo clippy --all-targets --all-features -- -D warnings