### PR TITLE
fix(deps): update git2 to 0.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -101,7 +101,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -720,7 +720,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -830,7 +830,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1114,7 +1114,7 @@ dependencies = [
  "dirs",
  "fs2",
  "git-absorb",
- "git2",
+ "git2 0.21.0",
  "indicatif",
  "ratatui",
  "regex",
@@ -1135,7 +1135,7 @@ name = "gg-mcp"
 version = "0.9.4-dev"
 dependencies = [
  "gg-core",
- "git2",
+ "git2 0.21.0",
  "rmcp",
  "schemars",
  "serde",
@@ -1160,7 +1160,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "clap_complete_nushell",
- "git2",
+ "git2 0.20.4",
  "memchr",
  "slog",
  "slog-term",
@@ -1176,9 +1176,19 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
- "openssl-probe",
- "openssl-sys",
  "url",
+]
+
+[[package]]
+name = "git2"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "libgit2-sys",
+ "log",
 ]
 
 [[package]]
@@ -1442,7 +1452,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1557,15 +1567,13 @@ checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.3+1.9.2"
+version = "0.18.4+1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+checksum = "9b26f66f35e1871b22efcf7191564123d2a446ca0538cde63c23adfefa9b15b7"
 dependencies = [
  "cc",
  "libc",
- "libssh2-sys",
  "libz-sys",
- "openssl-sys",
  "pkg-config",
 ]
 
@@ -1586,20 +1594,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "libssh2-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -1858,24 +1852,6 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.111"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -2400,7 +2376,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2715,7 +2691,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2806,7 +2782,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2815,7 +2791,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/gg-core/Cargo.toml
+++ b/crates/gg-core/Cargo.toml
@@ -13,7 +13,7 @@ clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 
 # Git
