### PR TITLE
fix(sync): clarify immutable auto-rebase hint

### DIFF
--- a/crates/gg-cli/tests/integration_tests/sync.rs
+++ b/crates/gg-cli/tests/integration_tests/sync.rs
@@ -792,3 +792,118 @@ fn test_sync_until_nonexistent_target() {
         stderr
     );
 }
+
+#[test]
+fn test_sync_auto_rebase_shows_rebase_force_hint_on_immutable_commit() {
+    // Reproduces the confusing UX where `gg sync --force` still fails with
+    // an immutable-commit error, because the actual override is on
+    // `gg rebase --force` / `gg rebase --ignore-immutable`.
+    let (_temp_dir, repo_path, _remote_path) = create_test_repo_with_remote();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser","provider":"github","sync_auto_rebase":true,"sync_behind_threshold":1}}"#,
+    )
+    .expect("Failed to write config");
+
+    let (success, _, stderr) = run_gg(&repo_path, &["co", "immutable-sync-test"]);
+    assert!(success, "Failed to create stack: {}", stderr);
+
+    // Create two commits on the stack.
+    // Commit #1 stays mutable so the guard cannot drop #2 via
+    // without_bottom_merged_prs().
+    fs::write(repo_path.join("stack1.txt"), "stack1\n").expect("Failed to write stack1 file");
+    run_git(&repo_path, &["add", "."]);
+    run_git(
+        &repo_path,
+        &["commit", "-m", "Stack commit 1\n\nGG-ID: c-1111111"],
+    );
+
+    fs::write(repo_path.join("stack2.txt"), "stack2\n").expect("Failed to write stack2 file");
+    run_git(&repo_path, &["add", "."]);
+    run_git(
+        &repo_path,
+        &["commit", "-m", "Stack commit 2\n\nGG-ID: c-2222222"],
+    );
+
+    // Inject a merged MR mapping for commit #2 into the config after gg co
+    // created the stack entry.
+    let stack_branch = git_current_branch(&repo_path);
+    let config_json = fs::read_to_string(gg_dir.join("config.json")).unwrap_or_default();
+    let mut config: serde_json::Value =
+        serde_json::from_str(&config_json).expect("config.json must be valid JSON after gg co");
+    config["stacks"]["immutable-sync-test"]["mrs"]["c-2222222"] = serde_json::json!(99);
+    fs::write(
+        gg_dir.join("config.json"),
+        serde_json::to_string_pretty(&config).unwrap(),
+    )
+    .expect("Failed to write merged config");
+
+    // Advance origin/main so the behind-base check triggers auto-rebase.
+    run_git(&repo_path, &["checkout", "main"]);
+    fs::write(repo_path.join("base.txt"), "base update\n").expect("Failed to write base file");
+    run_git(&repo_path, &["add", "base.txt"]);
+    run_git(&repo_path, &["commit", "-m", "Merged upstream"]);
+    run_git(&repo_path, &["push", "origin", "main"]);
+    run_git(&repo_path, &["checkout", &stack_branch]);
+
+    // The fake gh exists so provider checks pass, and also returns Merged for
+    // the MR so refresh_mr_state_for_guard populates mr_state correctly.
+    let fake_bin = repo_path.join("fake-bin");
+    fs::create_dir_all(&fake_bin).expect("Failed to create fake bin dir");
+    fs::write(
+        fake_bin.join("gh"),
+        "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  echo 'gh version 2.0.0'\n  exit 0\nfi\nif [ \"$1\" = \"auth\" ] && [ \"$2\" = \"status\" ]; then\n  exit 0\nfi\nif [ \"$1\" = \"pr\" ] && [ \"$2\" = \"view\" ] && [ \"$3\" = \"99\" ]; then\n  echo '{\"number\":99,\"title\":\"Stack commit 2\",\"state\":\"MERGED\",\"url\":\"https://github.com/test/repo/pull/99\",\"headRefName\":\"testuser/immutable-sync-test--c-2222222\",\"isDraft\":false,\"mergeable\":\"MERGEABLE\",\"reviews\":[]}'\n  exit 0\nfi\necho 'unexpected gh invocation' >&2\nexit 1\n",
+    )
+    .expect("Failed to write fake gh");
+    #[cfg(unix)]
+    {
+        let mut perms = fs::metadata(fake_bin.join("gh"))
+            .expect("Failed to stat fake gh")
+            .permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(fake_bin.join("gh"), perms).expect("Failed to chmod fake gh");
+    }
+
+    let old_path = std::env::var_os("PATH").unwrap_or_default();
+    let mut new_path = std::ffi::OsString::from(fake_bin.as_os_str());
+    new_path.push(":");
+    new_path.push(old_path);
+
+    let (success, stdout, stderr) = run_gg_with_env(
+        &repo_path,
+        &["sync", "--force"],
+        &[("PATH", new_path.as_os_str())],
+    );
+    assert!(
+        !success,
+        "sync should fail when auto-rebase hits immutable commit\nstdout: {}\nstderr: {}",
+        stdout, stderr
+    );
+    assert!(
+        stderr.contains("cannot rewrite immutable commits during sync"),
+        "error should mention 'during sync', got: {}",
+        stderr
+    );
+    assert!(
+        stderr.contains("gg rebase --force") || stderr.contains("gg rebase --ignore-immutable"),
+        "error should point to `gg rebase --force`, got: {}",
+        stderr
+    );
+    assert!(
+        !stderr.contains("pass --force / --ignore-immutable to override"),
+        "error should not imply `gg sync --force` is sufficient, got: {}",
+        stderr
+    );
+}
+
+fn git_current_branch(repo_path: &std::path::Path) -> String {
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .current_dir(repo_path)
+        .output()
+        .expect("git rev-parse failed");
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}

