### PR TITLE
fix(land): avoid duplicate error on gg land --wait interrupt

### DIFF
--- a/crates/gg-core/src/commands/land.rs
+++ b/crates/gg-core/src/commands/land.rs
@@ -1041,8 +1041,8 @@ pub fn run(opts: LandOptions) -> Result<()> {
     // breaking machine consumers that expect a single JSON document.
     if json {
         Ok(())
-    } else if let Some(error) = land_error {
-        Err(GgError::Other(error))
+    } else if let Some(_error) = land_error {
+        Err(GgError::Silenced)
     } else {
         Ok(())
     }


### PR DESCRIPTION
When cancelling gg land --wait with Ctrl-C, the interrupt error was reported twice:
- once by the land command error reporter (Error: Interrupted by user)
- once by the CLI top-level handler (error: Interrupted by user)

This change uses the existing GgError::Silenced pattern (already used by the undo command) to suppress the CLI-level duplicate. The command-level error message stays intact, including its context such as Landed N PR(s), but encountered an error.

Before:

Interrupted. Stopping...

Error: Interrupted by user
error: Interrupted by user


After:

Interrupted. Stopping...

Error: Interrupted by user


Fixes #324