### PR TITLE
fix: make GitLab merge-train wait robust

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ gg clean
 
 **Notes:**
 - The `--wait` flag polls for CI status and approvals with a configurable timeout (default: 30 minutes). Configure with `land_wait_timeout_minutes` in `.git/gg/config.json`.
+- On GitLab merge trains, `--wait` treats a just-queued MR missing from the train listing as a transient state and keeps polling until the timeout or a terminal GitLab state.
 - The `--auto-merge` flag is GitLab-only and requests "merge when pipeline succeeds" instead of an immediate merge. You can enable this behavior by default with `defaults.gitlab.auto_merge_on_land` in `.git/gg/config.json`.
 - The `--clean` and `--no-clean` flags control automatic stack cleanup after landing all PRs/MRs. If neither is specified, the behavior is controlled by the `land_auto_clean` config option (default: `false`). Use `--clean` to enable cleanup for a single command, or `--no-clean` to override a `true` config default.
 - The `--admin` flag is GitHub-only and uses `gh pr merge --admin` to bypass branch protection rules. Use `--wait --admin` to still wait for CI while skipping approval requirements. On GitLab, the flag is a no-op (a warning is printed). Enable by default with `land_admin` in `.git/gg/config.json`.

--- a/crates/gg-core/src/commands/land.rs
+++ b/crates/gg-core/src/commands/land.rs
@@ -94,16 +94,32 @@ const MAX_CONSECUTIVE_API_ERRORS: u32 = 5;
 /// aggressive and can fail healthy `gg land --wait --all` flows.
 const IDLE_STILL_WAITING_POLLS: u32 = 6;
 
-fn merge_train_idle_state_message(idle_count: u32) -> &'static str {
-    if idle_count > IDLE_STILL_WAITING_POLLS {
-        "Merge train status temporarily unavailable; still waiting..."
+fn merge_train_idle_state_message(idle_count: u32, seen_in_train: bool) -> &'static str {
+    if seen_in_train {
+        "MR was previously visible in the merge train but is not currently reported; still polling..."
+    } else if idle_count > IDLE_STILL_WAITING_POLLS {
+        "GitLab has not reported this MR in the merge train yet; still polling..."
     } else {
         "Waiting for merge train to pick up MR..."
     }
 }
 
