### PR TITLE
feat(reconcile): add non-interactive --yes flag

### DIFF
--- a/crates/gg-cli/src/main.rs
+++ b/crates/gg-cli/src/main.rs
@@ -437,6 +437,11 @@ enum Commands {
         /// Show what would be done without making changes
         #[arg(short = 'n', long)]
         dry_run: bool,
+        /// Skip the metadata normalization confirmation prompt. Use this for
+        /// non-interactive callers (CI, MCP) that intentionally want the
+        /// reconcile operation to proceed.
+        #[arg(short = 'y', long = "yes")]
+        yes: bool,
     },
 
     /// Show actionable inbox triage across all stacks
@@ -752,9 +757,13 @@ fn main() {
             (gg_core::commands::completions::run(shell), false)
         }
         Some(Commands::Init { shell }) => (gg_core::commands::init::run(shell), false),
-        Some(Commands::Reconcile { dry_run }) => {
-            (gg_core::commands::reconcile::run(dry_run), false)
-        }
+        Some(Commands::Reconcile { dry_run, yes }) => (
+            gg_core::commands::reconcile::run(gg_core::commands::reconcile::ReconcileOptions {
+                dry_run,
+                yes,
+            }),
+            false,
+        ),
         Some(Commands::Inbox { all, json }) => (gg_core::commands::inbox::run(all, json), json),
         Some(Commands::Restack {
             dry_run,

--- a/crates/gg-cli/tests/integration_tests/reconcile.rs
+++ b/crates/gg-cli/tests/integration_tests/reconcile.rs
@@ -9,6 +9,7 @@ fn test_reconcile_help() {
 
     assert!(success);
     assert!(stdout.contains("--dry-run") || stdout.contains("-n"));
+    assert!(stdout.contains("--yes") || stdout.contains("-y"));
     assert!(stdout.contains("Reconcile") || stdout.contains("reconcile"));
 }
 
@@ -133,6 +134,44 @@ fn test_reconcile_not_on_stack() {
             || stderr.contains("error"),
         "Should fail with error when not on a stack: {}",
         stderr
+    );
+}
+
+#[test]
+fn test_reconcile_yes_flag_parsing() {
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    // Set up config
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser","provider":"github"}}"#,
+    )
+    .expect("Failed to write config");
+
+    // Create a stack
+    run_gg(&repo_path, &["co", "test-yes-parsing"]);
+
+    // Make a commit without GG-ID
+    fs::write(repo_path.join("file.txt"), "content").expect("Failed to write file");
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "Commit without GG-ID"]);
+
+    // --dry-run --yes should parse and run (yes has no effect in dry-run)
+    let (success, stdout, stderr) = run_gg(&repo_path, &["reconcile", "--dry-run", "--yes"]);
+    assert!(
+        success,
+        "--dry-run --yes should parse and succeed: {} {}",
+        stdout, stderr
+    );
+
+    // -y short form should also parse
+    let (success2, stdout2, stderr2) = run_gg(&repo_path, &["reconcile", "--dry-run", "-y"]);
+    assert!(
+        success2,
+        "--dry-run -y should parse and succeed: {} {}",
+        stdout2, stderr2
     );
 }
 

--- a/crates/gg-core/src/commands/reconcile.rs
+++ b/crates/gg-core/src/commands/reconcile.rs
@@ -40,14 +40,44 @@ struct PrMapping {
     pr_number: u64,
 }
 
+/// Decide whether to normalize metadata, respecting `--yes`.
+///
+/// When `yes` is true, the interactive prompt is skipped and the operation
+/// proceeds. When false, the user is asked via `dialoguer::Confirm`.
+fn should_normalize_metadata_with<F>(yes: bool, confirm: F) -> bool
+where
+    F: FnOnce() -> bool,
+{
+    yes || confirm()
+}
+
+/// Production wrapper that uses `dialoguer::Confirm`.
+fn should_normalize_metadata(yes: bool) -> bool {
+    should_normalize_metadata_with(yes, || {
+        Confirm::new()
+            .with_prompt("Normalize GG metadata on commits? (requires rebase)")
+            .default(true)
+            .interact()
+            .unwrap_or(false)
+    })
+}
+
 impl ReconcileActions {
     fn is_empty(&self) -> bool {
         self.commits_needing_ids.is_empty() && self.prs_to_map.is_empty()
     }
 }
 
