### PR TITLE
test: isolate global config in gg tests

### DIFF
--- a/crates/gg-cli/tests/integration_tests/helpers.rs
+++ b/crates/gg-cli/tests/integration_tests/helpers.rs
@@ -4,6 +4,12 @@ use std::process::Command;
 
 use tempfile::TempDir;
 
+fn isolated_home(repo_path: &std::path::Path) -> PathBuf {
+    let home = repo_path.join(".test-home");
+    fs::create_dir_all(&home).expect("Failed to create isolated test home");
+    home
+}
+
 pub(crate) fn create_test_repo() -> (TempDir, PathBuf) {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
     let repo_path = temp_dir.path().to_path_buf();
@@ -53,6 +59,7 @@ pub(crate) fn run_gg(repo_path: &std::path::Path, args: &[&str]) -> (bool, Strin
     let output = Command::new(gg_path)
         .args(args)
         .current_dir(repo_path)
+        .env("HOME", isolated_home(repo_path))
         .output()
         .expect("Failed to run gg");
 
@@ -70,7 +77,9 @@ pub(crate) fn run_gg_with_env(
     let gg_path = env!("CARGO_BIN_EXE_gg");
 
     let mut cmd = Command::new(gg_path);
-    cmd.args(args).current_dir(repo_path);
+    cmd.args(args)
+        .current_dir(repo_path)
+        .env("HOME", isolated_home(repo_path));
     for (key, value) in envs {
         cmd.env(key, value);
     }

--- a/crates/gg-core/src/config.rs
+++ b/crates/gg-core/src/config.rs
@@ -953,14 +953,19 @@ mod tests {
     }
 
     #[test]
-    fn test_load_with_global_returns_default_when_no_configs() {
+    fn test_load_with_global_uses_global_or_default_when_no_local_config() {
         let temp_dir = TempDir::new().unwrap();
         let git_dir = temp_dir.path();
 
         // No local config exists, global may or may not exist
+        let expected = Config::load_global()
+            .unwrap_or_default()
+            .unwrap_or_default();
         let loaded = Config::load_with_global(git_dir).unwrap();
-        // Should at least have default values
-        assert!(!loaded.get_sync_draft()); // Default
-        assert!(loaded.get_sync_update_descriptions()); // Default is true
+        assert_eq!(loaded.get_sync_draft(), expected.get_sync_draft());
+        assert_eq!(
+            loaded.get_sync_update_descriptions(),
+            expected.get_sync_update_descriptions()
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Isolates integration test `gg` invocations from the developer's real global `~/.config/gg/config.json` by setting a per-test `HOME`.
- Updates the core config test so the no-local-config case asserts the documented global-or-default behavior instead of assuming no global config exists.

## Root cause

The scheduled playground run executes under Nacho's real home. His global gg config sets values such as `branch_username` and `sync_update_descriptions`, which changed expected test behavior and made the suite fail even though the code path was working as configured.

## Validation

- `HOME=/Users/nacho.lopez PATH="/Users/nacho.lopez/.cargo/bin:$PATH" cargo fmt --all -- --check`
- `HOME=/Users/nacho.lopez PATH="/Users/nacho.lopez/.cargo/bin:$PATH" cargo test --all-features`

Note: the configured cron script path `/Users/nacho.lopez/clawd/scripts/gg-playground-test.sh` does not exist in this checkout, so I ran the git-gud suite directly with the cron-equivalent environment fixed for Rust.