### PR TITLE
feat: add shell auto-cd for worktree checkout (gg co --wt)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,18 @@ gg co my-feature --worktree
 ```
 
 This creates (or reuses) a managed worktree for the stack and checks it out there.
+To also move your shell into that worktree automatically, enable shell integration:
+
+```bash
+# zsh
+eval "$(gg init zsh)"
+
+# bash
+eval "$(gg init bash)"
+
+# fish
+gg init fish | source
+```
 
 ### Unstack into a worktree
 
@@ -244,6 +256,7 @@ gg clean
 | `gg abort` | Abort current operation |
 | `gg undo [OP_ID]` | Reverse the local ref/HEAD effects of the most recent mutating `gg` command (refuses on remote-touching ops) |
 | `gg undo --list` | Show recent operations from the per-repo operation log |
+| `gg init <shell>` | Generate shell integration for auto-cd |
 | `gg completions <shell>` | Generate shell completions |
 
 ## Configuration
@@ -551,6 +564,23 @@ git-gud includes an MCP (Model Context Protocol) server that lets AI assistants 
 | **Output** | Typed JSON responses | Parses CLI text or `--json` output |
 
 Use **MCP** when your AI client supports it. Use **Skills** when the agent has direct terminal access and you want zero extra setup.
+
+## Shell Integration
+
+Shell integration lets `gg co <stack> --wt` move your current shell into the created or reused worktree. Add the matching line to your shell config:
+
+```bash
+# Bash
+eval "$(gg init bash)"
+
+# Zsh
+eval "$(gg init zsh)"
+
+# Fish
+gg init fish | source
+```
+
+Without shell integration, `gg co --wt` still creates or reuses the worktree and prints its path, but your shell stays in the original checkout.
 
 ## Shell Completions
 

--- a/crates/gg-cli/src/main.rs
+++ b/crates/gg-cli/src/main.rs
@@ -406,6 +406,14 @@ enum Commands {
         shell: clap_complete::Shell,
     },
 
+    /// Generate shell integration for parent-shell features
+    #[command(name = "init")]
+    Init {
+        /// Shell to generate integration for
+        #[arg(value_enum)]
+        shell: gg_core::commands::init::Shell,
+    },
+
     /// Arrange commits in the stack: reorder and/or drop interactively (alias for reorder)
     #[command(name = "arrange")]
     Arrange {
@@ -743,6 +751,7 @@ fn main() {
         Some(Commands::Completions { shell }) => {
             (gg_core::commands::completions::run(shell), false)
         }
+        Some(Commands::Init { shell }) => (gg_core::commands::init::run(shell), false),
         Some(Commands::Reconcile { dry_run }) => {
             (gg_core::commands::reconcile::run(dry_run), false)
         }

--- a/crates/gg-cli/tests/integration_tests/checkout.rs
+++ b/crates/gg-cli/tests/integration_tests/checkout.rs
@@ -1,6 +1,9 @@
-use crate::helpers::{create_test_repo, create_test_repo_with_remote, run_gg, run_git};
+use crate::helpers::{
+    create_test_repo, create_test_repo_with_remote, run_gg, run_gg_with_env, run_git,
+};
 
 use std::fs;
+use std::path::Path;
 
 #[test]
 fn test_gg_checkout_creates_branch() {
@@ -179,4 +182,137 @@ fn test_gg_checkout_with_worktree_creates_worktree_and_preserves_main_repo_head(
         "Expected worktree path to exist: {}",
         expected_path.display()
     );
+}
+
+#[test]
+fn test_gg_checkout_with_worktree_requests_shell_cd() {
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .expect("Failed to write config");
+
+    let cd_file = repo_path.join(".git/gg/cd-target");
+    let cd_file_os = cd_file.as_os_str();
+    let (success, stdout, stderr) = run_gg_with_env(
+        &repo_path,
+        &["co", "cd-stack", "--wt"],
+        &[("GG_CD_FILE", cd_file_os)],
+    );
+    assert!(
+        success,
+        "checkout --wt should succeed: stdout={}, stderr={}",
+        stdout, stderr
+    );
+
+    let cd_target = fs::read_to_string(&cd_file).expect("Failed to read cd target");
+    assert!(
+        Path::new(&cd_target).exists(),
+        "cd target should exist: {}",
+        cd_target
+    );
+    assert!(
+        cd_target.ends_with(".cd-stack"),
+        "cd target should point to the stack worktree: {}",
+        cd_target
+    );
+}
+
+#[test]
+fn test_gg_checkout_existing_worktree_requests_shell_cd() {
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .expect("Failed to write config");
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["co", "existing-cd-stack", "--wt"]);
+    assert!(
+        success,
+        "initial checkout --wt should succeed: stdout={}, stderr={}",
+        stdout, stderr
+    );
+
+    let cd_file = repo_path.join(".git/gg/cd-target-existing");
+    let cd_file_os = cd_file.as_os_str();
+    let (success, stdout, stderr) = run_gg_with_env(
+        &repo_path,
+        &["co", "existing-cd-stack", "--wt"],
+        &[("GG_CD_FILE", cd_file_os)],
+    );
+    assert!(
+        success,
+        "existing checkout --wt should succeed: stdout={}, stderr={}",
+        stdout, stderr
+    );
+
+    let cd_target = fs::read_to_string(&cd_file).expect("Failed to read cd target");
+    assert!(
+        Path::new(&cd_target).exists(),
+        "cd target should exist: {}",
+        cd_target
+    );
+    assert!(
+        cd_target.ends_with(".existing-cd-stack"),
+        "cd target should point to the stack worktree: {}",
+        cd_target
+    );
+}
+
+#[test]
+fn test_gg_checkout_without_worktree_does_not_request_shell_cd() {
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .expect("Failed to write config");
+
+    let cd_file = repo_path.join(".git/gg/cd-target-plain");
+    let cd_file_os = cd_file.as_os_str();
+    let (success, stdout, stderr) = run_gg_with_env(
+        &repo_path,
+        &["co", "plain-stack"],
+        &[("GG_CD_FILE", cd_file_os)],
+    );
+    assert!(
+        success,
+        "plain checkout should succeed: stdout={}, stderr={}",
+        stdout, stderr
+    );
+    assert!(!cd_file.exists(), "plain checkout should not request cd");
+}
+
+#[test]
+fn test_gg_checkout_failure_does_not_request_shell_cd() {
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .expect("Failed to write config");
+
+    let cd_file = repo_path.join(".git/gg/cd-target-failed");
+    let cd_file_os = cd_file.as_os_str();
+    let (success, _stdout, _stderr) = run_gg_with_env(
+        &repo_path,
+        &["co", "bad/stack", "--wt"],
+        &[("GG_CD_FILE", cd_file_os)],
+    );
+    assert!(!success, "invalid stack checkout should fail");
+    assert!(!cd_file.exists(), "failed checkout should not request cd");
 }

--- a/crates/gg-cli/tests/integration_tests/misc.rs
+++ b/crates/gg-cli/tests/integration_tests/misc.rs
@@ -44,6 +44,41 @@ fn test_completions() {
 }
 
 #[test]
+fn test_init_shell_integration() {
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["init", "bash"]);
+    assert!(success, "bash init should succeed: {}", stderr);
+    assert!(stdout.contains("gg()"));
+    assert!(stdout.contains("GG_CD_FILE"));
+    assert!(stdout.contains("command gg"));
+    assert!(stdout.contains("cd \"$gg_cd_target\""));
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["init", "zsh"]);
+    assert!(success, "zsh init should succeed: {}", stderr);
+    assert!(stdout.contains("gg()"));
+    assert!(stdout.contains("GG_CD_FILE"));
+    assert!(stdout.contains("command gg"));
+    assert!(stdout.contains("cd \"$gg_cd_target\""));
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["init", "fish"]);
+    assert!(success, "fish init should succeed: {}", stderr);
+    assert!(stdout.contains("function gg"));
+    assert!(stdout.contains("GG_CD_FILE"));
+    assert!(stdout.contains("command gg $argv"));
+    assert!(stdout.contains("cd \"$gg_cd_target\""));
+}
+
+#[test]
+fn test_init_rejects_unsupported_shell() {
+    let (_temp_dir, repo_path) = create_test_repo();
+    let (success, _stdout, stderr) = run_gg(&repo_path, &["init", "powershell"]);
+
+    assert!(!success);
+    assert!(stderr.contains("invalid value") || stderr.contains("possible values"));
+}
+
+#[test]
 fn test_stack_name_sanitization_spaces_to_kebab() {
     let (_temp_dir, repo_path) = create_test_repo();
 

--- a/crates/gg-core/src/commands/checkout.rs
+++ b/crates/gg-core/src/commands/checkout.rs
@@ -92,6 +92,7 @@ pub fn run(stack_name: Option<String>, base: Option<String>, use_worktree: bool)
         if use_worktree {
             let worktree_path =
                 ensure_stack_worktree(&repo, &mut config, &stack_name, &branch_name)?;
+            request_shell_cd(&worktree_path);
             println!(
                 "{} Opened stack {} in worktree {}",
                 style("OK").green().bold(),
@@ -114,6 +115,7 @@ pub fn run(stack_name: Option<String>, base: Option<String>, use_worktree: bool)
         if use_worktree {
             let worktree_path =
                 ensure_stack_worktree(&repo, &mut config, &stack_name, &entry_branch)?;
+            request_shell_cd(&worktree_path);
             println!(
                 "{} Opened stack {} in worktree {}",
                 style("OK").green().bold(),
@@ -167,12 +169,18 @@ pub fn run(stack_name: Option<String>, base: Option<String>, use_worktree: bool)
             let local_branch = git::format_stack_branch(&username, &stack_name);
             repo.branch(&local_branch, &remote_commit, false)?;
 
-            if use_worktree {
-                ensure_stack_worktree(&repo, &mut config, &stack_name, &local_branch)?;
+            let worktree_path = if use_worktree {
+                Some(ensure_stack_worktree(
+                    &repo,
+                    &mut config,
+                    &stack_name,
+                    &local_branch,
+                )?)
             } else {
                 // Checkout the branch
                 git::checkout_branch(&repo, &local_branch)?;
-            }
+                None
+            };
 
             // Import PR mappings from remote
             if let Err(e) =
@@ -198,15 +206,13 @@ pub fn run(stack_name: Option<String>, base: Option<String>, use_worktree: bool)
             }
 
             if use_worktree {
-                let worktree_path = config
-                    .get_stack(&stack_name)
-                    .and_then(|stack| stack.worktree_path.as_deref())
-                    .unwrap_or("<unknown>");
+                let worktree_path = worktree_path.expect("worktree path should be set");
+                request_shell_cd(&worktree_path);
                 println!(
                     "{} Checked out remote stack {} in worktree {}",
                     style("OK").green().bold(),
                     style(&stack_name).cyan(),
-                    style(worktree_path).yellow()
+                    style(worktree_path.display()).yellow()
                 );
             } else {
                 println!(
@@ -259,6 +265,7 @@ pub fn run(stack_name: Option<String>, base: Option<String>, use_worktree: bool)
             if use_worktree {
                 let worktree_path =
                     ensure_stack_worktree(&repo, &mut config, &stack_name, &branch_name)?;
+                request_shell_cd(&worktree_path);
                 println!(
                     "{} Created stack {} based on {} in worktree {}",
                     style("OK").green().bold(),
@@ -337,6 +344,14 @@ pub(crate) fn ensure_stack_worktree(
     Ok(target_path)
 }
 
+fn request_shell_cd(path: &Path) {
+    let Ok(cd_file) = std::env::var("GG_CD_FILE") else {
+        return;
+    };
+
+    let _ = std::fs::write(cd_file, path.to_string_lossy().as_bytes());
+}
+
 fn is_worktree_registered(repo_root: &Path, target_path: &Path) -> bool {
     let output = Command::new("git")
         .arg("worktree")
@@ -353,11 +368,24 @@ fn is_worktree_registered(repo_root: &Path, target_path: &Path) -> bool {
         return false;
     }
 
+    let canonical_target = target_path.canonicalize().ok();
     let target = target_path.to_string_lossy();
     let stdout = String::from_utf8_lossy(&output.stdout);
-    stdout
-        .lines()
-        .any(|line| line == format!("worktree {}", target))
+    stdout.lines().any(|line| {
+        if let Some(path) = line.strip_prefix("worktree ") {
+            if path == target {
+                return true;
+            }
+
+            if let Some(canonical_target) = &canonical_target {
+                return Path::new(path)
+                    .canonicalize()
+                    .is_ok_and(|worktree_path| worktree_path == *canonical_target);
+            }
+        }
+
+        false
+    })
 }
 
 /// Find a remote entry branch for a stack (returns the first one found)

--- a/crates/gg-core/src/commands/completions.rs
+++ b/crates/gg-core/src/commands/completions.rs
@@ -96,6 +96,11 @@ enum Commands {
     },
     #[command(name = "absorb")]
     Absorb,
+    #[command(name = "init")]
+    Init {
+        #[arg(value_enum)]
+        shell: crate::commands::init::Shell,
+    },
     #[command(name = "completions")]
     Completions {
         #[arg(value_enum)]

--- a/crates/gg-core/src/commands/init.rs
+++ b/crates/gg-core/src/commands/init.rs
@@ -1,0 +1,98 @@
+//! `gg init` - Generate shell integration
+
+use clap::ValueEnum;
+
+use crate::error::Result;
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum Shell {
+    Bash,
+    Zsh,
+    Fish,
+}
+
+/// Run the init command
+pub fn run(shell: Shell) -> Result<()> {
+    print!("{}", shell.template());
+    Ok(())
+}
+
+impl Shell {
+    fn template(self) -> &'static str {
+        match self {
+            Shell::Bash => BASH_TEMPLATE,
+            Shell::Zsh => ZSH_TEMPLATE,
+            Shell::Fish => FISH_TEMPLATE,
+        }
+    }
+}
+
+const BASH_TEMPLATE: &str = r#"# git-gud shell integration
+gg() {
+    local gg_cd_file
+    gg_cd_file="$(mktemp "${TMPDIR:-/tmp}/gg-cd.XXXXXX")" || return
+
+    GG_CD_FILE="$gg_cd_file" command gg "$@"
+    local gg_status=$?
+
+    if [ "$gg_status" -eq 0 ] && [ -s "$gg_cd_file" ]; then
+        local gg_cd_target
+        gg_cd_target="$(cat "$gg_cd_file")"
+        if [ -n "$gg_cd_target" ]; then
+            cd "$gg_cd_target" || gg_status=$?
+        fi
+    fi
+
+    rm -f "$gg_cd_file"
+    return "$gg_status"
+}
+"#;
+
+const ZSH_TEMPLATE: &str = r#"# git-gud shell integration
+gg() {
+    local gg_cd_file
+    gg_cd_file="$(mktemp "${TMPDIR:-/tmp}/gg-cd.XXXXXX")" || return
+
+    GG_CD_FILE="$gg_cd_file" command gg "$@"
+    local gg_status=$?
+
+    if [ "$gg_status" -eq 0 ] && [ -s "$gg_cd_file" ]; then
+        local gg_cd_target
+        gg_cd_target="$(cat "$gg_cd_file")"
+        if [ -n "$gg_cd_target" ]; then
+            cd "$gg_cd_target" || gg_status=$?
+        fi
+    fi
+
+    rm -f "$gg_cd_file"
+    return "$gg_status"
+}
+"#;
+
+const FISH_TEMPLATE: &str = r#"# git-gud shell integration
+function gg
+    set -l gg_tmp_dir "$TMPDIR"
+    if test -z "$gg_tmp_dir"
+        set gg_tmp_dir /tmp
+    end
+
+    set -l gg_cd_file (mktemp "$gg_tmp_dir/gg-cd.XXXXXX")
+    if test $status -ne 0
+        return
+    end
+
+    env GG_CD_FILE="$gg_cd_file" command gg $argv
+    set -l gg_status $status
+
+    if test $gg_status -eq 0; and test -s "$gg_cd_file"
+        set -l gg_cd_target (cat "$gg_cd_file")
+        if test -n "$gg_cd_target"
+            cd "$gg_cd_target"
+            set gg_status $status
+        end
+    end
+
+    rm -f "$gg_cd_file"
+    return $gg_status
+end
+"#;

--- a/crates/gg-core/src/commands/init.rs
+++ b/crates/gg-core/src/commands/init.rs
@@ -81,7 +81,7 @@ function gg
         return
     end
 
-    env GG_CD_FILE="$gg_cd_file" command gg $argv
+    GG_CD_FILE="$gg_cd_file" command gg $argv
     set -l gg_status $status
 
     if test $gg_status -eq 0; and test -s "$gg_cd_file"

--- a/crates/gg-core/src/commands/mod.rs
+++ b/crates/gg-core/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod clean;
 pub mod completions;
 pub mod drop_cmd;
 pub mod inbox;
+pub mod init;
 pub mod land;
 pub mod lint;
 pub mod log;

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -37,5 +37,5 @@
   - [undo](./commands/undo.md)
 - [MCP Server](./mcp-server.md)
 - [Configuration](./configuration.md)
-- [Shell Completions](./shell-completions.md)
+- [Shell Integration and Completions](./shell-completions.md)
 - [Troubleshooting / FAQ](./faq.md)

--- a/docs/src/commands/README.md
+++ b/docs/src/commands/README.md
@@ -8,4 +8,4 @@ Unlike the guides, this section is organized by command surface and flags. Each 
 
 - Stack lifecycle: `co`, `ls`, `sync`, `land`, `clean`
 - Editing: `mv`, `first`, `last`, `prev`, `next`, `sc`, `absorb`, `reorder`, `split`, `unstack`, `rebase`
-- Utilities: `lint`, `setup`, `reconcile`, `continue`, `abort`, `completions`
+- Utilities: `lint`, `setup`, `reconcile`, `continue`, `abort`, `init`, `completions`

--- a/docs/src/commands/co.md
+++ b/docs/src/commands/co.md
@@ -23,3 +23,12 @@ gg co user-auth --base develop
 # Create stack in worktree
 gg co user-auth --worktree
 ```