+/// Options for the reconcile command.
+pub struct ReconcileOptions {
+    /// Preview only; make no changes.
+    pub dry_run: bool,
+    /// Skip the metadata normalization confirmation prompt.
+    pub yes: bool,
+}
+
 /// Run the reconcile command
-pub fn run(dry_run: bool) -> Result<()> {
+pub fn run(options: ReconcileOptions) -> Result<()> {
     let repo = git::open_repo()?;
     let git_dir = repo.commondir();
     let mut config = Config::load_with_global(git_dir)?;
@@ -70,7 +100,7 @@ pub fn run(dry_run: bool) -> Result<()> {
 
     // Only check installed/auth if not doing a dry run
     // (dry run can show what would be done without actual provider access)
-    if !dry_run {
+    if !options.dry_run {
         provider.check_installed()?;
         provider.check_auth()?;
     }
@@ -116,7 +146,7 @@ pub fn run(dry_run: bool) -> Result<()> {
 
     // Phase 2: Find PRs/MRs for entry branches that aren't mapped
     // In dry-run mode, try to find PRs but don't fail if provider isn't available
-    let prs_to_map = if dry_run {
+    let prs_to_map = if options.dry_run {
         // Check if provider is available before trying to list PRs
         if provider.check_installed().is_ok() && provider.check_auth().is_ok() {
             find_unmapped_prs(&repo, &stack, &config, &provider)?
@@ -154,7 +184,7 @@ pub fn run(dry_run: bool) -> Result<()> {
         return Ok(());
     }
 
-    if dry_run {
+    if options.dry_run {
         println!("\n{} Dry run complete. No changes made.", style("→").cyan());
         guard.finalize_with_scope(
             &repo,
@@ -166,13 +196,9 @@ pub fn run(dry_run: bool) -> Result<()> {
         return Ok(());
     }
 
-    // Confirm before proceeding
+    // Confirm before proceeding (skipped when --yes is passed)
     if !actions.commits_needing_ids.is_empty() {
-        let should_add_ids = Confirm::new()
-            .with_prompt("Normalize GG metadata on commits? (requires rebase)")
-            .default(true)
-            .interact()
-            .unwrap_or(false);
+        let should_add_ids = should_normalize_metadata(options.yes);
 
         if should_add_ids {
             git::normalize_stack_metadata(&repo, &stack)?;
@@ -325,6 +351,58 @@ fn map_prs(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_should_normalize_metadata_with_yes_true() {
+        let called = std::cell::Cell::new(false);
+        let result = should_normalize_metadata_with(true, || {
+            called.set(true);
+            false
+        });
+        assert!(result, "yes=true should always return true");
+        assert!(
+            !called.get(),
+            "confirm closure should not be called when yes=true"
+        );
+    }
+
+    #[test]
+    fn test_should_normalize_metadata_with_yes_false_delegates() {
+        let called = std::cell::Cell::new(false);
+        let result = should_normalize_metadata_with(false, || {
+            called.set(true);
+            true
+        });
+        assert!(result);
+        assert!(
+            called.get(),
+            "confirm closure should be called when yes=false"
+        );
+    }
+
+    #[test]
+    fn test_should_normalize_metadata_with_yes_false_respects_negative() {
+        let called = std::cell::Cell::new(false);
+        let result = should_normalize_metadata_with(false, || {
+            called.set(true);
+            false
+        });
+        assert!(!result);
+        assert!(
+            called.get(),
+            "confirm closure should be called when yes=false"
+        );
+    }
+
+    #[test]
+    fn test_reconcile_options_defaults() {
+        let opts = ReconcileOptions {
+            dry_run: false,
+            yes: false,
+        };
+        assert!(!opts.dry_run);
+        assert!(!opts.yes);
+    }
 
     #[test]
     fn test_reconcile_actions_is_empty() {

--- a/crates/gg-mcp/src/tools.rs
+++ b/crates/gg-mcp/src/tools.rs
@@ -272,6 +272,11 @@ pub struct StackReconcileParams {
     /// Show what would change without making changes
     #[serde(default)]
     pub dry_run: bool,
+    /// Skip the metadata normalization confirmation prompt.
+    /// Use for non-interactive callers (CI, MCP) that intentionally want
+    /// the reconcile operation to proceed.
+    #[serde(default)]
+    pub yes: bool,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -871,7 +876,7 @@ impl GgMcpServer {
 
     /// Reconcile remotely-pushed branches with the local stack.
     #[tool(
-        description = "Reconcile out-of-sync branches that were pushed outside of gg (e.g., from CI or web UI edits)"
+        description = "Reconcile out-of-sync branches that were pushed outside of gg (e.g., from CI or web UI edits). Pass yes=true to skip the confirmation prompt for non-interactive callers."
     )]
     fn stack_reconcile(
         &self,
@@ -880,6 +885,9 @@ impl GgMcpServer {
         let mut args = vec!["reconcile".to_string()];
         if params.dry_run {
             args.push("--dry-run".to_string());
+        }
+        if params.yes {
+            args.push("--yes".to_string());
         }
         run_gg_command(&args)
     }
@@ -1221,6 +1229,21 @@ mod tests {
         }
         // Verify server is usable (not consumed by tests above)
         assert!(server.get_info().instructions.is_some());
+    }
+
+    #[test]
+    fn test_reconcile_params_defaults() {
+        let params: StackReconcileParams = serde_json::from_str("{}").unwrap();
+        assert!(!params.dry_run);
+        assert!(!params.yes);
+    }
+
+    #[test]
+    fn test_reconcile_params_with_yes() {
+        let params: StackReconcileParams =
+            serde_json::from_str(r#"{"yes": true, "dry_run": true}"#).unwrap();
+        assert!(params.yes);
+        assert!(params.dry_run);
     }
 
     #[test]

--- a/docs/src/commands/reconcile.md
+++ b/docs/src/commands/reconcile.md
@@ -9,6 +9,7 @@ gg reconcile [OPTIONS]
 ## Options
 
 - `-n, --dry-run`: Preview only; make no changes
+- `-y, --yes`: Skip the metadata normalization confirmation prompt. Use for non-interactive callers such as agents, MCP, or CI when you intentionally want reconciliation to proceed.
 
 ## What it does
 
@@ -23,4 +24,7 @@ gg reconcile --dry-run
 
 # Apply reconciliation
 gg reconcile
+
+# Non-interactive / agent usage — skip the confirmation prompt
+gg reconcile --yes
 ```

--- a/skills/gg/SKILL.md
+++ b/skills/gg/SKILL.md
@@ -358,7 +358,7 @@ The `gg-mcp` binary exposes git-gud as an MCP server (stdio transport). Set `GG_
 - `stack_clean` — remove merged stacks
 - `stack_rebase` — rebase onto latest base
 - `stack_squash` / `stack_absorb` — amend commits
-- `stack_reconcile` — fix out-of-sync remote branches
+- `stack_reconcile` — fix out-of-sync remote branches (pass `yes: true` to skip the metadata normalization confirmation prompt in non-interactive/MCP contexts; this does not bypass safety checks or immutability protections)
 - `stack_drop` — remove commits from the stack (always passes `--yes`; set `force: true` only to bypass the immutability guard for merged/base commits; agent confirms with user before any drop)
 - `stack_split` — split a commit using interactive hunk selection (TUI opens by default; pass FILES... to auto-select all hunks for those files)
 - `stack_reorder` — reorder commits with explicit order string (no TUI)

--- a/skills/gg/reference.md
+++ b/skills/gg/reference.md
@@ -233,6 +233,7 @@ Repair metadata after external branch/PR/MR manipulation.
 
 - Normalizes `GG-ID` and `GG-Parent` trailers across the stack
 - `-n, --dry-run`
+- `-y, --yes` — skip the metadata normalization confirmation prompt for non-interactive callers. Does not bypass safety checks or immutability protections.
 
 #### `gg continue` / `gg abort`
 Resume/abort paused operations.
@@ -843,7 +844,7 @@ Auto-absorb staged changes into correct commits.
 
 #### `stack_reconcile`
 Reconcile out-of-sync remote branches.
-- **Params:** `dry_run` (bool)
+- **Params:** `dry_run` (bool), `yes` (bool, default false) — skip the metadata normalization confirmation prompt for non-interactive callers
 
 #### `stack_move`
 Move to a specific commit in the stack.


### PR DESCRIPTION
## Summary

- Adds `-y, --yes` flag to `gg reconcile` so non-interactive callers (LLM agents, MCP, CI) can skip the metadata normalization confirmation prompt
- Mirrors the existing `gg drop --yes` convention — only skips the `dialoguer::Confirm` prompt, does not bypass safety checks or immutability protections
- Includes `ReconcileOptions` struct for type-safe dispatch, testable `should_normalize_metadata_with` helper, MCP `yes` param forwarding, and updated docs/reference

Closes #331