### PR TITLE
fix: simplify sync no-lint output

### DIFF
--- a/crates/gg-cli/tests/integration_tests/lint.rs
+++ b/crates/gg-cli/tests/integration_tests/lint.rs
@@ -56,6 +56,32 @@ fn test_gg_lint_json_no_lint_commands() {
 }
 
 #[test]
+fn test_gg_lint_no_commands_shows_example_configuration() {
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .expect("Failed to write config");
+
+    let (success, _stdout, stderr) = run_gg(&repo_path, &["co", "lint-no-commands"]);
+    assert!(success, "Failed to create stack: {}", stderr);
+
+    fs::write(repo_path.join("test.txt"), "content").expect("Failed to write file");
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "Test commit"]);
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["lint"]);
+    assert!(success, "gg lint failed: {}", stderr);
+    assert!(stdout.contains("No lint commands configured"));
+    assert!(stdout.contains("Example configuration:"));
+    assert!(stdout.contains(r#""lint": ["cargo fmt", "cargo clippy -- -D warnings"]"#));
+}
+
+#[test]
 fn test_gg_lint_json_empty_stack() {
     let (_temp_dir, repo_path) = create_test_repo();
 

--- a/crates/gg-cli/tests/integration_tests/sync.rs
+++ b/crates/gg-cli/tests/integration_tests/sync.rs
@@ -101,6 +101,82 @@ fn test_gg_sync_help_has_no_verify() {
 }
 
 #[test]
+fn test_sync_lint_no_commands_omits_example_configuration() {
+    let (_temp_dir, repo_path, _remote_path) = create_test_repo_with_remote();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser","provider":"github","base":"main","sync_behind_threshold":0}}"#,
+    )
+    .expect("Failed to write config");
+
+    let (success, _, stderr) = run_gg(&repo_path, &["co", "sync-no-lint-config"]);
+    assert!(success, "Failed to create stack: {}", stderr);
+
+    fs::write(repo_path.join("entry.txt"), "content\n").expect("Failed to write entry");
+    run_git(&repo_path, &["add", "entry.txt"]);
+    run_git(&repo_path, &["commit", "-m", "Entry\n\nGG-ID: c-8fd7581"]);
+
+    let fake_bin = repo_path.join("fake-bin");
+    fs::create_dir_all(&fake_bin).expect("Failed to create fake bin dir");
+    fs::write(
+        fake_bin.join("gh"),
+        r#"#!/bin/sh
+set -eu
+
+if [ "$1" = "--version" ]; then
+  echo "gh version 2.0.0"
+  exit 0
+fi
+
+if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
+  exit 0
+fi
+
+if [ "$1" = "pr" ] && [ "$2" = "create" ]; then
+  echo "https://github.com/test/repo/pull/915"
+  exit 0
+fi
+
+echo "unexpected gh invocation: $@" >&2
+exit 1
+"#,
+    )
+    .expect("Failed to write fake gh");
+    #[cfg(unix)]
+    {
+        let mut perms = fs::metadata(fake_bin.join("gh"))
+            .expect("Failed to stat fake gh")
+            .permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(fake_bin.join("gh"), perms).expect("Failed to chmod fake gh");
+    }
+
+    let old_path = std::env::var_os("PATH").unwrap_or_default();
+    let mut new_path = std::ffi::OsString::from(fake_bin.as_os_str());
+    new_path.push(":");
+    new_path.push(old_path);
+
+    let (success, stdout, stderr) = run_gg_with_env(
+        &repo_path,
+        &["sync", "--lint", "--no-rebase-check"],
+        &[("PATH", new_path.as_os_str())],
+    );
+    assert!(
+        success,
+        "sync failed\nstdout:\n{}\nstderr:\n{}",
+        stdout, stderr
+    );
+    assert!(
+        stdout.contains("No lint commands configured. Run 'gg setup' to configure lint commands.")
+    );
+    assert!(!stdout.contains("Example configuration:"));
+    assert!(!stdout.contains(r#""lint": ["cargo fmt", "cargo clippy -- -D warnings"]"#));
+}
+
+#[test]
 fn test_sync_recreates_mapped_pr_when_head_branch_changed() {
     let (_temp_dir, repo_path, _remote_path) = create_test_repo_with_remote();
 

--- a/crates/gg-core/src/commands/lint.rs
+++ b/crates/gg-core/src/commands/lint.rs
@@ -19,6 +19,33 @@ use super::run::{self, ChangeMode, RunOptions};
 /// Returns `Ok(true)` when all lint commands passed for all linted commits,
 /// `Ok(false)` when one or more commits had lint failures.
 pub fn run(until: Option<usize>, json: bool, emit_json_output: bool) -> Result<bool> {
+    run_with_no_commands_help(until, json, emit_json_output, NoCommandsHelp::Example)
+}
+
+/// Run the lint command with a shorter no-config message for parent commands.
+///
+/// Parent commands such as `gg sync --lint` already have their own workflow
+/// output, so they should not print the full standalone `gg lint` example.
+pub fn run_brief_no_commands(
+    until: Option<usize>,
+    json: bool,
+    emit_json_output: bool,
+) -> Result<bool> {
+    run_with_no_commands_help(until, json, emit_json_output, NoCommandsHelp::Brief)
+}
+
+#[derive(Clone, Copy)]
+enum NoCommandsHelp {
+    Brief,
+    Example,
+}
+
+fn run_with_no_commands_help(
+    until: Option<usize>,
+    json: bool,
+    emit_json_output: bool,
+    no_commands_help: NoCommandsHelp,
+) -> Result<bool> {
     let repo = git::open_repo()?;
     let config = Config::load_with_global(repo.commondir())?;
 
@@ -32,13 +59,15 @@ pub fn run(until: Option<usize>, json: bool, emit_json_output: bool) -> Result<b
                 style("No lint commands configured. Run 'gg setup' to configure lint commands.")
                     .dim()
             );
-            println!();
-            println!("Example configuration:");
-            println!("  {{");
-            println!("    \"defaults\": {{");
-            println!("      \"lint\": [\"cargo fmt\", \"cargo clippy -- -D warnings\"]");
-            println!("    }}");
-            println!("  }}");
+            if matches!(no_commands_help, NoCommandsHelp::Example) {
+                println!();
+                println!("Example configuration:");
+                println!("  {{");
+                println!("    \"defaults\": {{");
+                println!("      \"lint\": [\"cargo fmt\", \"cargo clippy -- -D warnings\"]");
+                println!("    }}");
+                println!("  }}");
+            }
         }
         return Ok(true);
     }

--- a/crates/gg-core/src/commands/sync.rs
+++ b/crates/gg-core/src/commands/sync.rs
@@ -320,7 +320,7 @@ pub fn run(
         if !json {
             println!("{}", console::style("Running lint before sync...").dim());
         }
-        let lint_passed = crate::commands::lint::run(Some(end_pos), json, false)?;
+        let lint_passed = crate::commands::lint::run_brief_no_commands(Some(end_pos), json, false)?;
         if !lint_passed {
             restore_sync_start_position(
                 &repo,


### PR DESCRIPTION
## Summary
- simplify the no-lint output used by gg sync so it only prints the setup hint
- keep standalone gg lint showing the existing example configuration
- add integration coverage for both paths

## Tests
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- GIT_SEQUENCE_EDITOR=true GIT_EDITOR=true EDITOR=true cargo test --all-features