+
+With shell integration enabled, `gg co user-auth --worktree` also changes your current shell directory to the stack worktree after the command succeeds:
+
+```bash
+eval "$(gg init zsh)"  # or bash
+gg init fish | source # fish
+```
+
+Without shell integration, git-gud prints the worktree path and leaves your shell in the original checkout.

--- a/docs/src/guides/worktrees.md
+++ b/docs/src/guides/worktrees.md
@@ -8,6 +8,21 @@ Worktrees let you keep your main checkout clean while developing a stack in a de
 gg co user-auth --worktree
 ```
 
+To move your shell into the worktree automatically after checkout, enable shell integration:
+
+```bash
+# zsh
+eval "$(gg init zsh)"
+
+# bash
+eval "$(gg init bash)"
+
+# fish
+gg init fish | source
+```
+
+Without shell integration, `gg co --worktree` prints the worktree path and leaves your shell in the original checkout.
+
 Short flag:
 
 ```bash

--- a/docs/src/shell-completions.md
+++ b/docs/src/shell-completions.md
@@ -1,4 +1,25 @@
-# Shell Completions
+# Shell Integration and Completions
+
+## Shell integration
+
+Shell integration enables parent-shell features. Today that means `gg co <stack> --wt` can move your shell into the created or reused worktree after the command succeeds.
+
+Add the matching line to your shell config:
+
+```bash
+# Bash
+eval "$(gg init bash)"
+
+# Zsh
+eval "$(gg init zsh)"
+
+# Fish
+gg init fish | source
+```
+
+Without shell integration, `gg co --wt` still creates or reuses the worktree and prints its path, but your shell stays in the original checkout.
+
+## Shell completions
 
 Generate completions with:
 