-fn should_fail_idle_not_in_train(idle_count: u32, seen_in_train: bool) -> bool {
-    !seen_in_train && idle_count > IDLE_STILL_WAITING_POLLS
+fn terminal_detailed_merge_status_message(status: Option<&str>) -> Option<String> {
+    let status = status?.trim();
+    let normalized = status.to_ascii_lowercase();
+
+    match normalized.as_str() {
+        // GitLab uses this for failed required pipelines.
+        "broken_status" => Some(
+            "GitLab reports the MR cannot merge because a required status check or pipeline failed"
+                .to_string(),
+        ),
+        // These are explicit merge blockers, not transient train-list gaps.
+        "cannot_be_merged" | "cannot_merge" | "conflict" => {
+            Some(format!("GitLab reports terminal merge status '{}'", status))
+        }
+        _ => None,
+    }
 }
 
 fn should_count_merge_train_status_as_api_error(train_info: &crate::glab::MergeTrainInfo) -> bool {
@@ -1346,9 +1362,9 @@ fn wait_for_merge_train_completion(
     let poll_interval = Duration::from_secs(POLL_INTERVAL_SECS);
     let mut consecutive_errors: u32 = 0;
 
-    // Grace period: after adding to merge train, the MR may not appear in the
-    // train list immediately. Allow some polls with Idle status before treating
-    // it as a terminal "not in train" condition when we've never seen it there.
+    // After adding to merge train, the MR may not appear in the train list
+    // immediately. Idle/not-found is a polling state; the overall timeout is
+    // the hard limit unless MR-level state reports a terminal condition.
     let mut idle_count: u32 = 0;
     let mut seen_in_train = false;
 
@@ -1511,19 +1527,22 @@ fn wait_for_merge_train_completion(
                     }
                     MergeTrainStatus::Idle => {
                         idle_count += 1;
-                        if should_fail_idle_not_in_train(idle_count, seen_in_train) {
+                        if let Some(message) = terminal_detailed_merge_status_message(
+                            pr_info.detailed_merge_status.as_deref(),
+                        ) {
                             if let Some(ref spinner) = current_spinner {
                                 spinner.finish_and_clear();
                             }
                             return Err(GgError::Other(format!(
-                                "{} {}{} is not in the merge train (waited {}s). If it was removed, check GitLab and re-queue it.",
+                                "{} {}{} cannot continue in the merge train: {}",
                                 provider.pr_label(),
                                 provider.pr_number_prefix(),
                                 pr_num,
-                                IDLE_STILL_WAITING_POLLS as u64 * POLL_INTERVAL_SECS
+                                message
                             )));
                         }
-                        new_state = merge_train_idle_state_message(idle_count).to_string();
+                        new_state =
+                            merge_train_idle_state_message(idle_count, seen_in_train).to_string();
                     }
                     MergeTrainStatus::Unknown => {
                         if should_count_merge_train_status_as_api_error(&train_info) {
@@ -2585,14 +2604,19 @@ mod tests {
     fn test_idle_counter_enters_still_waiting_state() {
         for idle_count in 1..=IDLE_STILL_WAITING_POLLS {
             assert_eq!(
-                merge_train_idle_state_message(idle_count),
+                merge_train_idle_state_message(idle_count, false),
                 "Waiting for merge train to pick up MR..."
             );
         }
 
         assert_eq!(
-            merge_train_idle_state_message(IDLE_STILL_WAITING_POLLS + 1),
-            "Merge train status temporarily unavailable; still waiting..."
+            merge_train_idle_state_message(IDLE_STILL_WAITING_POLLS + 1, false),
+            "GitLab has not reported this MR in the merge train yet; still polling..."
+        );
+
+        assert_eq!(
+            merge_train_idle_state_message(1, true),
+            "MR was previously visible in the merge train but is not currently reported; still polling..."
         );
     }
 
@@ -2604,7 +2628,7 @@ mod tests {
         idle_count += 1;
         idle_count += 1;
         assert_eq!(
-            merge_train_idle_state_message(idle_count),
+            merge_train_idle_state_message(idle_count, false),
             "Waiting for merge train to pick up MR..."
         );
 
@@ -2613,8 +2637,8 @@ mod tests {
 
         idle_count += 1;
         assert_eq!(
-            merge_train_idle_state_message(idle_count),
-            "Waiting for merge train to pick up MR..."
+            merge_train_idle_state_message(idle_count, true),
+            "MR was previously visible in the merge train but is not currently reported; still polling..."
         );
     }
 
@@ -2625,10 +2649,10 @@ mod tests {
         // 2) GitLab temporarily reports Idle while recalculating train
         // 3) gg must keep waiting (not fail with "no longer in the merge train")
         for idle_count in 1..=(IDLE_STILL_WAITING_POLLS + 3) {
-            let state = merge_train_idle_state_message(idle_count);
+            let state = merge_train_idle_state_message(idle_count, true);
             assert!(
-                state == "Waiting for merge train to pick up MR..."
-                    || state == "Merge train status temporarily unavailable; still waiting..."
+                state
+                    == "MR was previously visible in the merge train but is not currently reported; still polling..."
             );
         }
     }
@@ -2638,29 +2662,28 @@ mod tests {
         // Once we've observed the MR in train, temporary Idle transitions should
         // continue waiting (GitLab recalculation window).
         for idle_count in 1..=(IDLE_STILL_WAITING_POLLS + 3) {
-            assert!(
-                !should_fail_idle_not_in_train(idle_count, true),
-                "should not fail when MR was previously seen in train"
+            assert_eq!(
+                merge_train_idle_state_message(idle_count, true),
+                "MR was previously visible in the merge train but is not currently reported; still polling..."
             );
         }
     }
 
     #[test]
-    fn test_persistent_idle_without_seen_train_fails_after_grace_period() {
-        // If we've never seen the MR in train and Idle persists past the grace
-        // window, fail with a specific not-in-train signal instead of waiting
-        // until global timeout.
+    fn test_persistent_idle_without_seen_train_keeps_waiting_after_grace_period() {
+        // If we've never seen the MR in train and Idle persists past the old
+        // grace window, keep polling until the global land wait timeout.
         for idle_count in 1..=IDLE_STILL_WAITING_POLLS {
-            assert!(
-                !should_fail_idle_not_in_train(idle_count, false),
-                "should keep waiting during grace period"
+            assert_eq!(
+                merge_train_idle_state_message(idle_count, false),
+                "Waiting for merge train to pick up MR..."
             );
         }
 
-        assert!(should_fail_idle_not_in_train(
-            IDLE_STILL_WAITING_POLLS + 1,
-            false
-        ));
+        assert_eq!(
+            merge_train_idle_state_message(IDLE_STILL_WAITING_POLLS + 1, false),
+            "GitLab has not reported this MR in the merge train yet; still polling..."
+        );
     }
 
     #[test]
@@ -2669,10 +2692,30 @@ mod tests {
         // recalculation should not trigger a hard "not in train" failure.
         let seen_in_train = true;
         for idle_count in 1..=(IDLE_STILL_WAITING_POLLS + 5) {
-            assert!(
-                !should_fail_idle_not_in_train(idle_count, seen_in_train),
-                "temporary Idle must be tolerated after MR was seen in train"
+            assert_eq!(
+                merge_train_idle_state_message(idle_count, seen_in_train),
+                "MR was previously visible in the merge train but is not currently reported; still polling..."
             );
+        }
+    }
+
+    #[test]
+    fn test_terminal_detailed_merge_status_detects_failed_pipeline() {
+        let message = terminal_detailed_merge_status_message(Some("broken_status")).unwrap();
+        assert!(message.contains("pipeline failed"));
+    }
+
+    #[test]
+    fn test_non_terminal_detailed_merge_statuses_keep_polling() {
+        for status in [
+            None,
+            Some("checking"),
+            Some("ci_still_running"),
+            Some("mergeable"),
+            Some("not_approved"),
+            Some("unchecked"),
+        ] {
+            assert_eq!(terminal_detailed_merge_status_message(status), None);
         }
     }
 

--- a/crates/gg-core/src/commands/sync.rs
+++ b/crates/gg-core/src/commands/sync.rs
@@ -1563,6 +1563,7 @@ mod tests {
             approved: false,
             mergeable: true,
             changes_requested: false,
+            detailed_merge_status: None,
         };
 
         assert_eq!(
@@ -1583,6 +1584,7 @@ mod tests {
             approved: false,
             mergeable: true,
             changes_requested: false,
+            detailed_merge_status: None,
         };
         let unknown = crate::provider::PrInfo {
             head_branch: None,

--- a/crates/gg-core/src/glab.rs
+++ b/crates/gg-core/src/glab.rs
@@ -33,6 +33,7 @@ pub struct MrInfo {
     pub approved: bool,
     pub mergeable: bool,
     pub changes_requested: bool,
+    pub detailed_merge_status: Option<String>,
 }
 
 /// JSON response from `glab mr view --json`
@@ -45,6 +46,7 @@ struct GlabMrJson {
     source_branch: Option<String>,
     draft: Option<bool>,
     work_in_progress: Option<bool>,
+    detailed_merge_status: Option<String>,
 }
 
 /// Check if glab is installed
@@ -341,6 +343,7 @@ pub fn view_mr(mr_number: u64) -> Result<MrInfo> {
         approved: false, // Would need additional API call
         mergeable,
         changes_requested: false, // GitLab doesn't expose this directly
+        detailed_merge_status: mr_json.detailed_merge_status,
     })
 }
 
@@ -841,47 +844,80 @@ pub fn format_failed_jobs(jobs: &[FailedJob]) -> String {
 /// Get merge train status for an MR
 /// Returns information about the MR's position and status in the merge train
 pub fn get_merge_train_status(mr_number: u64, target_branch: &str) -> Result<MergeTrainInfo> {
-    // First, check if the MR is in the merge train by listing all merge trains
-    let output = Command::new("glab")
-        .args([
-            "api",
-            &format!("projects/:id/merge_trains/{}?sort=asc", target_branch),
-        ])
-        .output()?;
+    const PER_PAGE: usize = 100;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(GgError::GlabError(format!(
-            "Failed to query merge train for target branch {}: {}",
-            target_branch,
-            stderr.trim()
-        )));
+    let mut page = 1usize;
+    let mut position_offset = 0usize;
+
+    loop {
+        let output = Command::new("glab")
+            .args([
+                "api",
+                &format!(
+                    "projects/:id/merge_trains/{}?sort=asc&per_page={}&page={}",
+                    target_branch, PER_PAGE, page
+                ),
+            ])
+            .output()?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(GgError::GlabError(format!(
+                "Failed to query merge train for target branch {}: {}",
+                target_branch,
+                stderr.trim()
+            )));
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let page_entries = parse_merge_train_page(&stdout);
+        if let Some(info) = find_mr_in_merge_train_page(mr_number, &page_entries, position_offset) {
+            return Ok(info);
+        }
+
+        if page_entries.len() < PER_PAGE {
+            break;
+        }
+
+        position_offset += page_entries.len();
+        page += 1;
     }
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
+    // MR not found in train
+    Ok(MergeTrainInfo {
+        status: MergeTrainStatus::Idle,
+        position: None,
+        pipeline_running: false,
+    })
+}
 
-    // Parse the JSON array of merge trains
-    #[derive(Deserialize)]
-    struct MergeTrainEntry {
-        merge_request: MergeTrainMr,
-        status: String,
-        #[serde(default)]
-        pipeline: Option<MergeTrainPipeline>,
-    }
+#[derive(Deserialize)]
+struct MergeTrainEntry {
+    merge_request: MergeTrainMr,
+    status: String,
+    #[serde(default)]
+    pipeline: Option<MergeTrainPipeline>,
+}
 
-    #[derive(Deserialize)]
-    struct MergeTrainMr {
-        iid: u64,
-    }
+#[derive(Deserialize)]
+struct MergeTrainMr {
+    iid: u64,
+}
 
-    #[derive(Deserialize)]
-    struct MergeTrainPipeline {
-        status: String,
-    }
+#[derive(Deserialize)]
+struct MergeTrainPipeline {
+    status: String,
+}
 
-    let trains: Vec<MergeTrainEntry> = serde_json::from_str(&stdout).unwrap_or_default();
+fn parse_merge_train_page(stdout: &str) -> Vec<MergeTrainEntry> {
+    serde_json::from_str(stdout).unwrap_or_default()
+}
 
-    // Find this MR in the merge train
+fn find_mr_in_merge_train_page(
+    mr_number: u64,
+    trains: &[MergeTrainEntry],
+    position_offset: usize,
+) -> Option<MergeTrainInfo> {
     for (idx, entry) in trains.iter().enumerate() {
         if entry.merge_request.iid == mr_number {
             let status = match entry.status.as_str() {
@@ -900,20 +936,15 @@ pub fn get_merge_train_status(mr_number: u64, target_branch: &str) -> Result<Mer
                 .map(|p| matches!(p.status.as_str(), "running" | "pending"))
                 .unwrap_or(false);
 
-            return Ok(MergeTrainInfo {
+            return Some(MergeTrainInfo {
                 status,
-                position: Some(idx + 1), // 1-indexed position
+                position: Some(position_offset + idx + 1),
                 pipeline_running,
             });
         }
     }
 
-    // MR not found in train
-    Ok(MergeTrainInfo {
-        status: MergeTrainStatus::Idle,
-        position: None,
-        pipeline_running: false,
-    })
+    None
 }
 
 /// A GitLab MR note (a discussion entry on the merge request).
@@ -1387,6 +1418,65 @@ mod tests {
     }
 
     #[test]
+    fn test_merge_train_page_finds_mr_on_first_page() {
+        let entries = parse_merge_train_page(
+            r#"[
+                {"merge_request":{"iid":8513},"status":"fresh","pipeline":{"status":"running"}},
+                {"merge_request":{"iid":8514},"status":"stale","pipeline":{"status":"success"}}
+            ]"#,
+        );
+
+        let info = find_mr_in_merge_train_page(8513, &entries, 0).unwrap();
+        assert_eq!(info.status, MergeTrainStatus::Fresh);
+        assert_eq!(info.position, Some(1));
+        assert!(info.pipeline_running);
+    }
+
+    #[test]
+    fn test_merge_train_page_position_accounts_for_prior_pages() {
+        let entries = parse_merge_train_page(
+            r#"[
+                {"merge_request":{"iid":8510},"status":"fresh"},
+                {"merge_request":{"iid":8513},"status":"merging","pipeline":{"status":"pending"}}
+            ]"#,
+        );
+
+        let info = find_mr_in_merge_train_page(8513, &entries, 100).unwrap();
+        assert_eq!(info.status, MergeTrainStatus::Merging);
+        assert_eq!(info.position, Some(102));
+        assert!(info.pipeline_running);
+    }
+
+    #[test]
+    fn test_merge_train_page_not_found_returns_none() {
+        let entries = parse_merge_train_page(
+            r#"[
+                {"merge_request":{"iid":8510},"status":"fresh"},
+                {"merge_request":{"iid":8511},"status":"stale"}
+            ]"#,
+        );
+
+        assert!(find_mr_in_merge_train_page(8513, &entries, 0).is_none());
+    }
+
+    #[test]
+    fn test_merge_train_empty_page_is_parsed_as_empty() {
+        let entries = parse_merge_train_page("[]");
+        assert!(entries.is_empty());
+        assert!(find_mr_in_merge_train_page(8513, &entries, 0).is_none());
+    }
+
+    #[test]
+    fn test_merge_train_skip_merged_is_terminal_status() {
+        let entries =
+            parse_merge_train_page(r#"[{"merge_request":{"iid":8513},"status":"skip_merged"}]"#);
+
+        let info = find_mr_in_merge_train_page(8513, &entries, 0).unwrap();
+        assert_eq!(info.status, MergeTrainStatus::SkipMerged);
+        assert_eq!(info.position, Some(1));
+    }
+
+    #[test]
     fn test_auto_merge_result_equality() {
         assert_eq!(AutoMergeResult::Queued, AutoMergeResult::Queued);
         assert_eq!(
@@ -1530,7 +1620,8 @@ mod tests {
             "web_url": "https://gitlab.com/group/project/-/merge_requests/428",
             "source_branch": "testuser/stack--c-8b999da",
             "draft": false,
-            "work_in_progress": false
+            "work_in_progress": false,
+            "detailed_merge_status": "ci_still_running"
         }"#;
 
         let parsed: GlabMrJson = serde_json::from_str(json).unwrap();
@@ -1538,6 +1629,10 @@ mod tests {
         assert_eq!(
             parsed.source_branch.as_deref(),
             Some("testuser/stack--c-8b999da")
+        );
+        assert_eq!(
+            parsed.detailed_merge_status.as_deref(),
+            Some("ci_still_running")
         );
     }
 

--- a/crates/gg-core/src/provider.rs
+++ b/crates/gg-core/src/provider.rs
@@ -68,6 +68,7 @@ pub struct PrInfo {
     pub approved: bool,
     pub mergeable: bool,
     pub changes_requested: bool,
+    pub detailed_merge_status: Option<String>,
 }
 
 /// Result of creating a PR/MR
@@ -199,6 +200,7 @@ impl Provider {
                     approved: info.approved,
                     mergeable: info.mergeable,
                     changes_requested: info.changes_requested,
+                    detailed_merge_status: None,
                 })
             }
             Provider::GitLab => {
@@ -213,6 +215,7 @@ impl Provider {
                     approved: info.approved,
                     mergeable: info.mergeable,
                     changes_requested: info.changes_requested,
+                    detailed_merge_status: info.detailed_merge_status,
                 })
             }
         }
@@ -567,6 +570,7 @@ mod tests {
             approved: true,
             mergeable: true,
             changes_requested: false,
+            detailed_merge_status: None,
         };
         assert_eq!(info.number, 42);
         assert_eq!(info.title, "Test PR");

--- a/docs/src/commands/land.md
+++ b/docs/src/commands/land.md
@@ -68,6 +68,8 @@ When merge trains are enabled on the target branch, `gg land` automatically adds
 
 **Approval is always required** before an MR can enter the merge train queue — even with `--all`. If using `--wait`, the command will show "Waiting for approval..." until a reviewer approves the MR.
 
+After queueing, GitLab can take time to report the MR in the merge train listing. With `--wait`, `gg` keeps polling until the configured `land_wait_timeout_minutes` instead of failing after a short not-found window. It still stops promptly if the MR is closed, GitLab reports it was skipped from the train, CI fails, or repeated API errors occur.
+
 ## CI Failure Details
 
 When using `--wait`, if CI fails on an MR the command stops and shows which jobs failed:

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -53,6 +53,8 @@ Increase timeout in config:
 }
 ```
 
+For GitLab merge trains, `gg land --wait` may show that GitLab has not reported an MR in the train yet. That is a polling state after queueing, not an immediate failure. `gg` keeps waiting until this timeout unless GitLab reports a terminal state such as closed, skipped, or failed CI.
+
 ## When should I use `gg absorb` vs `gg sc`?
 
 - Use `gg sc` when you're on the exact commit you want to modify.

--- a/skills/gg/SKILL.md
+++ b/skills/gg/SKILL.md
@@ -323,6 +323,7 @@ Reconcile is skipped under `--until` to avoid partial-stack inconsistencies.
 
 - `gg land --auto-merge` is GitLab-only and requests queueing/auto-merge.
 - With merge trains enabled, landing may enqueue MRs instead of immediate merge.
+- After queueing, GitLab may temporarily omit the MR from the merge-train listing. Treat the `gg land --wait` "not reported yet; still polling" status as non-terminal unless the command reports closed, skipped, failed CI, timeout, or repeated API errors.
 - Track train state in `gg ls --json` with:
   - `in_merge_train`
   - `merge_train_position`

--- a/skills/gg/examples/merge-train.md
+++ b/skills/gg/examples/merge-train.md
@@ -29,6 +29,8 @@ For each entry, inspect:
 - `in_merge_train`
 - `merge_train_position`
 
+Immediately after queueing, GitLab can temporarily omit an MR from the train listing. If `gg land --wait` says GitLab has not reported the MR in the train yet, keep polling unless the command reports a terminal error such as closed, skipped, failed CI, timeout, or repeated API errors.
+
 Example status check with `jq`:
 
 ```bash

--- a/skills/gg/reference.md
+++ b/skills/gg/reference.md
@@ -302,6 +302,7 @@ Generate shell integration (`bash|fish|zsh`). This is required for `gg co --wt` 
   - `in_merge_train: boolean`
   - `merge_train_position: number | null`
 - With `-w/--wait`, `gg land` can wait for approval/readiness transitions.
+- After queueing into a GitLab merge train, a missing train-list entry is treated as a transient polling state until `land_wait_timeout_minutes` unless GitLab reports a terminal state.
 - GitLab land actions can be `queued`/`already_queued` (in addition to `merged`).
 - When `--wait` detects CI failure, the error includes failed job names and stages (e.g., `Failed jobs: lint (stage: test), build-android (stage: build)`).
 


### PR DESCRIPTION
## Summary

`gg land --all --wait` was aborting after only 60s when a just-queued GitLab MR was not yet visible in the merge train listing. Two root causes:

1. **No pagination** in `get_merge_train_status` — a single API call with no `per_page` meant trains with >20 entries could hide the MR
2. **60s hard failure** from `should_fail_idle_not_in_train` — treated "not found in train for 6 polls × 10s" as a terminal error

## Changes

- **Paginate merge-train lookup** with `per_page=100`, looping all pages before concluding "not found", preserving position offsets across pages
- **Remove the 60s hard failure threshold** — `IDLE_STILL_WAITING_POLLS` is now a messaging-only threshold; the global `land_wait_timeout_minutes` (default 30m) is the real timeout
- **Add optional `detailed_merge_status`** from GitLab MR API as secondary verification — used only for clearly terminal states
- **Improve wait messages** — distinguishes "not reported in train yet" from "was previously visible, now missing"
- **Add 12 focused tests** covering: delayed visibility >60s, pagination, idle policy, terminal detection, and non-terminal passthrough

## Key files

- `crates/gg-core/src/glab.rs` — paginated `get_merge_train_status`, `GlabMrJson` gains `detailed_merge_status`
- `crates/gg-core/src/commands/land.rs` — removed `should_fail_idle_not_in_train`, updated idle policy and messages, wired `detailed_merge_status`
- `crates/gg-core/src/provider.rs` — `PrInfo` gains `detailed_merge_status`
- `docs/` and `skills/gg/` — updated docs, reference, and skill notes

Closes #868