### PR TITLE
docs(cli): mention GitHub-only scope in gg land --admin help text

### DIFF
--- a/crates/gg-cli/src/main.rs
+++ b/crates/gg-cli/src/main.rs
@@ -278,7 +278,7 @@ enum Commands {
         #[arg(long = "no-clean", conflicts_with = "clean")]
         no_clean: bool,
 
-        /// Use admin privileges to bypass branch protection approval requirements
+        /// (GitHub only) Use admin privileges to bypass branch protection approval requirements
         #[arg(long)]
         admin: bool,
     },

--- a/crates/gg-cli/tests/integration_tests/land.rs
+++ b/crates/gg-cli/tests/integration_tests/land.rs
@@ -79,6 +79,11 @@ fn test_land_help_shows_admin_option() {
         "Should show --admin option: {}",
         stdout
     );
+    assert!(
+        stdout.contains("GitHub only") || stdout.contains("GitHub-only"),
+        "Should indicate --admin is GitHub-only: {}",
+        stdout
+    );
 }
 
 #[test]


### PR DESCRIPTION
Task #869: Document `gg land --admin` as GitHub-only.

## What changed

- Updated CLI help text for `--admin` flag from `Use admin privileges to bypass branch protection approval requirements` to `(GitHub only) Use admin privileges to bypass branch protection approval requirements`, matching the `(--auto-merge)` GitLab-only pattern.
- Added assertion in `test_land_help_shows_admin_option` that help text contains the GitHub-only qualifier.
- Docs (`docs/src/commands/land.md`, `skills/gg/SKILL.md`, `skills/gg/reference.md`, `README.md`) already marked `--admin` as GitHub-only — no further changes needed.
- Implementation (`crates/gg-core/src/commands/land.rs`, `crates/gg-core/src/provider.rs`) already guards admin behavior on `Provider::GitHub` — no changes needed.

## Validation

- `cargo fmt --all` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --test integration_tests land` — 15/15 passing