--- a/docs/src/worktrees.md
+++ b/docs/src/worktrees.md
@@ -10,6 +10,15 @@ gg co my-feature --wt
 gg co my-feature --worktree
 ```
 
+Enable shell integration to automatically enter the stack worktree after `gg co --wt` succeeds:
+
+```bash
+eval "$(gg init zsh)"  # or bash
+gg init fish | source # fish
+```
+
+Without shell integration, git-gud prints the worktree path and your shell remains in the original checkout.
+
 ## Unstack into a worktree
 
 ```bash

--- a/skills/gg/SKILL.md
+++ b/skills/gg/SKILL.md
@@ -87,6 +87,8 @@ Store shared defaults in `~/.config/gg/config.json` that apply to all repos. Loc
 gg co -w feature-auth
 ```
 
+When shell integration is installed (`eval "$(gg init zsh)"`, `eval "$(gg init bash)"`, or `gg init fish | source`), `gg co -w` changes into the stack worktree after checkout succeeds. Without it, read the printed worktree path and `cd` there before editing.
+
 When splitting an existing stack into lower and upper stacks, prefer a managed
 worktree for the new upper stack:
 
@@ -135,7 +137,7 @@ gg land -a -c --json
 
 1. **Never run `gg land` without explicit user confirmation.**
 2. **Always use `--json`** for `gg ls`, `gg sync`, `gg land`, `gg clean -a`, and `gg lint`.
-3. **Prefer worktrees** for isolation (`gg co -w <stack>`).
+3. **Prefer worktrees** for isolation (`gg co -w <stack>`). If shell integration is unavailable, manually `cd` to the printed worktree path before editing.
 4. Verify `approved: true` and `ci_status` success before landing. If the user requests `--admin`, skip the approval check (GitHub only — GitLab ignores the flag).
 5. If sync warns stack is behind base, run `gg rebase` first.
 6. Prefer `gg absorb -s` for multi-commit edits.

--- a/skills/gg/reference.md
+++ b/skills/gg/reference.md
@@ -59,6 +59,13 @@ Create/switch stack, optionally worktree-backed.
 - `-b, --base <BASE>`
 - `-w, --worktree`
 
+With shell integration installed, worktree checkout also changes the current shell directory to the stack worktree after success:
+
+```bash
+eval "$(gg init zsh)"  # or bash
+gg init fish | source # fish
+```
+
 #### `gg ls [OPTIONS]`
 List current/all/remote stacks.
 
@@ -280,6 +287,9 @@ Supports global config at `~/.config/gg/config.json` for shared defaults across 
 
 #### `gg completions <SHELL>`
 Generate shell completion (`bash|elvish|fish|powershell|zsh`).
+
+#### `gg init <SHELL>`
+Generate shell integration (`bash|fish|zsh`). This is required for `gg co --wt` to auto-cd into the created or reused worktree.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `gg init <bash|zsh|fish>` command that outputs a shell wrapper function for auto-cd after `gg co <stack> --wt`
- `gg co <stack> --wt` now writes the target worktree path to `GG_CD_FILE` (temp-file side channel) so the wrapper can `cd` into it on success
- Plain `gg co <stack>` remains unchanged — no cd request emitted
- Fixes `is_worktree_registered` to canonicalize paths before comparison (fixes `/tmp` vs `/private/tmp` on macOS)

## Shell Integration

Users enable auto-cd by adding to their shell config:

```bash
eval "$(gg init zsh)"   # or bash, fish
```

Without shell integration, `gg co --wt` behavior is unchanged — it prints the worktree path but doesn't cd.

## Key Files

- `crates/gg-core/src/commands/init.rs` — shell integration command
- `crates/gg-core/src/commands/checkout.rs` — `request_shell_cd` helper + worktree path tracking
- `crates/gg-cli/src/main.rs` — CLI wiring for `gg init`
- `crates/gg-core/src/commands/completions.rs` — completions model update
- Integration tests for GG_CD_FILE contract (new/existing/plain/failed checkout)
- Shell init output tests
- Docs: `co.md`, `worktrees.md`, `worktrees guide`, `shell-completions.md`, `README.md`
- Skills: `SKILL.md`, `reference.md`

Closes #752