--- a/crates/gg-core/src/commands/sync.rs
+++ b/crates/gg-core/src/commands/sync.rs
@@ -70,8 +70,13 @@ fn maybe_rebase_if_base_is_behind(
         // Internal auto-rebase during sync: the user hasn't been asked to
         // --force, so respect the immutability guard rather than silently
         // bypassing it.
-        crate::commands::rebase::run_with_repo(repo, None, json, false)?;
-        return Ok(true);
+        match crate::commands::rebase::run_with_repo(repo, None, json, false) {
+            Ok(()) => return Ok(true),
+            Err(GgError::ImmutableTargets(msg)) => {
+                return Err(GgError::ImmutableTargetsDuringSync(msg));
+            }
+            Err(e) => return Err(e),
+        }
     }
 
     if !json {
@@ -95,8 +100,13 @@ fn maybe_rebase_if_base_is_behind(
         .unwrap_or(true);
 
     if should_rebase {
-        crate::commands::rebase::run_with_repo(repo, None, json, false)?;
-        return Ok(true);
+        match crate::commands::rebase::run_with_repo(repo, None, json, false) {
+            Ok(()) => return Ok(true),
+            Err(GgError::ImmutableTargets(msg)) => {
+                return Err(GgError::ImmutableTargetsDuringSync(msg));
+            }
+            Err(e) => return Err(e),
+        }
     }
 
     Ok(false)

--- a/crates/gg-core/src/error.rs
+++ b/crates/gg-core/src/error.rs
@@ -71,6 +71,11 @@ pub enum GgError {
     )]
     ImmutableTargets(String),
 
+    #[error(
+        "cannot rewrite immutable commits during sync (run `gg rebase --force` or `gg rebase --ignore-immutable` to override):\n{0}"
+    )]
+    ImmutableTargetsDuringSync(String),
+
     #[error("Git error: {0}")]
     Git(#[from] git2::Error),
 

--- a/docs/src/core-concepts.md
+++ b/docs/src/core-concepts.md
@@ -95,6 +95,10 @@ If you genuinely want to rewrite history anyway, pass `--force` (or
 rewrite command accepts both spellings. The guard still emits a warning so
 scripts see that they are bypassing a safety check.
 
+When the guard is hit by `gg sync` while it is auto-rebasing before push, the
+override belongs to the rebase step, not sync's push `--force`. Run
+`gg rebase --force` or `gg rebase --ignore-immutable`, then rerun `gg sync`.
+
 ### Keeping PR state fresh
 
 Each rewrite command runs a best-effort PR-state refresh against the

--- a/skills/gg/SKILL.md
+++ b/skills/gg/SKILL.md
@@ -142,7 +142,7 @@ gg land -a -c --json
 5. If sync warns stack is behind base, run `gg rebase` first.
 6. Prefer `gg absorb -s` for multi-commit edits.
 7. **Never use `git add -A` blindly.** Review `git status` first and only stage intended files. Use `git add <specific-files>` to avoid leaking secrets, env files, or unrelated changes.
-8. **Respect the immutability guard.** Rewrite-style commands (`gg sc`, `gg absorb`, `gg reorder`/`gg arrange`, `gg split`, `gg unstack`, `gg drop`, `gg rebase`, `gg restack`) refuse to rewrite merged PRs/MRs or commits already on the base branch, except that `gg rebase` silently skips base-ancestor commits that naturally drop out when rebasing onto the refreshed base. If a command exits with `ImmutableTargets`, surface the listed commits and reasons to the user and get explicit confirmation before retrying with `-f` / `--force` (alias `--ignore-immutable`).
+8. **Respect the immutability guard.** Rewrite-style commands (`gg sc`, `gg absorb`, `gg reorder`/`gg arrange`, `gg split`, `gg unstack`, `gg drop`, `gg rebase`, `gg restack`) refuse to rewrite merged PRs/MRs or commits already on the base branch, except that `gg rebase` silently skips base-ancestor commits that naturally drop out when rebasing onto the refreshed base. If a command exits with `ImmutableTargets`, surface the listed commits and reasons to the user and get explicit confirmation before retrying with `-f` / `--force` (alias `--ignore-immutable`). If the error comes from `gg sync`'s auto-rebase, the override is `gg rebase --force` / `gg rebase --ignore-immutable`, not `gg sync --force`.
 
 ## Common operations
 
@@ -277,6 +277,10 @@ The guard protects `gg sc`, `gg absorb`, `gg reorder` / `gg arrange`,
 To bypass it intentionally, pass `-f` / `--force` (long alias
 `--ignore-immutable`). Always surface the listed commits and reasons to the
 user first; the override still emits a warning and proceeds.
+
+If `gg sync` surfaces the guard during auto-rebase, run `gg rebase --force` or
+`gg rebase --ignore-immutable` after user confirmation, then retry `gg sync`.
+`gg sync --force` only affects push behavior.
 
 `gg land`'s post-merge cleanup bypasses the guard by design, and
 `gg absorb --dry-run` skips it (no rewrite happens). See

--- a/skills/gg/reference.md
+++ b/skills/gg/reference.md
@@ -727,6 +727,10 @@ To override intentionally, pass `-f` / `--force` (or the longer alias
 `--ignore-immutable`) to the command. The override emits a warning listing
 what is being rewritten and then proceeds.
 
+If this error is surfaced from `gg sync` during its pre-sync auto-rebase,
+`gg sync --force` is not the override. Run `gg rebase --force` or
+`gg rebase --ignore-immutable`, then retry `gg sync`.
+
 Notes for agents:
 
 - Before offering `--force`, surface the guard output to the user and get


### PR DESCRIPTION
## Summary

When `gg sync` hits immutable-commit protection during its internal auto-rebase, the error message previously suggested passing `--force` / `--ignore-immutable`, which is misleading because `gg sync --force` doesn't resolve it — only `gg rebase --force` does.

## Changes

- Added `ImmutableTargetsDuringSync` error variant in `gg-core/src/error.rs` with a sync-specific message pointing to `gg rebase --force` / `gg rebase --ignore-immutable`.
- Wrapped `ImmutableTargets` errors from sync's internal auto-rebase and interactive rebase paths into the new sync-specific variant.
- Added integration test that exercises `gg sync --force` against an immutable commit and asserts the new hint is present while the old generic hint is absent.
- Updated docs (`docs/src/core-concepts.md`) and agent skill references (`skills/gg/SKILL.md`, `skills/gg/reference.md`) with the sync-specific caveat.

## Testing

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p gg-core --all-features`
- `cargo test -p gg-mcp --all-features`
- `cargo test -p gg-cli --test integration_tests sync::`

Closes #865