-git2 = { version = "0.20", features = ["default"] }
+git2 = { version = "0.21", default-features = false }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/crates/gg-core/src/commands/inbox.rs
+++ b/crates/gg-core/src/commands/inbox.rs
@@ -96,7 +96,7 @@ fn resolve_base_branch(
 ) -> Result<String> {
     fn remote_head_base_branch(repo: &git2::Repository) -> Option<String> {
         let head_ref = repo.find_reference("refs/remotes/origin/HEAD").ok()?;
-        let target = head_ref.symbolic_target()?;
+        let target = head_ref.symbolic_target().ok().flatten()?;
         let branch = target.strip_prefix("refs/remotes/origin/")?;
         repo.find_reference(target).ok()?;
         Some(branch.to_string())

--- a/crates/gg-core/src/commands/land.rs
+++ b/crates/gg-core/src/commands/land.rs
@@ -234,7 +234,7 @@ fn rebase_remaining_branches(
     // Save current branch
     let current_branch = if let Ok(head) = repo.head() {
         if head.is_branch() {
-            head.shorthand().map(String::from)
+            head.shorthand().ok().map(String::from)
         } else {
             None
         }
@@ -2376,7 +2376,7 @@ mod tests {
         use crate::stack::StackEntry;
 
         // Create a mock entry without MR (unsynced)
-        let commit_oid = git2::Oid::zero();
+        let commit_oid = git2::Oid::ZERO_SHA1;
         let commit = StackEntry {
             oid: commit_oid,
             short_sha: "abc1234".to_string(),
@@ -2438,7 +2438,7 @@ mod tests {
         // Create a mix of synced and unsynced entries
         let entries = [
             StackEntry {
-                oid: git2::Oid::zero(),
+                oid: git2::Oid::ZERO_SHA1,
                 short_sha: "a1".to_string(),
                 title: "Merged".to_string(),
                 gg_id: Some("c-aaa".to_string()),
@@ -2454,7 +2454,7 @@ mod tests {
                 merge_train_position: None,
             },
             StackEntry {
-                oid: git2::Oid::zero(),
+                oid: git2::Oid::ZERO_SHA1,
                 short_sha: "b2".to_string(),
                 title: "Also merged".to_string(),
                 gg_id: Some("c-bbb".to_string()),
@@ -2470,7 +2470,7 @@ mod tests {
                 merge_train_position: None,
             },
             StackEntry {
-                oid: git2::Oid::zero(),
+                oid: git2::Oid::ZERO_SHA1,
                 short_sha: "c3".to_string(),
                 title: "New unsynced commit".to_string(),
                 gg_id: Some("c-ccc".to_string()),
@@ -2486,7 +2486,7 @@ mod tests {
                 merge_train_position: None,
             },
             StackEntry {
-                oid: git2::Oid::zero(),
+                oid: git2::Oid::ZERO_SHA1,
                 short_sha: "d4".to_string(),
                 title: "Another new commit".to_string(),
                 gg_id: Some("c-ddd".to_string()),

--- a/crates/gg-core/src/commands/log.rs
+++ b/crates/gg-core/src/commands/log.rs
@@ -267,7 +267,7 @@ mod tests {
 
     fn fake_entry(position: usize, title: &str) -> StackEntry {
         StackEntry {
-            oid: git2::Oid::zero(),
+            oid: git2::Oid::ZERO_SHA1,
             short_sha: format!("sha{position}"),
             title: title.to_string(),
             gg_id: Some(format!("c-fake{position}")),

--- a/crates/gg-core/src/commands/ls.rs
+++ b/crates/gg-core/src/commands/ls.rs
@@ -255,7 +255,12 @@ fn get_stack_commits_info(
         let oid = oid?;
         let commit = repo.find_commit(oid)?;
         let sha = oid.to_string()[..7].to_string();
-        let title = commit.summary().unwrap_or("<no message>").to_string();
+        let title = commit
+            .summary()
+            .ok()
+            .flatten()
+            .unwrap_or("<no message>")
+            .to_string();
         commits.push((sha, title));
     }
 

--- a/crates/gg-core/src/commands/reorder.rs
+++ b/crates/gg-core/src/commands/reorder.rs
@@ -433,7 +433,7 @@ mod tests {
     fn make_test_stack() -> Stack {
         use crate::stack::StackEntry;
         let make_entry = |sha: &str, title: &str, gg_id: &str, pos: usize| StackEntry {
-            oid: git2::Oid::zero(),
+            oid: git2::Oid::ZERO_SHA1,
             short_sha: sha.to_string(),
             title: title.to_string(),
             gg_id: Some(gg_id.to_string()),

--- a/crates/gg-core/src/commands/setup.rs
+++ b/crates/gg-core/src/commands/setup.rs
@@ -297,7 +297,7 @@ fn prompt_provider(
     let remote_url = repo
         .find_remote("origin")
         .ok()
-        .and_then(|r| r.url().map(|s| s.to_string()));
+        .and_then(|r| r.url().ok().map(|s| s.to_string()));
 
     let detected_default = remote_url.as_ref().and_then(|url| {
         git::detect_remote_provider_from_url(url).map(|provider| match provider {

--- a/crates/gg-core/src/commands/sync.rs
+++ b/crates/gg-core/src/commands/sync.rs
@@ -1707,7 +1707,7 @@ mod tests {
 
     fn make_test_entry(gg_id: &str) -> crate::stack::StackEntry {
         crate::stack::StackEntry {
-            oid: git2::Oid::zero(),
+            oid: git2::Oid::ZERO_SHA1,
             short_sha: "abc1234".to_string(),
             title: "Test entry".to_string(),
             gg_id: Some(gg_id.to_string()),

--- a/crates/gg-core/src/git.rs
+++ b/crates/gg-core/src/git.rs
@@ -266,7 +266,7 @@ pub fn find_base_branch(repo: &Repository) -> Result<String> {
 pub fn current_branch_name(repo: &Repository) -> Option<String> {
     let head = repo.head().ok()?;
     if head.is_branch() {
-        head.shorthand().map(|s| s.to_string())
+        head.shorthand().ok().map(|s| s.to_string())
     } else {
         None
     }
@@ -340,7 +340,7 @@ pub fn find_entry_branch_for_stack(
 /// Returns the worktree name if the branch is checked out, None otherwise
 pub fn is_branch_checked_out_in_worktree(repo: &Repository, branch_name: &str) -> Option<String> {
     if let Ok(worktrees) = repo.worktrees() {
-        for name in worktrees.iter().flatten() {
+        for name in worktrees.iter().flatten().flatten() {
             if let Ok(wt) = repo.find_worktree(name) {
                 // Open repo from worktree to check its HEAD
                 if let Ok(wt_repo) = Repository::open_from_worktree(&wt) {
@@ -455,7 +455,7 @@ pub fn get_stack_commit_oids(
 
 /// Extract the GG-ID from a commit message (case-insensitive)
 pub fn get_gg_id(commit: &Commit) -> Option<String> {
-    let message = commit.message()?;
+    let message = commit.message().ok()?;
     let re = Regex::new(r"(?i)^GG-ID:\s*(.+)$").ok()?;
 
     for line in message.lines() {
@@ -474,7 +474,7 @@ pub fn generate_gg_id() -> String {
 
 /// Extract the GG-Parent from a commit message (case-insensitive)
 pub fn get_gg_parent(commit: &Commit) -> Option<String> {
-    let message = commit.message()?;
+    let message = commit.message().ok()?;
     let re = Regex::new(r"(?i)^GG-Parent:\s*(.+)$").ok()?;
 
     for line in message.lines() {
@@ -644,7 +644,7 @@ pub fn normalize_stack_metadata(
             stack_refname
         } else {
             let head = repo.head()?;
-            if let Some(branch_name) = head.shorthand() {
+            if let Ok(branch_name) = head.shorthand() {
                 format!("refs/heads/{}", branch_name)
             } else {
                 return Err(GgError::Other(format!(
@@ -681,12 +681,17 @@ fn extract_description_from_message(message: &str) -> Option<String> {
 
 /// Get the commit message title (first line)
 pub fn get_commit_title(commit: &Commit) -> String {
-    commit.summary().unwrap_or("<no summary>").to_string()
+    commit
+        .summary()
+        .ok()
+        .flatten()
+        .unwrap_or("<no summary>")
+        .to_string()
 }
 
 /// Get the commit message description (body), if present
 pub fn get_commit_description(commit: &Commit) -> Option<String> {
-    let message = commit.message()?;
+    let message = commit.message().ok()?;
     extract_description_from_message(message)
 }
 
@@ -2287,7 +2292,7 @@ pub fn detect_remote_provider(repo: &Repository) -> Result<RemoteProvider> {
 
     let url = remote
         .url()
-        .ok_or_else(|| GgError::Other("Origin remote has no URL".to_string()))?;
+        .map_err(|_| GgError::Other("Origin remote has no URL".to_string()))?;
 
     detect_remote_provider_from_url(url).ok_or_else(|| {
         GgError::Other(format!(

--- a/crates/gg-core/src/immutability.rs
+++ b/crates/gg-core/src/immutability.rs
@@ -349,7 +349,7 @@ mod tests {
 
     fn mk_entry(pos: usize, sha: &str, title: &str) -> StackEntry {
         StackEntry {
-            oid: git2::Oid::zero(),
+            oid: git2::Oid::ZERO_SHA1,
             short_sha: sha.to_string(),
             title: title.to_string(),
             gg_id: None,
@@ -443,7 +443,7 @@ mod tests {
     #[test]
     fn reasons_for_merged_pr_returns_merged_pr_reason() {
         // Use an in-memory bare repo so `graph_descendant_of` can run on OIDs
-        // that don't match any real commit (Oid::zero() is unknown).
+        // that don't match any real commit (Oid::ZERO_SHA1 is unknown).
         let temp = tempfile::tempdir().unwrap();
         let repo = Repository::init(temp.path()).unwrap();
 

--- a/crates/gg-core/src/stack.rs
+++ b/crates/gg-core/src/stack.rs
@@ -506,7 +506,7 @@ mod tests {
 
     fn mk_entry(pos: usize, gg_id: Option<&str>) -> StackEntry {
         StackEntry {
-            oid: git2::Oid::zero(),
+            oid: git2::Oid::ZERO_SHA1,
             short_sha: format!("sha{}", pos),
             title: format!("commit {}", pos),
             gg_id: gg_id.map(ToString::to_string),

--- a/crates/gg-mcp/Cargo.toml
+++ b/crates/gg-mcp/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 
 [dependencies]
 gg-core = { path = "../gg-core" }
-git2 = { version = "0.20", features = ["default"] }
+git2 = { version = "0.21", default-features = false }
 rmcp = { version = "1.0", features = ["server", "transport-io"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary
- Bump git2 from 0.20 to 0.21 across `gg-core` and `gg-mcp`.
- 0.21 changed many string accessors from `Option<&str>` to `Result<&str, Error>` / `Result<Option<&str>, Error>` (see [git2-rs#1241](https://github.com/rust-lang/git2-rs/pull/1241)); update ~11 call sites with `.ok()` / `.ok().flatten()` to preserve existing semantics. Non-UTF-8 branch/commit names aren't a meaningful case for this tool.
- Drop the `ssh`/`https`/`cred` default features (no longer default upstream). All network operations in this repo use subprocess `git`/`gh`/`glab`; git2 is only used for local repo inspection, so transport features are unused.
- Replace deprecated `Oid::zero()` with the `Oid::ZERO_SHA1` constant (11 sites).

Supersedes #336 (renovate's version-only bump, which didn't update call sites).

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` — 229 pass; 1 pre-existing failure (`squash::test_squash_requires_stack`) confirmed unrelated by running on the unmodified branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)