### PR TITLE
feat: insert commits in the middle of a stack (#348)

### DIFF
--- a/crates/gg-cli/tests/integration_tests/ls.rs
+++ b/crates/gg-cli/tests/integration_tests/ls.rs
@@ -417,3 +417,64 @@ fn test_gg_ls_marks_stacks_with_worktree_indicator() {
     assert!(stdout.contains("wt-list"), "ls should show stack name");
     assert!(stdout.contains("[wt]"), "ls should show worktree indicator");
 }
+
+#[test]
+fn test_ls_reports_unintegrated_midstack_commit() {
+    use std::fs;
+
+    let (_temp_dir, repo_path) = create_test_repo();
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).unwrap();
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .unwrap();
+
+    run_gg(&repo_path, &["co", "testing"]);
+    run_git(&repo_path, &["commit", "--allow-empty", "-m", "one"]);
+    run_git(&repo_path, &["commit", "--allow-empty", "-m", "two"]);
+    let (ok, out, err) = run_gg(&repo_path, &["mv", "1"]);
+    assert!(ok, "mv failed: {out}{err}");
+    run_git(&repo_path, &["commit", "--allow-empty", "-m", "inserted"]);
+
+    let (ok, out, err) = run_gg(&repo_path, &["ls"]);
+    assert!(ok, "ls failed: {out}{err}");
+    assert!(out.contains("Un-integrated commit"), "ls output: {out}");
+    assert!(out.contains("inserted"), "ls output: {out}");
+    assert!(out.contains("gg restack"), "ls output: {out}");
+
+    let (_ok, log) = run_git(&repo_path, &["log", "--oneline", "testuser/testing"]);
+    assert!(log.contains("two"), "branch log: {log}");
+    assert!(!log.contains("inserted"), "branch must be untouched: {log}");
+}
+
+#[test]
+fn test_ls_json_includes_unintegrated_commits() {
+    use std::fs;
+
+    let (_temp_dir, repo_path) = create_test_repo();
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).unwrap();
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .unwrap();
+
+    run_gg(&repo_path, &["co", "testing"]);
+    run_git(&repo_path, &["commit", "--allow-empty", "-m", "one"]);
+    run_git(&repo_path, &["commit", "--allow-empty", "-m", "two"]);
+    run_gg(&repo_path, &["mv", "1"]);
+    run_git(&repo_path, &["commit", "--allow-empty", "-m", "inserted"]);
+
+    let (ok, out, err) = run_gg(&repo_path, &["ls", "--json"]);
+    assert!(ok, "ls --json failed: {out}{err}");
+    let v: serde_json::Value = serde_json::from_str(&out).expect("valid json");
+    let arr = v["stack"]["unintegrated_commits"]
+        .as_array()
+        .expect("unintegrated_commits array present");
+    assert_eq!(arr.len(), 1, "json: {out}");
+    assert_eq!(arr[0]["subject"], "inserted", "json: {out}");
+    assert_eq!(arr[0]["sits_on_position"], 1, "json: {out}");
+}

--- a/crates/gg-cli/tests/integration_tests/ls.rs
+++ b/crates/gg-cli/tests/integration_tests/ls.rs
@@ -477,4 +477,12 @@ fn test_ls_json_includes_unintegrated_commits() {
     assert_eq!(arr.len(), 1, "json: {out}");
     assert_eq!(arr[0]["subject"], "inserted", "json: {out}");
     assert_eq!(arr[0]["sits_on_position"], 1, "json: {out}");
+
+    // With an orphan present, HEAD is on the orphan — no listed entry is current
+    // (parity with the human-readable view).
+    let entries = v["stack"]["entries"].as_array().expect("entries array");
+    assert!(
+        entries.iter().all(|e| e["is_current"] == false),
+        "no entry should be current while an orphan exists: {out}"
+    );
 }

--- a/crates/gg-cli/tests/integration_tests/restack.rs
+++ b/crates/gg-cli/tests/integration_tests/restack.rs
@@ -382,3 +382,43 @@ fn test_restack_without_orphan_is_unchanged() {
         "expected normal restack path (reconcile guidance): {combined}"
     );
 }
+
+#[test]
+fn test_restack_integrates_amended_midstack_commit() {
+    use crate::helpers::{create_test_repo, run_gg, run_git};
+    use std::fs;
+
+    let (_temp_dir, repo_path) = create_test_repo();
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).unwrap();
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .unwrap();
+
+    run_gg(&repo_path, &["co", "testing"]);
+    run_git(&repo_path, &["commit", "--allow-empty", "-m", "one"]);
+    run_git(&repo_path, &["commit", "--allow-empty", "-m", "two"]);
+    run_gg(&repo_path, &["mv", "1"]);
+    // Amend the navigated commit in place (rewrites "one").
+    // --allow-empty is required because the original commit had no tree changes.
+    run_git(
+        &repo_path,
+        &["commit", "--allow-empty", "--amend", "-m", "one_amended"],
+    );
+
+    let (ok, out, err) = run_gg(&repo_path, &["restack"]);
+    assert!(ok, "restack failed: {out}{err}");
+
+    // HEAD stays on the amended commit.
+    let (_ok, head_subj) = run_git(&repo_path, &["log", "-1", "--pretty=%s", "HEAD"]);
+    assert_eq!(head_subj.trim(), "one_amended", "HEAD subject: {head_subj}");
+
+    // Branch is one_amended -> two (2 commits, "one" gone).
+    let (_ok, log) = run_git(&repo_path, &["log", "--oneline", "testuser/testing"]);
+    assert!(
+        log.contains("one_amended") && log.contains("two"),
+        "log: {log}"
+    );
+}

--- a/crates/gg-cli/tests/integration_tests/restack.rs
+++ b/crates/gg-cli/tests/integration_tests/restack.rs
@@ -315,6 +315,16 @@ fn test_restack_integrates_inserted_midstack_commit() {
         out.contains("inserted") && out.contains("<- HEAD"),
         "ls: {out}"
     );
+
+    // Metadata was normalized during integration, so the inserted commit now has
+    // a GG-ID: a follow-up `gg restack` must succeed (already consistent), not
+    // fail with a missing-GG-ID error.
+    let (ok, out, err) = run_gg(&repo_path, &["restack"]);
+    assert!(ok, "follow-up restack failed: {out}{err}");
+    assert!(
+        out.contains("consistent"),
+        "follow-up restack should be a no-op: {out}"
+    );
 }
 
 #[test]

--- a/crates/gg-cli/tests/integration_tests/restack.rs
+++ b/crates/gg-cli/tests/integration_tests/restack.rs
@@ -271,3 +271,114 @@ fn test_restack_missing_gg_ids_errors() {
         stderr
     );
 }
+
+#[test]
+fn test_restack_integrates_inserted_midstack_commit() {
+    use crate::helpers::{create_test_repo, run_gg, run_git};
+    use std::fs;
+
+    let (_temp_dir, repo_path) = create_test_repo();
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).unwrap();
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .unwrap();
+
+    run_gg(&repo_path, &["co", "testing"]);
+    run_git(&repo_path, &["commit", "--allow-empty", "-m", "one"]);
+    run_git(&repo_path, &["commit", "--allow-empty", "-m", "two"]);
+    run_gg(&repo_path, &["mv", "1"]);
+    run_git(&repo_path, &["commit", "--allow-empty", "-m", "inserted"]);
+
+    let (ok, out, err) = run_gg(&repo_path, &["restack"]);
+    assert!(ok, "restack failed: {out}{err}");
+
+    let (_ok, log) = run_git(&repo_path, &["log", "--oneline", "testuser/testing"]);
+    assert!(
+        log.contains("one") && log.contains("inserted") && log.contains("two"),
+        "log: {log}"
+    );
+
+    let (_ok, head_subj) = run_git(&repo_path, &["log", "-1", "--pretty=%s", "HEAD"]);
+    assert_eq!(head_subj.trim(), "inserted", "HEAD subject: {head_subj}");
+
+    let (ok, out, err) = run_gg(&repo_path, &["ls"]);
+    assert!(ok, "ls failed: {out}{err}");
+    assert!(out.contains("3 commits"), "ls: {out}");
+    assert!(
+        !out.contains("Un-integrated commit"),
+        "ls should be clean: {out}"
+    );
+    assert!(
+        out.contains("inserted") && out.contains("<- HEAD"),
+        "ls: {out}"
+    );
+}
+
+#[test]
+fn test_restack_integrates_multiple_inserted_commits() {
+    use crate::helpers::{create_test_repo, run_gg, run_git};
+    use std::fs;
+
+    let (_temp_dir, repo_path) = create_test_repo();
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).unwrap();
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .unwrap();
+
+    run_gg(&repo_path, &["co", "testing"]);
+    run_git(&repo_path, &["commit", "--allow-empty", "-m", "one"]);
+    run_git(&repo_path, &["commit", "--allow-empty", "-m", "two"]);
+    run_gg(&repo_path, &["mv", "1"]);
+    run_git(&repo_path, &["commit", "--allow-empty", "-m", "ins_a"]);
+    run_git(&repo_path, &["commit", "--allow-empty", "-m", "ins_b"]);
+
+    let (ok, out, err) = run_gg(&repo_path, &["restack"]);
+    assert!(ok, "restack failed: {out}{err}");
+
+    let (_ok, head_subj) = run_git(&repo_path, &["log", "-1", "--pretty=%s", "HEAD"]);
+    assert_eq!(head_subj.trim(), "ins_b", "HEAD subject: {head_subj}");
+
+    let (_ok, log) = run_git(&repo_path, &["log", "--oneline", "testuser/testing"]);
+    for m in ["one", "ins_a", "ins_b", "two"] {
+        assert!(log.contains(m), "missing {m} in log: {log}");
+    }
+}
+
+#[test]
+fn test_restack_without_orphan_is_unchanged() {
+    use crate::helpers::{create_test_repo, run_gg, run_git};
+    use std::fs;
+
+    let (_temp_dir, repo_path) = create_test_repo();
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).unwrap();
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .unwrap();
+
+    run_gg(&repo_path, &["co", "testing"]);
+    run_git(&repo_path, &["commit", "--allow-empty", "-m", "one"]);
+    run_git(&repo_path, &["commit", "--allow-empty", "-m", "two"]);
+
+    // No detached orphan: the integration path must NOT fire. restack falls
+    // through to its normal path, which (on a stack without GG-IDs) reports the
+    // usual reconcile guidance rather than integrating anything.
+    let (_ok, out, err) = run_gg(&repo_path, &["restack"]);
+    let combined = format!("{out}{err}");
+    assert!(
+        !combined.contains("Integrated"),
+        "should not integrate: {combined}"
+    );
+    assert!(
+        combined.contains("GG-ID") || combined.contains("reconcile"),
+        "expected normal restack path (reconcile guidance): {combined}"
+    );
+}

--- a/crates/gg-cli/tests/integration_tests/restack.rs
+++ b/crates/gg-cli/tests/integration_tests/restack.rs
@@ -380,6 +380,14 @@ fn test_restack_dry_run_does_not_integrate_midstack_commit() {
             && !repo_path.join(".git/rebase-apply").exists(),
         "dry-run must not leave a rebase in progress"
     );
+
+    // --dry-run --json reports the stack name ("testing"), not the branch name
+    // ("testuser/testing"), for parity with every other restack JSON path.
+    let (ok, out, err) = run_gg(&repo_path, &["restack", "--dry-run", "--json"]);
+    assert!(ok, "restack --dry-run --json failed: {out}{err}");
+    let v: serde_json::Value = serde_json::from_str(&out).expect("valid json");
+    assert_eq!(v["restack"]["stack_name"], "testing", "json: {out}");
+    assert_eq!(v["restack"]["dry_run"], true, "json: {out}");
 }
 
 #[test]

--- a/crates/gg-cli/tests/integration_tests/restack.rs
+++ b/crates/gg-cli/tests/integration_tests/restack.rs
@@ -496,6 +496,62 @@ fn test_restack_integration_conflict_reports_guidance() {
 }
 
 #[test]
+fn test_restack_integration_conflict_continue_finishes_integration() {
+    use crate::helpers::{create_test_repo, run_gg, run_git};
+    use std::fs;
+
+    let (_temp_dir, repo_path) = create_test_repo();
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).unwrap();
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .unwrap();
+
+    run_gg(&repo_path, &["co", "testing"]);
+    run_git(&repo_path, &["commit", "--allow-empty", "-m", "one"]);
+    fs::write(repo_path.join("conflict.txt"), "two\n").unwrap();
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "two"]);
+
+    run_gg(&repo_path, &["mv", "1"]);
+    fs::write(repo_path.join("conflict.txt"), "inserted\n").unwrap();
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "inserted"]);
+
+    // Conflicts while replaying "two" onto "inserted".
+    let (ok, _out, _err) = run_gg(&repo_path, &["restack"]);
+    assert!(!ok, "expected conflict");
+
+    // Resolve the conflict and continue.
+    fs::write(repo_path.join("conflict.txt"), "resolved\n").unwrap();
+    run_git(&repo_path, &["add", "."]);
+    let (ok, out, err) = run_gg(&repo_path, &["continue"]);
+    assert!(ok, "gg continue failed: {out}{err}");
+
+    // Integration finished: HEAD is back on the inserted commit (detached).
+    let (_ok, head_subj) = run_git(&repo_path, &["log", "-1", "--pretty=%s", "HEAD"]);
+    assert_eq!(head_subj.trim(), "inserted", "HEAD subject: {head_subj}");
+
+    // Branch contains all three in order.
+    let (_ok, log) = run_git(&repo_path, &["log", "--oneline", "testuser/testing"]);
+    assert!(
+        log.contains("one") && log.contains("inserted") && log.contains("two"),
+        "log: {log}"
+    );
+
+    // Metadata was normalized: a follow-up `gg restack` is a no-op, not a
+    // missing-GG-ID error.
+    let (ok, out, err) = run_gg(&repo_path, &["restack"]);
+    assert!(ok, "follow-up restack failed: {out}{err}");
+    assert!(
+        out.contains("consistent"),
+        "follow-up restack should be a no-op: {out}"
+    );
+}
+
+#[test]
 fn test_restack_integrates_amended_midstack_commit() {
     use crate::helpers::{create_test_repo, run_gg, run_git};
     use std::fs;

--- a/crates/gg-cli/tests/integration_tests/restack.rs
+++ b/crates/gg-cli/tests/integration_tests/restack.rs
@@ -384,6 +384,45 @@ fn test_restack_without_orphan_is_unchanged() {
 }
 
 #[test]
+fn test_restack_integration_conflict_reports_guidance() {
+    use crate::helpers::{create_test_repo, run_gg, run_git};
+    use std::fs;
+
+    let (_temp_dir, repo_path) = create_test_repo();
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).unwrap();
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .unwrap();
+
+    run_gg(&repo_path, &["co", "testing"]);
+    // "one" leaves conflict.txt absent; "two" adds conflict.txt = "two".
+    run_git(&repo_path, &["commit", "--allow-empty", "-m", "one"]);
+    fs::write(repo_path.join("conflict.txt"), "two\n").unwrap();
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "two"]);
+
+    run_gg(&repo_path, &["mv", "1"]);
+    // Inserted commit writes the same file with different content -> conflict
+    // when "two" is replayed on top.
+    fs::write(repo_path.join("conflict.txt"), "inserted\n").unwrap();
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "inserted"]);
+
+    let (ok, out, err) = run_gg(&repo_path, &["restack"]);
+    assert!(!ok, "expected conflict failure: {out}{err}");
+    let combined = format!("{out}{err}");
+    assert!(
+        combined.contains("gg continue")
+            || combined.contains("gg abort")
+            || combined.contains("conflict"),
+        "expected conflict guidance: {combined}"
+    );
+}
+
+#[test]
 fn test_restack_integrates_amended_midstack_commit() {
     use crate::helpers::{create_test_repo, run_gg, run_git};
     use std::fs;

--- a/crates/gg-cli/tests/integration_tests/restack.rs
+++ b/crates/gg-cli/tests/integration_tests/restack.rs
@@ -318,6 +318,61 @@ fn test_restack_integrates_inserted_midstack_commit() {
 }
 
 #[test]
+fn test_restack_dry_run_does_not_integrate_midstack_commit() {
+    use crate::helpers::{create_test_repo, run_gg, run_git};
+    use std::fs;
+
+    let (_temp_dir, repo_path) = create_test_repo();
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).unwrap();
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .unwrap();
+
+    run_gg(&repo_path, &["co", "testing"]);
+    run_git(&repo_path, &["commit", "--allow-empty", "-m", "one"]);
+    run_git(&repo_path, &["commit", "--allow-empty", "-m", "two"]);
+    run_gg(&repo_path, &["mv", "1"]);
+    run_git(&repo_path, &["commit", "--allow-empty", "-m", "inserted"]);
+
+    let head_before = run_git(&repo_path, &["rev-parse", "HEAD"]).1;
+    let branch_before = run_git(&repo_path, &["rev-parse", "testuser/testing"]).1;
+
+    // --dry-run must preview without mutating anything.
+    let (ok, out, err) = run_gg(&repo_path, &["restack", "--dry-run"]);
+    assert!(ok, "restack --dry-run failed: {out}{err}");
+    assert!(
+        out.contains("Would integrate"),
+        "dry-run should preview: {out}"
+    );
+
+    // The branch tip is unchanged: "inserted" was NOT folded in.
+    let (_ok, log) = run_git(&repo_path, &["log", "--oneline", "testuser/testing"]);
+    assert!(!log.contains("inserted"), "branch must be untouched: {log}");
+
+    // HEAD and the branch ref are byte-for-byte unchanged.
+    assert_eq!(
+        run_git(&repo_path, &["rev-parse", "HEAD"]).1,
+        head_before,
+        "HEAD moved under --dry-run"
+    );
+    assert_eq!(
+        run_git(&repo_path, &["rev-parse", "testuser/testing"]).1,
+        branch_before,
+        "branch moved under --dry-run"
+    );
+
+    // No rebase was left in progress.
+    assert!(
+        !repo_path.join(".git/rebase-merge").exists()
+            && !repo_path.join(".git/rebase-apply").exists(),
+        "dry-run must not leave a rebase in progress"
+    );
+}
+
+#[test]
 fn test_restack_integrates_multiple_inserted_commits() {
     use crate::helpers::{create_test_repo, run_gg, run_git};
     use std::fs;

--- a/crates/gg-core/src/commands/ls.rs
+++ b/crates/gg-core/src/commands/ls.rs
@@ -525,6 +525,7 @@ fn show_stack(stack: &Stack, json: bool) -> Result<()> {
     let total = stack.len();
 
     let repo = git::open_repo()?;
+    let unintegrated = stack::detect_unintegrated(&repo, stack)?;
 
     if json {
         let current_pos = stack
@@ -565,6 +566,15 @@ fn show_stack(stack: &Stack, json: bool) -> Result<()> {
                 current_position: stack.current_position.map(|p| p + 1),
                 behind_base: behind_count(&repo, &stack.base),
                 entries,
+                unintegrated_commits: unintegrated
+                    .iter()
+                    .map(|u| crate::output::UnintegratedCommitJson {
+                        sha: u.short_sha.clone(),
+                        subject: u.subject.clone(),
+                        sits_on_position: u.sits_on_position,
+                        count: u.count,
+                    })
+                    .collect(),
             },
         });
 
@@ -613,9 +623,12 @@ fn show_stack(stack: &Stack, json: bool) -> Result<()> {
         .current_position
         .unwrap_or(stack.len().saturating_sub(1));
 
+    let has_orphan = unintegrated.is_some();
+
     for entry in &stack.entries {
-        let is_current = entry.position == current_pos + 1
-            || (stack.current_position.is_none() && entry.position == stack.len());
+        let is_current = !has_orphan
+            && (entry.position == current_pos + 1
+                || (stack.current_position.is_none() && entry.position == stack.len()));
 
         let position = format!("[{}]", entry.position);
         let sha = &entry.short_sha;
@@ -685,6 +698,30 @@ fn show_stack(stack: &Stack, json: bool) -> Result<()> {
 
             println!("      {}", style(&mr_line).blue());
         }
+    }
+
+    if let Some(u) = &unintegrated {
+        println!();
+        let more = if u.count > 1 {
+            format!(" (+{} more)", u.count - 1)
+        } else {
+            String::new()
+        };
+        println!(
+            "  {} Un-integrated commit at HEAD (detached):",
+            style("⚠").yellow().bold()
+        );
+        println!(
+            "      {} {}{}  — sits on top of [{}]",
+            style(&u.short_sha).yellow(),
+            u.subject,
+            more,
+            u.sits_on_position
+        );
+        println!(
+            "    {}",
+            style("Run `gg restack` to fold it into the stack.").dim()
+        );
     }
 
     println!();

--- a/crates/gg-core/src/commands/ls.rs
+++ b/crates/gg-core/src/commands/ls.rs
@@ -532,12 +532,17 @@ fn show_stack(stack: &Stack, json: bool) -> Result<()> {
             .current_position
             .unwrap_or(stack.len().saturating_sub(1));
 
+        // When an un-integrated commit exists, HEAD is on that orphan, not on any
+        // listed entry — so no entry is current (mirrors the text view).
+        let has_orphan = unintegrated.is_some();
+
         let entries = stack
             .entries
             .iter()
             .map(|entry| {
-                let is_current = entry.position == current_pos + 1
-                    || (stack.current_position.is_none() && entry.position == stack.len());
+                let is_current = !has_orphan
+                    && (entry.position == current_pos + 1
+                        || (stack.current_position.is_none() && entry.position == stack.len()));
 
                 StackEntryJson {
                     position: entry.position,

--- a/crates/gg-core/src/commands/rebase.rs
+++ b/crates/gg-core/src/commands/rebase.rs
@@ -335,6 +335,42 @@ pub fn continue_rebase() -> Result<()> {
 
     match git::rebase_continue() {
         Ok(_) => {
+            // If the paused rebase was a mid-stack integration (`gg restack`
+            // folding in a detached commit), finish the integration-specific
+            // cleanup that the conflict short-circuited: normalize GG metadata,
+            // land HEAD back on the inserted commit, and rewrite the nav context.
+            if let Some((branch_name, head_oid)) =
+                crate::stack::read_pending_integration(repo.path())
+            {
+                let config = Config::load_with_global(repo.commondir())?;
+                let (new_head_oid, stack_name) =
+                    crate::commands::restack::finalize_detached_integration(
+                        &repo,
+                        &config,
+                        &branch_name,
+                        head_oid,
+                    )?;
+                crate::stack::clear_pending_integration(repo.path())?;
+
+                let short = repo
+                    .find_object(new_head_oid, None)?
+                    .short_id()?
+                    .as_str()
+                    .unwrap_or("")
+                    .to_string();
+                println!(
+                    "{} Integrated mid-stack commit into stack {:?}; HEAD stays on {}",
+                    style("OK").green().bold(),
+                    stack_name,
+                    style(&short).yellow()
+                );
+                println!(
+                    "  {}",
+                    style("Run `gg sync` to push the updated stack.").dim()
+                );
+                return Ok(());
+            }
+
             println!(
                 "{} Rebase continued successfully",
                 style("OK").green().bold()
@@ -375,6 +411,9 @@ pub fn abort_rebase() -> Result<()> {
     }
 
     git::rebase_abort()?;
+
+    // Discard any pending mid-stack integration: the fold-in is cancelled.
+    crate::stack::clear_pending_integration(repo.path())?;
 
     println!("{} Rebase aborted", style("OK").green().bold());
 

--- a/crates/gg-core/src/commands/restack.rs
+++ b/crates/gg-core/src/commands/restack.rs
@@ -142,6 +142,7 @@ fn integrate_unintegrated(
     repo: &git2::Repository,
     config: &Config,
     unintegrated: stack::UnintegratedCommit,
+    stack_name: &str,
     dry_run: bool,
     json: bool,
 ) -> Result<()> {
@@ -151,7 +152,10 @@ fn integrate_unintegrated(
             print_json(&RestackResponse {
                 version: OUTPUT_VERSION,
                 restack: RestackResultJson {
-                    stack_name: unintegrated.branch_name.clone(),
+                    // Report the stack name (e.g. "testing"), not the branch name
+                    // (e.g. "user/testing"), for parity with every other restack
+                    // JSON path.
+                    stack_name: stack_name.to_string(),
                     total_entries: 0,
                     entries_restacked: unintegrated.count,
                     entries_ok: 0,
@@ -320,7 +324,15 @@ pub fn run(options: RestackOptions) -> Result<()> {
     // stay on it (early return). This is the only restack path that mutates
     // while keeping HEAD detached.
     if let Some(unintegrated) = stack::detect_unintegrated(&repo, &stack)? {
-        return integrate_unintegrated(&repo, &config, unintegrated, options.dry_run, options.json);
+        let stack_name = stack.name.clone();
+        return integrate_unintegrated(
+            &repo,
+            &config,
+            unintegrated,
+            &stack_name,
+            options.dry_run,
+            options.json,
+        );
     }
 
     // Resolve --from target

--- a/crates/gg-core/src/commands/restack.rs
+++ b/crates/gg-core/src/commands/restack.rs
@@ -136,6 +136,113 @@ impl RestackPlan {
     }
 }
 
+/// Integrate a commit made at a detached mid-stack HEAD into the stack branch,
+/// then leave HEAD detached on that commit. Returns early from `run`.
+fn integrate_unintegrated(
+    repo: &git2::Repository,
+    config: &Config,
+    unintegrated: stack::UnintegratedCommit,
+    json: bool,
+) -> Result<()> {
+    let guard = git::begin_recorded_op(
+        repo,
+        config,
+        OperationKind::Restack,
+        std::env::args().skip(1).collect(),
+        None,
+        SnapshotScope::AllUserBranches,
+    )?;
+
+    // Move the commits above the navigated position onto the detached HEAD work.
+    // The same `rebase --onto` handles both kinds (`Inserted` and `Amended`):
+    // whether `head_oid` descends from `original_oid` or merely replaces it, the
+    // commits above `original_oid` are replayed onto `head_oid` identically.
+    // git rebase --onto <new_base> <old_base> <branch>
+    let output = std::process::Command::new("git")
+        .args([
+            "rebase",
+            "--onto",
+            &unintegrated.head_oid.to_string(),
+            &unintegrated.original_oid.to_string(),
+            &unintegrated.branch_name,
+        ])
+        .current_dir(repo.workdir().unwrap_or_else(|| repo.path()))
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        if stderr.contains("CONFLICT")
+            || stderr.contains("conflict")
+            || stdout.contains("CONFLICT")
+            || stdout.contains("conflict")
+        {
+            return Err(GgError::RebaseConflict);
+        }
+        return Err(GgError::Other(format!(
+            "Failed to integrate commit: {}",
+            if stderr.is_empty() { stdout } else { stderr }
+        )));
+    }
+
+    // Stay on the integrated commit (detached HEAD).
+    let head_commit = repo.find_commit(unintegrated.head_oid)?;
+    git::checkout_commit(repo, &head_commit)?;
+
+    // Rewrite the nav context to the new position of the integrated commit.
+    // The rebase does not rewrite `head_oid` itself (it is the new base), so the
+    // reloaded stack must contain it; if it somehow does not, fail loudly rather
+    // than persist a wrong position.
+    let reloaded = Stack::load(repo, config)?;
+    let new_position = reloaded.current_position.ok_or_else(|| {
+        GgError::Other(
+            "Integrated commit not found in the reloaded stack. Run `gg last` to recover."
+                .to_string(),
+        )
+    })?;
+    stack::save_nav_context(
+        repo.path(),
+        &unintegrated.branch_name,
+        new_position,
+        unintegrated.head_oid,
+    )?;
+
+    guard.finalize_with_scope(repo, config, SnapshotScope::AllUserBranches, vec![], false)?;
+
+    if json {
+        print_json(&RestackResponse {
+            version: OUTPUT_VERSION,
+            restack: RestackResultJson {
+                stack_name: reloaded.name.clone(),
+                total_entries: reloaded.entries.len(),
+                entries_restacked: unintegrated.count,
+                entries_ok: reloaded.entries.len().saturating_sub(unintegrated.count),
+                dry_run: false,
+                steps: vec![],
+            },
+        });
+    } else {
+        println!(
+            "{} Integrated {} commit(s) into stack {:?}; HEAD stays on {} {}",
+            style("✓").green().bold(),
+            unintegrated.count,
+            reloaded.name,
+            style(&unintegrated.short_sha).yellow(),
+            unintegrated.subject,
+        );
+        println!(
+            "  {}",
+            style("Note: HEAD is detached on the integrated commit. Use `gg last` to return to stack head.").dim()
+        );
+        println!(
+            "  {}",
+            style("Hint: Run `gg sync` to push the updated stack.").dim()
+        );
+    }
+
+    Ok(())
+}
+
 /// Run the restack command.
 pub fn run(options: RestackOptions) -> Result<()> {
     let repo = git::open_repo()?;
@@ -161,6 +268,13 @@ pub fn run(options: RestackOptions) -> Result<()> {
 
     if stack.is_empty() {
         return Err(GgError::Other("Stack is empty".to_string()));
+    }
+
+    // If there is a commit made at a detached mid-stack HEAD, fold it in and
+    // stay on it (early return). This is the only restack path that mutates
+    // while keeping HEAD detached.
+    if let Some(unintegrated) = stack::detect_unintegrated(&repo, &stack)? {
+        return integrate_unintegrated(&repo, &config, unintegrated, options.json);
     }
 
     // Resolve --from target

--- a/crates/gg-core/src/commands/restack.rs
+++ b/crates/gg-core/src/commands/restack.rs
@@ -136,6 +136,43 @@ impl RestackPlan {
     }
 }
 
+/// Finish a mid-stack integration whose `rebase --onto` has already moved the
+/// upper commits onto the inserted/amended work. With HEAD set to detached on
+/// `head_oid`, normalize GG metadata across the folded-in stack (assigning the
+/// inserted commit a GG-ID / GG-Parent, exactly as the normal restack path does)
+/// and rewrite the nav context, leaving HEAD on the (possibly rewritten)
+/// integrated commit. Returns the post-normalization HEAD oid and stack name.
+///
+/// Shared by the clean fold-in path and the `gg continue` conflict-resume path.
+pub(crate) fn finalize_detached_integration(
+    repo: &git2::Repository,
+    config: &Config,
+    branch_name: &str,
+    head_oid: git2::Oid,
+) -> Result<(git2::Oid, String)> {
+    // Stay on the integrated commit (detached HEAD) so normalization can remap
+    // HEAD onto its rewritten counterpart.
+    let head_commit = repo.find_commit(head_oid)?;
+    git::checkout_commit(repo, &head_commit)?;
+
+    let folded = Stack::load(repo, config)?;
+    git::normalize_stack_metadata(repo, &folded)?;
+
+    // Normalization remaps the detached HEAD, so read the current HEAD oid; the
+    // reloaded stack must contain it (fail loudly rather than persist a wrong
+    // position).
+    let reloaded = Stack::load(repo, config)?;
+    let new_head_oid = repo.head()?.peel_to_commit()?.id();
+    let new_position = reloaded.current_position.ok_or_else(|| {
+        GgError::Other(
+            "Integrated commit not found in the reloaded stack. Run `gg last` to recover."
+                .to_string(),
+        )
+    })?;
+    stack::save_nav_context(repo.path(), branch_name, new_position, new_head_oid)?;
+    Ok((new_head_oid, reloaded.name))
+}
+
 /// Integrate a commit made at a detached mid-stack HEAD into the stack branch,
 /// then leave HEAD detached on that commit. Returns early from `run`.
 fn integrate_unintegrated(
@@ -210,6 +247,15 @@ fn integrate_unintegrated(
             || stdout.contains("CONFLICT")
             || stdout.contains("conflict")
         {
+            // Record what `gg continue` needs to finish the integration once the
+            // conflict is resolved (detach back to the inserted commit, normalize
+            // metadata, rewrite the nav context). `head_oid` is the rebase's new
+            // base, so its OID survives conflict resolution.
+            stack::save_pending_integration(
+                repo.path(),
+                &unintegrated.branch_name,
+                unintegrated.head_oid,
+            )?;
             return Err(GgError::RebaseConflict);
         }
         return Err(GgError::Other(format!(
@@ -218,38 +264,15 @@ fn integrate_unintegrated(
         )));
     }
 
-    // Stay on the integrated commit (detached HEAD) so the metadata
-    // normalization below can remap HEAD onto its rewritten counterpart.
-    let head_commit = repo.find_commit(unintegrated.head_oid)?;
-    git::checkout_commit(repo, &head_commit)?;
-
-    // Normalize GG metadata across the folded-in stack, exactly as the normal
-    // restack path does: assign the newly inserted commit a GG-ID and fix
-    // GG-Parent trailers so a follow-up command that requires IDs (e.g. another
-    // `gg restack`) does not fail. This rewrites commits and remaps the detached
-    // HEAD onto the rewritten inserted commit, so reload afterwards.
-    let folded = Stack::load(repo, config)?;
-    git::normalize_stack_metadata(repo, &folded)?;
-
-    // Rewrite the nav context to the new position of the integrated commit.
-    // Normalization remaps the detached HEAD, so read the current HEAD oid; the
-    // reloaded stack must contain it (fail loudly rather than persist a wrong
-    // position).
-    let reloaded = Stack::load(repo, config)?;
-    let new_head_oid = repo.head()?.peel_to_commit()?.id();
-    let new_position = reloaded.current_position.ok_or_else(|| {
-        GgError::Other(
-            "Integrated commit not found in the reloaded stack. Run `gg last` to recover."
-                .to_string(),
-        )
-    })?;
-    stack::save_nav_context(
-        repo.path(),
+    // Fold-in succeeded: normalize metadata and leave HEAD on the integrated
+    // commit (shared with the `gg continue` conflict-resume path).
+    let (new_head_oid, _) = finalize_detached_integration(
+        repo,
+        config,
         &unintegrated.branch_name,
-        new_position,
-        new_head_oid,
+        unintegrated.head_oid,
     )?;
-
+    let reloaded = Stack::load(repo, config)?;
     let new_short_sha = repo
         .find_object(new_head_oid, None)?
         .short_id()?

--- a/crates/gg-core/src/commands/restack.rs
+++ b/crates/gg-core/src/commands/restack.rs
@@ -142,8 +142,37 @@ fn integrate_unintegrated(
     repo: &git2::Repository,
     config: &Config,
     unintegrated: stack::UnintegratedCommit,
+    dry_run: bool,
     json: bool,
 ) -> Result<()> {
+    // Preview only: never record an op or run the rebase under `--dry-run`.
+    if dry_run {
+        if json {
+            print_json(&RestackResponse {
+                version: OUTPUT_VERSION,
+                restack: RestackResultJson {
+                    stack_name: unintegrated.branch_name.clone(),
+                    total_entries: 0,
+                    entries_restacked: unintegrated.count,
+                    entries_ok: 0,
+                    dry_run: true,
+                    steps: vec![],
+                },
+            });
+        } else {
+            println!(
+                "{} Would integrate {} commit(s) at HEAD ({} {}) into the stack at position {}.",
+                style("→").cyan().bold(),
+                unintegrated.count,
+                style(&unintegrated.short_sha).yellow(),
+                unintegrated.subject,
+                unintegrated.sits_on_position,
+            );
+            println!("  {}", style("Run without --dry-run to fold it in.").dim());
+        }
+        return Ok(());
+    }
+
     let guard = git::begin_recorded_op(
         repo,
         config,
@@ -274,7 +303,7 @@ pub fn run(options: RestackOptions) -> Result<()> {
     // stay on it (early return). This is the only restack path that mutates
     // while keeping HEAD detached.
     if let Some(unintegrated) = stack::detect_unintegrated(&repo, &stack)? {
-        return integrate_unintegrated(&repo, &config, unintegrated, options.json);
+        return integrate_unintegrated(&repo, &config, unintegrated, options.dry_run, options.json);
     }
 
     // Resolve --from target

--- a/crates/gg-core/src/commands/restack.rs
+++ b/crates/gg-core/src/commands/restack.rs
@@ -214,15 +214,25 @@ fn integrate_unintegrated(
         )));
     }
 
-    // Stay on the integrated commit (detached HEAD).
+    // Stay on the integrated commit (detached HEAD) so the metadata
+    // normalization below can remap HEAD onto its rewritten counterpart.
     let head_commit = repo.find_commit(unintegrated.head_oid)?;
     git::checkout_commit(repo, &head_commit)?;
 
+    // Normalize GG metadata across the folded-in stack, exactly as the normal
+    // restack path does: assign the newly inserted commit a GG-ID and fix
+    // GG-Parent trailers so a follow-up command that requires IDs (e.g. another
+    // `gg restack`) does not fail. This rewrites commits and remaps the detached
+    // HEAD onto the rewritten inserted commit, so reload afterwards.
+    let folded = Stack::load(repo, config)?;
+    git::normalize_stack_metadata(repo, &folded)?;
+
     // Rewrite the nav context to the new position of the integrated commit.
-    // The rebase does not rewrite `head_oid` itself (it is the new base), so the
-    // reloaded stack must contain it; if it somehow does not, fail loudly rather
-    // than persist a wrong position.
+    // Normalization remaps the detached HEAD, so read the current HEAD oid; the
+    // reloaded stack must contain it (fail loudly rather than persist a wrong
+    // position).
     let reloaded = Stack::load(repo, config)?;
+    let new_head_oid = repo.head()?.peel_to_commit()?.id();
     let new_position = reloaded.current_position.ok_or_else(|| {
         GgError::Other(
             "Integrated commit not found in the reloaded stack. Run `gg last` to recover."
@@ -233,8 +243,15 @@ fn integrate_unintegrated(
         repo.path(),
         &unintegrated.branch_name,
         new_position,
-        unintegrated.head_oid,
+        new_head_oid,
     )?;
+
+    let new_short_sha = repo
+        .find_object(new_head_oid, None)?
+        .short_id()?
+        .as_str()
+        .unwrap_or("")
+        .to_string();
 
     guard.finalize_with_scope(repo, config, SnapshotScope::AllUserBranches, vec![], false)?;
 
@@ -256,7 +273,7 @@ fn integrate_unintegrated(
             style("✓").green().bold(),
             unintegrated.count,
             reloaded.name,
-            style(&unintegrated.short_sha).yellow(),
+            style(&new_short_sha).yellow(),
             unintegrated.subject,
         );
         println!(

--- a/crates/gg-core/src/output.rs
+++ b/crates/gg-core/src/output.rs
@@ -39,6 +39,16 @@ pub struct StackJson {
     pub current_position: Option<usize>,
     pub behind_base: Option<usize>,
     pub entries: Vec<StackEntryJson>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub unintegrated_commits: Vec<UnintegratedCommitJson>,
+}
+
+#[derive(Serialize)]
+pub struct UnintegratedCommitJson {
+    pub sha: String,
+    pub subject: String,
+    pub sits_on_position: usize,
+    pub count: usize,
 }
 
 #[derive(Serialize)]

--- a/crates/gg-core/src/stack.rs
+++ b/crates/gg-core/src/stack.rs
@@ -16,6 +16,11 @@ use crate::provider::{CiStatus, PrState, Provider};
 /// File to store the current stack when in detached HEAD mode
 const CURRENT_STACK_FILE: &str = "gg/current_stack";
 
+/// File marking a mid-stack integration whose rebase paused on a conflict, so
+/// `gg continue` can finish the integration-specific cleanup. Format:
+/// `branch_name|head_oid`.
+const PENDING_INTEGRATION_FILE: &str = "gg/pending_integration";
+
 /// A single entry in a stack (one commit)
 #[derive(Debug, Clone)]
 pub struct StackEntry {
@@ -463,6 +468,46 @@ pub fn read_nav_context(git_dir: &Path) -> Option<(String, usize, git2::Oid)> {
         // Old format (just branch name) - return None
         None
     }
+}
+
+/// Record that a mid-stack integration rebase paused on a conflict, so that
+/// `gg continue` can finish the integration-specific cleanup once the rebase
+/// completes. `head_oid` is the inserted/amended commit (the rebase's new base),
+/// whose OID survives conflict resolution.
+pub fn save_pending_integration(
+    git_dir: &Path,
+    branch_name: &str,
+    head_oid: git2::Oid,
+) -> Result<()> {
+    let file = git_dir.join(PENDING_INTEGRATION_FILE);
+    if let Some(parent) = file.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(file, format!("{}|{}", branch_name, head_oid))?;
+    Ok(())
+}
+
+/// Read a pending mid-stack integration marker (branch, head_oid) if present.
+pub fn read_pending_integration(git_dir: &Path) -> Option<(String, git2::Oid)> {
+    let file = git_dir.join(PENDING_INTEGRATION_FILE);
+    let content = fs::read_to_string(file).ok()?;
+    let parts: Vec<&str> = content.trim().split('|').collect();
+    if parts.len() == 2 {
+        let branch = parts[0].to_string();
+        let oid = git2::Oid::from_str(parts[1]).ok()?;
+        Some((branch, oid))
+    } else {
+        None
+    }
+}
+
+/// Clear the pending mid-stack integration marker, if any.
+pub fn clear_pending_integration(git_dir: &Path) -> Result<()> {
+    let file = git_dir.join(PENDING_INTEGRATION_FILE);
+    if file.exists() {
+        fs::remove_file(file)?;
+    }
+    Ok(())
 }
 
 /// A commit (or chain of commits) made at a detached mid-stack HEAD that has not

--- a/crates/gg-core/src/stack.rs
+++ b/crates/gg-core/src/stack.rs
@@ -515,6 +515,11 @@ pub fn detect_unintegrated(repo: &Repository, stack: &Stack) -> Result<Option<Un
         return Ok(None);
     }
 
+    // Only mid-stack positions can have un-integrated work: there must be at
+    // least one commit above the navigated position to rebase onto the new
+    // HEAD. At the tip there is nothing to move (`rebase --onto` would span an
+    // empty range), and `gg` checks out the branch rather than detaching there
+    // anyway. Mirrors the guard in `check_and_rebase_if_modified`.
     if saved_position + 1 >= stack.len() {
         return Ok(None);
     }

--- a/crates/gg-core/src/stack.rs
+++ b/crates/gg-core/src/stack.rs
@@ -465,14 +465,6 @@ pub fn read_nav_context(git_dir: &Path) -> Option<(String, usize, git2::Oid)> {
     }
 }
 
-/// Whether the detached-HEAD commit was added on top of the navigated commit
-/// (`Inserted`) or rewrites it in place (`Amended`).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum UnintegratedKind {
-    Inserted,
-    Amended,
-}
-
 /// A commit (or chain of commits) made at a detached mid-stack HEAD that has not
 /// yet been folded into the stack branch.
 #[derive(Debug, Clone)]
@@ -493,7 +485,6 @@ pub struct UnintegratedCommit {
     pub subject: String,
     /// Number of un-integrated commits (1 for an amend).
     pub count: usize,
-    pub kind: UnintegratedKind,
 }
 
 /// Detect a commit made at a detached mid-stack HEAD that has not been folded
@@ -524,18 +515,19 @@ pub fn detect_unintegrated(repo: &Repository, stack: &Stack) -> Result<Option<Un
         return Ok(None);
     }
 
-    let kind = if repo.graph_descendant_of(head_oid, original_oid)? {
-        UnintegratedKind::Inserted
-    } else {
+    // Accept only two shapes, both folded in by the same `rebase --onto`:
+    //   - inserted: a commit (chain) built on top of the navigated commit, or
+    //   - amended: the navigated commit rewritten in place (same first parent).
+    // Anything else is unrelated detached state we must not touch.
+    if !repo.graph_descendant_of(head_oid, original_oid)? {
         let original = repo.find_commit(original_oid)?;
         let original_parent = original.parent_id(0).ok();
         let head_parent = head.parent_id(0).ok();
-        if original_parent.is_some() && original_parent == head_parent {
-            UnintegratedKind::Amended
-        } else {
+        let is_amended = original_parent.is_some() && original_parent == head_parent;
+        if !is_amended {
             return Ok(None);
         }
-    };
+    }
 
     let branch_tip = match stack.entries.last() {
         Some(entry) => entry.oid,
@@ -565,7 +557,6 @@ pub fn detect_unintegrated(repo: &Repository, stack: &Stack) -> Result<Option<Un
         short_sha,
         subject,
         count,
-        kind,
     }))
 }
 

--- a/crates/gg-core/src/stack.rs
+++ b/crates/gg-core/src/stack.rs
@@ -465,6 +465,105 @@ pub fn read_nav_context(git_dir: &Path) -> Option<(String, usize, git2::Oid)> {
     }
 }
 
+/// Whether the detached-HEAD commit was added on top of the navigated commit
+/// (`Inserted`) or rewrites it in place (`Amended`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnintegratedKind {
+    Inserted,
+    Amended,
+}
+
+/// A commit (or chain of commits) made at a detached mid-stack HEAD that has not
+/// yet been folded into the stack branch.
+#[derive(Debug, Clone)]
+pub struct UnintegratedCommit {
+    /// Current detached HEAD oid (the tip of the un-integrated work).
+    pub head_oid: git2::Oid,
+    /// The commit we navigated to (`gg mv`), recorded in the nav context.
+    pub original_oid: git2::Oid,
+    /// Stack branch name from the nav context.
+    pub branch_name: String,
+    /// 0-indexed position of the navigated commit within the stack.
+    pub saved_position: usize,
+    /// 1-indexed display position the un-integrated work sits on.
+    pub sits_on_position: usize,
+    /// Short sha of `head_oid`.
+    pub short_sha: String,
+    /// First line of the head commit message.
+    pub subject: String,
+    /// Number of un-integrated commits (1 for an amend).
+    pub count: usize,
+    pub kind: UnintegratedKind,
+}
+
+/// Detect a commit made at a detached mid-stack HEAD that has not been folded
+/// into the stack yet. Returns `None` when there is nothing to integrate.
+///
+/// Pure detection — never mutates the repository.
+pub fn detect_unintegrated(repo: &Repository, stack: &Stack) -> Result<Option<UnintegratedCommit>> {
+    let (branch_name, saved_position, original_oid) = match read_nav_context(repo.path()) {
+        Some(ctx) => ctx,
+        None => return Ok(None),
+    };
+
+    if !repo.head_detached()? {
+        return Ok(None);
+    }
+    let head = repo.head()?.peel_to_commit()?;
+    let head_oid = head.id();
+    if head_oid == original_oid {
+        return Ok(None);
+    }
+
+    if saved_position + 1 >= stack.len() {
+        return Ok(None);
+    }
+
+    let kind = if repo.graph_descendant_of(head_oid, original_oid)? {
+        UnintegratedKind::Inserted
+    } else {
+        let original = repo.find_commit(original_oid)?;
+        let original_parent = original.parent_id(0).ok();
+        let head_parent = head.parent_id(0).ok();
+        if original_parent.is_some() && original_parent == head_parent {
+            UnintegratedKind::Amended
+        } else {
+            return Ok(None);
+        }
+    };
+
+    let branch_tip = match stack.entries.last() {
+        Some(entry) => entry.oid,
+        None => return Ok(None),
+    };
+    if branch_tip == head_oid || repo.graph_descendant_of(branch_tip, head_oid)? {
+        return Ok(None);
+    }
+
+    let (count, _) = repo.graph_ahead_behind(head_oid, original_oid)?;
+    let count = count.max(1);
+
+    let subject = head.summary()?.unwrap_or("(no message)").to_string();
+    let short_sha = repo
+        .find_object(head_oid, None)?
+        .short_id()?
+        .as_str()
+        .unwrap_or("")
+        .to_string();
+
+    Ok(Some(UnintegratedCommit {
+        head_oid,
+        original_oid,
+        branch_name,
+        saved_position,
+        sits_on_position: saved_position + 1,
+        short_sha,
+        subject,
+        count,
+        kind,
+    }))
+}
+
 /// List all stacks in the repository
 pub fn list_all_stacks(repo: &Repository, config: &Config, username: &str) -> Result<Vec<String>> {
     let mut stacks = Vec::new();

--- a/docs/src/commands/ls.md
+++ b/docs/src/commands/ls.md
@@ -41,3 +41,43 @@ gg ls --json
 gg ls --all --json
 gg ls --remote --json
 ```
+
+## Un-integrated commits at HEAD
+
+`gg ls` is read-only — it never mutates the stack. When you navigate to a mid-stack commit with `gg mv` and make a `git commit` (or `git commit --amend`) there, HEAD becomes detached with a commit that isn't part of the stack yet. `gg ls` detects this and shows a callout instead of silently losing the commit:
+
+```
+⚠ Un-integrated commit at HEAD (detached):
+    3fb873d inserted  — sits on top of [1]
+  Run `gg restack` to fold it into the stack.
+```
+
+The commit is not lost — run `gg restack` to fold it into the stack.
+
+### `unintegrated_commits` in JSON output
+
+When `gg ls --json` is called for the current stack, an `unintegrated_commits` array is included on the stack object when there are commits at a detached HEAD that haven't been integrated yet. The array is omitted entirely when empty.
+
+```json
+{
+  "version": 1,
+  "stack": {
+    "name": "my-feature",
+    "entries": [...],
+    "unintegrated_commits": [
+      {
+        "sha": "3fb873d",
+        "subject": "inserted",
+        "sits_on_position": 1,
+        "count": 1
+      }
+    ]
+  }
+}
+```
+
+Field types for each entry in `unintegrated_commits`:
+- `sha`: `string` — short SHA of the un-integrated commit
+- `subject`: `string` — first line of the commit message
+- `sits_on_position`: `number` — position of the stack entry that this commit sits directly on top of
+- `count`: `number` — total number of un-integrated commits at HEAD (useful when multiple commits were made before restacking)

--- a/docs/src/commands/restack.md
+++ b/docs/src/commands/restack.md
@@ -91,7 +91,7 @@ gg restack          # folds "inserted" into the stack; HEAD stays on it
 
 After `gg restack` completes, HEAD is left on the just-inserted (or just-amended) commit. Run `gg sync` to push the updated stack.
 
-> **Note:** If folding the commit in hits a conflict, resolve it and run `gg continue` (or `gg abort`). The conflict path goes through Git's normal rebase-continue, so afterwards you are returned to the stack head rather than left on the integrated commit, and the freshly folded commit may not yet have its `GG-ID`/`GG-Parent` assigned. The commit is still folded in correctly — run `gg sync` (or `gg reconcile`) to finish normalizing the metadata, and `gg mv` to navigate back to it if you want to keep working there. (This matches how `gg restack` behaves after any rebase conflict.)
+> **Note:** If folding the commit in hits a conflict, resolve it (stage the fixes with `git add`) and run `gg continue` — or `gg abort` to cancel the fold-in entirely. `gg continue` finishes the integration just like the non-conflict path: it normalizes the metadata (assigning the inserted commit its `GG-ID`/`GG-Parent`) and leaves HEAD on the integrated commit.
 
 ## Edge Cases
 

--- a/docs/src/commands/restack.md
+++ b/docs/src/commands/restack.md
@@ -91,6 +91,8 @@ gg restack          # folds "inserted" into the stack; HEAD stays on it
 
 After `gg restack` completes, HEAD is left on the just-inserted (or just-amended) commit. Run `gg sync` to push the updated stack.
 
+> **Note:** If folding the commit in hits a conflict, resolve it and run `gg continue` (or `gg abort`). After resolving a conflict this way you are returned to the stack head rather than left on the integrated commit — the commit is still folded in correctly; use `gg mv` to navigate back to it if you want to keep working there.
+
 ## Edge Cases
 
 - **Empty stack** produces an error

--- a/docs/src/commands/restack.md
+++ b/docs/src/commands/restack.md
@@ -79,6 +79,18 @@ gg restack --dry-run --json
 }
 ```
 
+## Inserting a commit mid-stack
+
+`gg restack` also integrates commits you make at a detached HEAD after navigating to a mid-stack position with `gg mv`:
+
+```bash
+gg mv 1             # detach HEAD at position 1
+git commit -m "inserted"
+gg restack          # folds "inserted" into the stack; HEAD stays on it
+```
+
+After `gg restack` completes, HEAD is left on the just-inserted (or just-amended) commit. Run `gg sync` to push the updated stack.
+
 ## Edge Cases
 
 - **Empty stack** produces an error
@@ -86,3 +98,4 @@ gg restack --dry-run --json
 - **Rebase in progress** blocks with a clear error message
 - **Rebase conflicts** are handled the same as `gg reorder` — resolve with `gg continue` or `gg abort`
 - **`--from 1`** is equivalent to a full restack
+- **Detached HEAD with un-integrated commits** — `gg restack` detects and folds them in automatically

--- a/docs/src/commands/restack.md
+++ b/docs/src/commands/restack.md
@@ -91,7 +91,7 @@ gg restack          # folds "inserted" into the stack; HEAD stays on it
 
 After `gg restack` completes, HEAD is left on the just-inserted (or just-amended) commit. Run `gg sync` to push the updated stack.
 
-> **Note:** If folding the commit in hits a conflict, resolve it and run `gg continue` (or `gg abort`). After resolving a conflict this way you are returned to the stack head rather than left on the integrated commit — the commit is still folded in correctly; use `gg mv` to navigate back to it if you want to keep working there.
+> **Note:** If folding the commit in hits a conflict, resolve it and run `gg continue` (or `gg abort`). The conflict path goes through Git's normal rebase-continue, so afterwards you are returned to the stack head rather than left on the integrated commit, and the freshly folded commit may not yet have its `GG-ID`/`GG-Parent` assigned. The commit is still folded in correctly — run `gg sync` (or `gg reconcile`) to finish normalizing the metadata, and `gg mv` to navigate back to it if you want to keep working there. (This matches how `gg restack` behaves after any rebase conflict.)
 
 ## Edge Cases
 

--- a/docs/src/guides/editing-commits.md
+++ b/docs/src/guides/editing-commits.md
@@ -51,3 +51,34 @@ After major edits, run:
 ```bash
 gg sync
 ```
+
+## Insert a commit in the middle of a stack
+
+Sometimes you realize a commit is missing between two existing ones. Use `gg mv` to navigate there, make a normal `git commit`, then run `gg restack` to fold it in.
+
+```bash
+gg co testing
+git commit -m "one"
+git commit -m "two"
+
+# navigate to position 1 (HEAD detaches)
+gg mv 1
+
+# make the new commit
+git add <files>
+git commit -m "inserted"
+
+# gg ls shows the un-integrated commit rather than losing it:
+#   ⚠ Un-integrated commit at HEAD (detached):
+#       3fb873d inserted  — sits on top of [1]
+#     Run `gg restack` to fold it into the stack.
+gg ls
+
+# fold it in — stack becomes: one, inserted, two
+# HEAD stays on the inserted commit when restack finishes
+gg restack
+```
+
+`gg ls` is read-only: it never mutates the stack. The "un-integrated commit" callout is purely informational — the commit is not lost, it just isn't part of the stack yet. `gg restack` is what integrates it.
+
+The same flow works when you `git commit --amend` the navigated commit instead of creating a new one. In that case `gg restack` rewrites the commit in place and replays everything above it on top.

--- a/docs/superpowers/plans/2026-06-09-mid-stack-commit-insertion.md
+++ b/docs/superpowers/plans/2026-06-09-mid-stack-commit-insertion.md
@@ -1,0 +1,800 @@
+# Mid-stack commit insertion — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop `gg ls` from appearing to lose a commit made at a detached mid-stack HEAD, and make `gg restack` fold that commit into the stack while leaving HEAD on it.
+
+**Architecture:** A shared detector in `stack.rs` recognizes "there is a commit at the detached HEAD that hasn't been integrated into the stack" using the existing nav context (`.git/gg/current_stack`). `gg ls` consumes it read-only (callout + JSON field, no mutation). `gg restack` consumes it as an early-return integration path: `git rebase --onto <head> <original> <branch>`, then re-checks-out the head commit detached and rewrites the nav context. Covers both inserted (committed on top) and amended (rewritten in place) detached commits.
+
+**Tech Stack:** Rust, `git2`, existing `gg-core` command modules, integration tests via `CARGO_BIN_EXE_gg` in `crates/gg-cli/tests/integration_tests/`.
+
+**Spec:** `docs/superpowers/specs/2026-06-09-mid-stack-commit-insertion-design.md`
+
+---
+
+## Background the engineer needs
+
+- A stack's commits are computed by walking the parent chain from the branch ref `<user>/<stack>` down to base (`git.rs:415`). There is no stored commit list.
+- `gg mv <n>` checks out a **detached HEAD** at that commit and writes a nav context file `.git/gg/current_stack` formatted `branch|position|oid` via `stack::save_nav_context` (`stack.rs:436`). `position` is **0-indexed**; `oid` is the commit you navigated to.
+- `stack::read_nav_context(git_dir) -> Option<(String, usize, git2::Oid)>` reads it back (`stack.rs:453`).
+- `Stack::load(repo, config)` computes `stack.entries` (each `StackEntry` has `position` (1-indexed), `oid`, `short_sha`, `title`, `gg_id`, etc.) and `stack.current_position: Option<usize>` (0-indexed index of the entry whose oid == HEAD, or `None` if HEAD isn't a stack entry).
+- `git::checkout_commit(repo, &commit)` checks out a detached HEAD (used at `nav.rs:255`).
+- `git2::Repository` provides `head_detached() -> Result<bool>`, `graph_descendant_of(commit, ancestor) -> Result<bool>`, and `graph_ahead_behind(local, upstream) -> Result<(usize, usize)>`.
+- The existing `nav.rs::check_and_rebase_if_modified` (`nav.rs:285`) already performs `git rebase --onto <new> <orig> <branch>` for the modify-on-nav case — we are *not* changing it; we are adding a parallel, read-aware path that stays in place.
+
+### Test setup pattern (copy this exactly)
+
+Tests live in `crates/gg-cli/tests/integration_tests/<module>.rs` and use helpers from `crate::helpers`. Standard stack setup:
+
+```rust
+use crate::helpers::{create_test_repo, run_gg, run_git};
+use std::fs;
+
+// inside a #[test] fn:
+let (_temp_dir, repo_path) = create_test_repo();
+
+// gg config with a username (so branch names resolve)
+let gg_dir = repo_path.join(".git/gg");
+fs::create_dir_all(&gg_dir).unwrap();
+fs::write(
+    gg_dir.join("config.json"),
+    r#"{"defaults":{"branch_username":"testuser"}}"#,
+)
+.unwrap();
+
+// create a stack "testing" with two commits
+run_gg(&repo_path, &["co", "testing"]);
+run_git(&repo_path, &["commit", "--allow-empty", "-m", "one"]);
+run_git(&repo_path, &["commit", "--allow-empty", "-m", "two"]);
+
+// navigate to the middle (commit [1]) -> detached HEAD
+let (ok, out, err) = run_gg(&repo_path, &["mv", "1"]);
+assert!(ok, "mv failed: {out}{err}");
+
+// insert a commit on top of [1]
+run_git(&repo_path, &["commit", "--allow-empty", "-m", "inserted"]);
+```
+
+`run_gg` returns `(success: bool, stdout: String, stderr: String)`. `run_git` returns `(success: bool, stdout: String)`. There is also `run_git_full` returning stderr too.
+
+---
+
+## Task 1: `gg ls` detects and reports the un-integrated commit (read-only)
+
+**Files:**
+- Modify: `crates/gg-core/src/stack.rs` (add detector + types near the nav-context helpers, ~`stack.rs:466`)
+- Modify: `crates/gg-core/src/commands/ls.rs` (`show_stack`, ~`ls.rs:521`-`670`)
+- Modify: `crates/gg-core/src/output.rs` (`StackJson`, ~`output.rs:34`)
+- Test: `crates/gg-cli/tests/integration_tests/ls.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `crates/gg-cli/tests/integration_tests/ls.rs`:
+
+```rust
+#[test]
+fn test_ls_reports_unintegrated_midstack_commit() {
+    use crate::helpers::{create_test_repo, run_gg, run_git};
+    use std::fs;
+
+    let (_temp_dir, repo_path) = create_test_repo();
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).unwrap();
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .unwrap();
+
+    run_gg(&repo_path, &["co", "testing"]);
+    run_git(&repo_path, &["commit", "--allow-empty", "-m", "one"]);
+    run_git(&repo_path, &["commit", "--allow-empty", "-m", "two"]);
+    let (ok, out, err) = run_gg(&repo_path, &["mv", "1"]);
+    assert!(ok, "mv failed: {out}{err}");
+    run_git(&repo_path, &["commit", "--allow-empty", "-m", "inserted"]);
+
+    // ls must NOT mutate and must surface the orphan commit.
+    let (ok, out, err) = run_gg(&repo_path, &["ls"]);
+    assert!(ok, "ls failed: {out}{err}");
+    assert!(out.contains("Un-integrated commit"), "ls output: {out}");
+    assert!(out.contains("inserted"), "ls output: {out}");
+    assert!(out.contains("gg restack"), "ls output: {out}");
+
+    // ls is read-only: the branch tip still has only the original 2 commits.
+    let (_ok, log) = run_git(&repo_path, &["log", "--oneline", "testuser/testing"]);
+    assert!(log.contains("two"), "branch log: {log}");
+    assert!(!log.contains("inserted"), "branch must be untouched: {log}");
+}
+
+#[test]
+fn test_ls_json_includes_unintegrated_commits() {
+    use crate::helpers::{create_test_repo, run_gg, run_git};
+    use std::fs;
+
+    let (_temp_dir, repo_path) = create_test_repo();
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).unwrap();
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .unwrap();
+
+    run_gg(&repo_path, &["co", "testing"]);
+    run_git(&repo_path, &["commit", "--allow-empty", "-m", "one"]);
+    run_git(&repo_path, &["commit", "--allow-empty", "-m", "two"]);
+    run_gg(&repo_path, &["mv", "1"]);
+    run_git(&repo_path, &["commit", "--allow-empty", "-m", "inserted"]);
+
+    let (ok, out, err) = run_gg(&repo_path, &["ls", "--json"]);
+    assert!(ok, "ls --json failed: {out}{err}");
+    let v: serde_json::Value = serde_json::from_str(&out).expect("valid json");
+    let arr = v["stack"]["unintegrated_commits"]
+        .as_array()
+        .expect("unintegrated_commits array present");
+    assert_eq!(arr.len(), 1, "json: {out}");
+    assert_eq!(arr[0]["subject"], "inserted", "json: {out}");
+    assert_eq!(arr[0]["sits_on_position"], 1, "json: {out}");
+}
+```
+
+Note: `serde_json` is already a dependency of the test crate (used elsewhere in these tests). If the import path differs, follow the existing usage in the test modules.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p gg-cli --test integration_tests test_ls_reports_unintegrated_midstack_commit test_ls_json_includes_unintegrated_commits`
+Expected: FAIL — output lacks "Un-integrated commit" / JSON has no `unintegrated_commits`.
+
+- [ ] **Step 3: Add the detector + types to `stack.rs`**
+
+Add after `read_nav_context` (~`stack.rs:466`):
+
+```rust
+/// Whether the detached-HEAD commit was added on top of the navigated commit
+/// (`Inserted`) or rewrites it in place (`Amended`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnintegratedKind {
+    Inserted,
+    Amended,
+}
+
+/// A commit (or chain of commits) made at a detached mid-stack HEAD that has not
+/// yet been folded into the stack branch.
+#[derive(Debug, Clone)]
+pub struct UnintegratedCommit {
+    /// Current detached HEAD oid (the tip of the un-integrated work).
+    pub head_oid: git2::Oid,
+    /// The commit we navigated to (`gg mv`), recorded in the nav context.
+    pub original_oid: git2::Oid,
+    /// Stack branch name from the nav context.
+    pub branch_name: String,
+    /// 0-indexed position of the navigated commit within the stack.
+    pub saved_position: usize,
+    /// 1-indexed display position the un-integrated work sits on.
+    pub sits_on_position: usize,
+    /// Short sha of `head_oid`.
+    pub short_sha: String,
+    /// First line of the head commit message.
+    pub subject: String,
+    /// Number of un-integrated commits (1 for an amend).
+    pub count: usize,
+    pub kind: UnintegratedKind,
+}
+
+/// Detect a commit made at a detached mid-stack HEAD that has not been folded
+/// into the stack yet. Returns `None` when there is nothing to integrate.
+///
+/// Pure detection — never mutates the repository.
+pub fn detect_unintegrated(
+    repo: &Repository,
+    stack: &Stack,
+) -> Result<Option<UnintegratedCommit>> {
+    let (branch_name, saved_position, original_oid) = match read_nav_context(repo.path()) {
+        Some(ctx) => ctx,
+        None => return Ok(None),
+    };
+
+    // Must be detached with HEAD different from the navigated commit.
+    if !repo.head_detached()? {
+        return Ok(None);
+    }
+    let head = repo.head()?.peel_to_commit()?;
+    let head_oid = head.id();
+    if head_oid == original_oid {
+        return Ok(None);
+    }
+
+    // There must be commits above the navigated position to move over.
+    if saved_position + 1 >= stack.len() {
+        return Ok(None);
+    }
+
+    // Classify: committed on top (Inserted) vs rewritten in place (Amended).
+    let kind = if repo.graph_descendant_of(head_oid, original_oid)? {
+        UnintegratedKind::Inserted
+    } else {
+        let original = repo.find_commit(original_oid)?;
+        let original_parent = original.parent_id(0).ok();
+        let head_parent = head.parent_id(0).ok();
+        if original_parent.is_some() && original_parent == head_parent {
+            UnintegratedKind::Amended
+        } else {
+            // Unrelated detached state — don't touch it.
+            return Ok(None);
+        }
+    };
+
+    // Guard against re-detecting after integration: if the branch tip already
+    // descends from HEAD, the upper commits have been moved over.
+    let branch_tip = match stack.entries.last() {
+        Some(entry) => entry.oid,
+        None => return Ok(None),
+    };
+    if branch_tip == head_oid || repo.graph_descendant_of(branch_tip, head_oid)? {
+        return Ok(None);
+    }
+
+    let (count, _) = repo.graph_ahead_behind(head_oid, original_oid)?;
+    let count = count.max(1);
+
+    let subject = head
+        .summary()
+        .unwrap_or("(no message)")
+        .to_string();
+    let short_sha = repo
+        .find_object(head_oid, None)?
+        .short_id()?
+        .as_str()
+        .unwrap_or("")
+        .to_string();
+
+    Ok(Some(UnintegratedCommit {
+        head_oid,
+        original_oid,
+        branch_name,
+        saved_position,
+        sits_on_position: saved_position + 1,
+        short_sha,
+        subject,
+        count,
+        kind,
+    }))
+}
+```
+
+If `Repository` / `Result` aren't already in scope at that location in `stack.rs`, they are imported at the top of the file (the module already uses `Repository` and the crate `Result`). Reuse the existing imports.
+
+- [ ] **Step 4: Add the JSON field to `output.rs`**
+
+In `crates/gg-core/src/output.rs`, add to `StackJson` (after `entries`):
+
+```rust
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub unintegrated_commits: Vec<UnintegratedCommitJson>,
+```
+
+And add the new struct near `StackEntryJson`:
+
+```rust
+#[derive(Serialize)]
+pub struct UnintegratedCommitJson {
+    pub sha: String,
+    pub subject: String,
+    pub sits_on_position: usize,
+    pub count: usize,
+}
+```
+
+- [ ] **Step 5: Wire detection into `ls.rs::show_stack`**
+
+In `crates/gg-core/src/commands/ls.rs`, inside `show_stack` after `let repo = git::open_repo()?;` (~`ls.rs:524`) add:
+
+```rust
+    let unintegrated = stack::detect_unintegrated(&repo, stack)?;
+```
+
+In the **JSON branch**, populate the field on `StackJson` (add to the struct literal at ~`ls.rs:560`):
+
+```rust
+                unintegrated_commits: unintegrated
+                    .iter()
+                    .map(|u| crate::output::UnintegratedCommitJson {
+                        sha: u.short_sha.clone(),
+                        subject: u.subject.clone(),
+                        sits_on_position: u.sits_on_position,
+                        count: u.count,
+                    })
+                    .collect(),
+```
+
+In the **text branch**: when `unintegrated.is_some()`, suppress the misleading `<- HEAD` marker (HEAD is on the orphan, not a listed entry) and print the callout after the entry loop. Replace the two `is_current` computations (`ls.rs:538` and `ls.rs:617`) so they are forced `false` when an orphan exists. The simplest change: introduce `let has_orphan = unintegrated.is_some();` and change each `let is_current = <expr>;` to `let is_current = !has_orphan && (<expr>);` (in the JSON branch use a separate `let has_orphan` based on the array; in the text branch use `unintegrated.is_some()`).
+
+After the entry-printing `for` loop (after `ls.rs:670`'s closing `}`), add:
+
+```rust
+    if let Some(u) = &unintegrated {
+        println!();
+        let more = if u.count > 1 {
+            format!(" (+{} more)", u.count - 1)
+        } else {
+            String::new()
+        };
+        println!(
+            "  {} Un-integrated commit at HEAD (detached):",
+            style("⚠").yellow().bold()
+        );
+        println!(
+            "      {} {}{}  — sits on top of [{}]",
+            style(&u.short_sha).yellow(),
+            u.subject,
+            more,
+            u.sits_on_position
+        );
+        println!(
+            "    {}",
+            style("Run `gg restack` to fold it into the stack.").dim()
+        );
+    }
+```
+
+Ensure `stack` is imported in `ls.rs` (it uses `crate::stack::...` elsewhere; if only `Stack` is imported, use `crate::stack::detect_unintegrated`).
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `cargo test -p gg-cli --test integration_tests test_ls_reports_unintegrated_midstack_commit test_ls_json_includes_unintegrated_commits`
+Expected: PASS.
+
+- [ ] **Step 7: Format, clippy, full build of affected crate**
+
+Run: `cargo fmt --all && cargo clippy -p gg-core -p gg-cli --all-targets --all-features -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/gg-core/src/stack.rs crates/gg-core/src/output.rs crates/gg-core/src/commands/ls.rs crates/gg-cli/tests/integration_tests/ls.rs
+git commit -m "feat(core): detect and report un-integrated mid-stack commits in gg ls (#348)"
+```
+
+---
+
+## Task 2: `gg restack` integrates the inserted commit and stays on it
+
+**Files:**
+- Modify: `crates/gg-core/src/commands/restack.rs` (`run`, add `integrate_unintegrated` helper)
+- Test: `crates/gg-cli/tests/integration_tests/restack.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `crates/gg-cli/tests/integration_tests/restack.rs`:
+
+```rust
+#[test]
+fn test_restack_integrates_inserted_midstack_commit() {
+    use crate::helpers::{create_test_repo, run_gg, run_git};
+    use std::fs;
+
+    let (_temp_dir, repo_path) = create_test_repo();
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).unwrap();
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .unwrap();
+
+    run_gg(&repo_path, &["co", "testing"]);
+    run_git(&repo_path, &["commit", "--allow-empty", "-m", "one"]);
+    run_git(&repo_path, &["commit", "--allow-empty", "-m", "two"]);
+    run_gg(&repo_path, &["mv", "1"]);
+    run_git(&repo_path, &["commit", "--allow-empty", "-m", "inserted"]);
+
+    let (ok, out, err) = run_gg(&repo_path, &["restack"]);
+    assert!(ok, "restack failed: {out}{err}");
+
+    // Branch now contains all three in order: one -> inserted -> two.
+    let (_ok, log) = run_git(&repo_path, &["log", "--oneline", "testuser/testing"]);
+    assert!(log.contains("one") && log.contains("inserted") && log.contains("two"), "log: {log}");
+
+    // HEAD stays on the inserted commit (detached).
+    let (_ok, head_subj) = run_git(&repo_path, &["log", "-1", "--pretty=%s", "HEAD"]);
+    assert_eq!(head_subj.trim(), "inserted", "HEAD subject: {head_subj}");
+
+    // ls now shows 3 commits with HEAD on [2] and no orphan warning.
+    let (ok, out, err) = run_gg(&repo_path, &["ls"]);
+    assert!(ok, "ls failed: {out}{err}");
+    assert!(out.contains("3 commits"), "ls: {out}");
+    assert!(!out.contains("Un-integrated commit"), "ls should be clean: {out}");
+    assert!(out.contains("inserted") && out.contains("<- HEAD"), "ls: {out}");
+}
+
+#[test]
+fn test_restack_integrates_multiple_inserted_commits() {
+    use crate::helpers::{create_test_repo, run_gg, run_git};
+    use std::fs;
+
+    let (_temp_dir, repo_path) = create_test_repo();
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).unwrap();
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .unwrap();
+
+    run_gg(&repo_path, &["co", "testing"]);
+    run_git(&repo_path, &["commit", "--allow-empty", "-m", "one"]);
+    run_git(&repo_path, &["commit", "--allow-empty", "-m", "two"]);
+    run_gg(&repo_path, &["mv", "1"]);
+    run_git(&repo_path, &["commit", "--allow-empty", "-m", "ins_a"]);
+    run_git(&repo_path, &["commit", "--allow-empty", "-m", "ins_b"]);
+
+    let (ok, out, err) = run_gg(&repo_path, &["restack"]);
+    assert!(ok, "restack failed: {out}{err}");
+
+    let (_ok, head_subj) = run_git(&repo_path, &["log", "-1", "--pretty=%s", "HEAD"]);
+    assert_eq!(head_subj.trim(), "ins_b", "HEAD subject: {head_subj}");
+
+    let (_ok, log) = run_git(&repo_path, &["log", "--oneline", "testuser/testing"]);
+    for m in ["one", "ins_a", "ins_b", "two"] {
+        assert!(log.contains(m), "missing {m} in log: {log}");
+    }
+}
+
+#[test]
+fn test_restack_without_orphan_is_unchanged() {
+    use crate::helpers::{create_test_repo, run_gg, run_git};
+    use std::fs;
+
+    let (_temp_dir, repo_path) = create_test_repo();
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).unwrap();
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .unwrap();
+
+    run_gg(&repo_path, &["co", "testing"]);
+    run_git(&repo_path, &["commit", "--allow-empty", "-m", "one"]);
+    run_git(&repo_path, &["commit", "--allow-empty", "-m", "two"]);
+
+    // No detached orphan: restack should report a consistent stack (no error).
+    let (ok, out, err) = run_gg(&repo_path, &["restack"]);
+    assert!(ok, "restack failed: {out}{err}");
+    assert!(!out.contains("Integrated"), "should not integrate: {out}");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p gg-cli --test integration_tests test_restack_integrates_inserted_midstack_commit test_restack_integrates_multiple_inserted_commits test_restack_without_orphan_is_unchanged`
+Expected: FAIL — the inserted commit is not integrated / HEAD not preserved.
+
+- [ ] **Step 3: Add the integration helper to `restack.rs`**
+
+Add this function above `pub fn run` (~`restack.rs:140`):
+
+```rust
+/// Integrate a commit made at a detached mid-stack HEAD into the stack branch,
+/// then leave HEAD detached on that commit. Returns early from `run`.
+fn integrate_unintegrated(
+    repo: &git2::Repository,
+    config: &Config,
+    unintegrated: stack::UnintegratedCommit,
+    json: bool,
+) -> Result<()> {
+    let guard = git::begin_recorded_op(
+        repo,
+        config,
+        OperationKind::Restack,
+        std::env::args().skip(1).collect(),
+        None,
+        SnapshotScope::AllUserBranches,
+    )?;
+
+    // Move the commits above the navigated position onto the detached HEAD work.
+    // git rebase --onto <new_base> <old_base> <branch>
+    let output = std::process::Command::new("git")
+        .args([
+            "rebase",
+            "--onto",
+            &unintegrated.head_oid.to_string(),
+            &unintegrated.original_oid.to_string(),
+            &unintegrated.branch_name,
+        ])
+        .current_dir(repo.workdir().unwrap_or_else(|| repo.path()))
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        if stderr.contains("CONFLICT")
+            || stderr.contains("conflict")
+            || stdout.contains("CONFLICT")
+            || stdout.contains("conflict")
+        {
+            return Err(GgError::RebaseConflict);
+        }
+        return Err(GgError::Other(format!(
+            "Failed to integrate commit: {}",
+            if stderr.is_empty() { stdout } else { stderr }
+        )));
+    }
+
+    // Stay on the integrated commit (detached HEAD).
+    let head_commit = repo.find_commit(unintegrated.head_oid)?;
+    git::checkout_commit(repo, &head_commit)?;
+
+    // Rewrite the nav context to the new position of the integrated commit.
+    let reloaded = Stack::load(repo, config)?;
+    let new_position = reloaded
+        .current_position
+        .unwrap_or(unintegrated.saved_position);
+    stack::save_nav_context(
+        repo.path(),
+        &unintegrated.branch_name,
+        new_position,
+        unintegrated.head_oid,
+    )?;
+
+    guard.finalize_with_scope(repo, config, SnapshotScope::AllUserBranches, vec![], false)?;
+
+    if json {
+        print_json(&RestackResponse {
+            version: OUTPUT_VERSION,
+            restack: RestackResultJson {
+                stack_name: reloaded.name.clone(),
+                total_entries: reloaded.entries.len(),
+                entries_restacked: unintegrated.count,
+                entries_ok: reloaded.entries.len().saturating_sub(unintegrated.count),
+                dry_run: false,
+                steps: vec![],
+            },
+        });
+    } else {
+        println!(
+            "{} Integrated {} commit(s) into stack {:?}; HEAD stays on {} {}",
+            style("✓").green().bold(),
+            unintegrated.count,
+            reloaded.name,
+            style(&unintegrated.short_sha).yellow(),
+            unintegrated.subject,
+        );
+        println!(
+            "  {}",
+            style("Hint: Run `gg sync` to push the updated stack.").dim()
+        );
+    }
+
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Call the helper from `run` before plan building**
+
+In `restack.rs::run`, after `let stack = Stack::load(&repo, &config)?;` and the `is_empty` check (after ~`restack.rs:164`), add:
+
+```rust
+    // If there is a commit made at a detached mid-stack HEAD, fold it in and
+    // stay on it (early return). This is the only restack path that mutates
+    // while keeping HEAD detached.
+    if let Some(unintegrated) = stack::detect_unintegrated(&repo, &stack)? {
+        return integrate_unintegrated(&repo, &config, unintegrated, options.json);
+    }
+```
+
+Note ordering: this is placed after `git::require_clean_working_directory(&repo)?` (`restack.rs:157`) and after `Stack::load`, so the working tree is already verified clean. `detect_unintegrated` is read-only.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test -p gg-cli --test integration_tests test_restack_integrates_inserted_midstack_commit test_restack_integrates_multiple_inserted_commits test_restack_without_orphan_is_unchanged`
+Expected: PASS.
+
+- [ ] **Step 6: Format + clippy**
+
+Run: `cargo fmt --all && cargo clippy -p gg-core -p gg-cli --all-targets --all-features -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/gg-core/src/commands/restack.rs crates/gg-cli/tests/integration_tests/restack.rs
+git commit -m "feat(core): integrate detached mid-stack commits via gg restack (#348)"
+```
+
+---
+
+## Task 3: `gg restack` also integrates an amended detached commit
+
+**Files:**
+- Test: `crates/gg-cli/tests/integration_tests/restack.rs`
+- (No new production code expected — `detect_unintegrated` already classifies `Amended` and `integrate_unintegrated` uses the same `rebase --onto`. This task verifies and, only if a test fails, fixes.)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `crates/gg-cli/tests/integration_tests/restack.rs`:
+
+```rust
+#[test]
+fn test_restack_integrates_amended_midstack_commit() {
+    use crate::helpers::{create_test_repo, run_gg, run_git};
+    use std::fs;
+
+    let (_temp_dir, repo_path) = create_test_repo();
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).unwrap();
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .unwrap();
+
+    run_gg(&repo_path, &["co", "testing"]);
+    run_git(&repo_path, &["commit", "--allow-empty", "-m", "one"]);
+    run_git(&repo_path, &["commit", "--allow-empty", "-m", "two"]);
+    run_gg(&repo_path, &["mv", "1"]);
+    // Amend the navigated commit in place (rewrites "one").
+    run_git(&repo_path, &["commit", "--amend", "-m", "one_amended"]);
+
+    let (ok, out, err) = run_gg(&repo_path, &["restack"]);
+    assert!(ok, "restack failed: {out}{err}");
+
+    // HEAD stays on the amended commit.
+    let (_ok, head_subj) = run_git(&repo_path, &["log", "-1", "--pretty=%s", "HEAD"]);
+    assert_eq!(head_subj.trim(), "one_amended", "HEAD subject: {head_subj}");
+
+    // Branch is one_amended -> two (2 commits, "one" gone).
+    let (_ok, log) = run_git(&repo_path, &["log", "--oneline", "testuser/testing"]);
+    assert!(log.contains("one_amended") && log.contains("two"), "log: {log}");
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `cargo test -p gg-cli --test integration_tests test_restack_integrates_amended_midstack_commit`
+Expected: PASS if the `Amended` classification works end-to-end. If it FAILS, debug `detect_unintegrated` (the `original_parent == head_parent` branch) using `superpowers:systematic-debugging`, fix in `crates/gg-core/src/stack.rs`, and re-run.
+
+- [ ] **Step 3: Format + clippy (only if code changed)**
+
+Run: `cargo fmt --all && cargo clippy -p gg-core -p gg-cli --all-targets --all-features -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/gg-cli/tests/integration_tests/restack.rs crates/gg-core/src/stack.rs
+git commit -m "test(core): cover amended detached mid-stack commit integration (#348)"
+```
+
+---
+
+## Task 4: Conflict path test
+
+**Files:**
+- Test: `crates/gg-cli/tests/integration_tests/restack.rs`
+
+Verifies that when folding the inserted commit conflicts with an upper commit, restack surfaces the existing conflict guidance and exits non-zero.
+
+- [ ] **Step 1: Write the test**
+
+Add to `crates/gg-cli/tests/integration_tests/restack.rs`:
+
+```rust
+#[test]
+fn test_restack_integration_conflict_reports_guidance() {
+    use crate::helpers::{create_test_repo, run_gg, run_git};
+    use std::fs;
+
+    let (_temp_dir, repo_path) = create_test_repo();
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).unwrap();
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .unwrap();
+
+    run_gg(&repo_path, &["co", "testing"]);
+    // commit "one" leaves conflict.txt absent; "two" adds conflict.txt = "two".
+    run_git(&repo_path, &["commit", "--allow-empty", "-m", "one"]);
+    fs::write(repo_path.join("conflict.txt"), "two\n").unwrap();
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "two"]);
+
+    run_gg(&repo_path, &["mv", "1"]);
+    // Inserted commit writes the same file with different content -> conflict
+    // when "two" is replayed on top.
+    fs::write(repo_path.join("conflict.txt"), "inserted\n").unwrap();
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "inserted"]);
+
+    let (ok, out, err) = run_gg(&repo_path, &["restack"]);
+    assert!(!ok, "expected conflict failure: {out}{err}");
+    let combined = format!("{out}{err}");
+    assert!(
+        combined.contains("gg continue") || combined.contains("gg abort") || combined.contains("conflict"),
+        "expected conflict guidance: {combined}"
+    );
+}
+```
+
+Note: `GgError::RebaseConflict`'s user-facing message is produced by the CLI's error rendering — assert on whichever of `gg continue` / `gg abort` / `conflict` the existing `RebaseConflict` rendering emits (check `crates/gg-core/src/error.rs` for the exact text and tighten the assertion to match).
+
+- [ ] **Step 2: Run the test**
+
+Run: `cargo test -p gg-cli --test integration_tests test_restack_integration_conflict_reports_guidance`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/gg-cli/tests/integration_tests/restack.rs
+git commit -m "test(core): cover conflict path when integrating mid-stack commit (#348)"
+```
+
+---
+
+## Task 5: Documentation and agent skill updates
+
+**Files:**
+- Modify: relevant page(s) under `docs/src/` (the stack-navigation / restack guide and command reference)
+- Modify: `skills/gg/SKILL.md`
+- Modify: `skills/gg/reference.md`
+
+- [ ] **Step 1: Find the right docs pages**
+
+Run: `rg -l "restack|gg mv|navigation" docs/src`
+Identify the navigation guide and the `restack` reference entry.
+
+- [ ] **Step 2: Document the insert-in-the-middle workflow**
+
+In the navigation/restack guide, add a short section: inserting a commit in the middle of a stack is done by `gg mv <n>`, making one or more `git commit`s, then `gg restack` — which folds them in and leaves you on the new commit. Note that `gg ls` will, in the meantime, show the commit as "un-integrated" rather than losing it. Include a concrete example mirroring issue #348:
+
+```
+gg co testing
+git commit -m one
+git commit -m two
+gg mv 1
+git commit -m inserted   # HEAD now detached on top of [1]
+gg ls                    # shows "Un-integrated commit at HEAD"
+gg restack               # folds it in -> one, inserted, two; HEAD stays on inserted
+```
+
+- [ ] **Step 3: Update the restack command reference**
+
+In the `restack` reference page, note that `restack` also integrates a commit made at a detached mid-stack HEAD (inserted or amended), keeping HEAD on that commit.
+
+- [ ] **Step 4: Update the skill**
+
+In `skills/gg/SKILL.md`, add the insert workflow to the relevant operating rules (how to insert a commit mid-stack, and that `gg ls` flags un-integrated commits). In `skills/gg/reference.md`, document the new `unintegrated_commits` array on the `gg ls --json` single-stack output (fields: `sha`, `subject`, `sits_on_position`, `count`) and the restack integration behavior.
+
+- [ ] **Step 5: Build the docs to verify**
+
+Run: `mdbook build docs`
+Expected: builds without error. (If `mdbook` is not installed, skip and note it.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs skills
+git commit -m "docs: document mid-stack commit insertion workflow (#348)"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the full suite**
+
+Run: `cargo fmt --all && cargo clippy --all-targets --all-features -- -D warnings && cargo test --all-features`
+Expected: format clean, no clippy warnings, all tests pass.
+
+---
+
+## Self-review notes (author)
+
+- **Spec coverage:** Detection (Task 1 §3) ✓; ls read-only callout + JSON (Task 1) ✓; restack integration + stay-in-place + nav-context rewrite + GG-ID left blank (Task 2) ✓; amend-in-place (Task 3) ✓; conflict path reuse (Task 4) ✓; docs/skill (Task 5) ✓.
+- **GG-IDs left blank:** the integration path deliberately does *not* call `normalize_stack_metadata`, matching the issue's `(id: -)` expected output; IDs are assigned on `gg sync` as for any new commit.
+- **Type consistency:** `detect_unintegrated`, `UnintegratedCommit`, `UnintegratedKind`, `UnintegratedCommitJson`, and field names (`head_oid`, `original_oid`, `branch_name`, `saved_position`, `sits_on_position`, `short_sha`, `subject`, `count`) are used identically across Tasks 1–4.
+- **Non-goal honored:** manual `git checkout <sha>` (no nav context) → `read_nav_context` returns `None` → detector returns `None`, so it's untouched, as specified.

--- a/docs/superpowers/specs/2026-06-09-mid-stack-commit-insertion-design.md
+++ b/docs/superpowers/specs/2026-06-09-mid-stack-commit-insertion-design.md
@@ -1,0 +1,174 @@
+# Mid-stack commit insertion
+
+**Issue:** [#348](https://github.com/mrmans0n/git-gud/issues/348) — `gg ls` loses commits made in the middle of the stack
+**Date:** 2026-06-09
+**Status:** Approved (design)
+
+## Problem
+
+A user navigates into the middle of a stack and commits:
+
+```
+gg co -b main testing
+git commit --allow-empty -m one
+git commit --allow-empty -m two
+gg mv 1                          # detached HEAD at "one"
+git commit --allow-empty -m inserted
+gg ls
+```
+
+`gg ls` shows only `one` and `two`, with HEAD apparently on `two`. The `inserted`
+commit appears lost.
+
+### Why it happens
+
+- A stack's commits are computed by walking the **parent chain from the stack
+  branch ref** (`<user>/<stack>`), stopping at the base. There is no stored commit
+  list (`git.rs:415`, `git.rs:437`).
+- `gg mv 1` checks out a **detached HEAD** at commit `one` and saves a nav context
+  to `.git/gg/current_stack` as `branch | position | original_oid`
+  (`nav.rs:245`, `stack.rs:436`).
+- `git commit -m inserted` lands the new commit on top of `one` at detached HEAD.
+  The branch ref `testing` still points at `two`, so `inserted` is **not reachable
+  from the tip**. `gg ls` walks `two → one → base` and never sees it.
+
+The commit is **not actually lost** — it is at HEAD and in the reflog. Crucially,
+`nav.rs::check_and_rebase_if_modified` (`nav.rs:285`) already handles this exact
+shape: had the user run `gg next` / `gg last`, it would have run
+`git rebase --onto inserted one testing` and produced the desired
+`one → inserted → two`. Those commands recover it because they call the helper;
+`gg ls` does not.
+
+So this is not a missing mechanism. It is two gaps:
+
+1. **`gg ls` / bare `gg` is read-only** and never triggers integration, so it shows
+   a misleading "the commit vanished" state when the data is safe.
+2. When nav *does* integrate, it **moves HEAD to the stack head**, whereas the
+   issue wants HEAD to **stay on the just-inserted commit**.
+
+## Goals
+
+- `gg ls` / bare `gg` must never present an inserted commit as lost.
+- There must be a single, discoverable command that folds an inserted commit into
+  the stack and leaves HEAD on it.
+- Reuse the existing rebase/conflict machinery; add no new conflict handling.
+
+## Non-goals
+
+- Detecting inserts made via a **manual** `git checkout <sha>` (no nav context).
+  v1 only handles inserts after a `gg`-driven navigation. Structural detection is a
+  possible follow-up.
+- Making `gg ls` (or any read command) mutate history.
+- Assigning GG-IDs to the inserted commit during integration (left to `sync` /
+  `reconcile`, as for any new commit).
+
+## Design
+
+### 1. Detection (shared helper)
+
+Reuse the existing nav context — no new state. A commit was inserted at a detached
+mid-stack HEAD when **all** of:
+
+1. A nav context exists in `.git/gg/current_stack`.
+2. HEAD is detached and `HEAD_oid != original_oid`.
+3. HEAD's commit is a **descendant** of `original_oid` (committed *on top of* the
+   navigated commit — distinct from amending it in place).
+4. The branch tip is not yet reachable from HEAD (the upper commits have not been
+   moved over).
+
+This naturally covers **multiple** inserted commits (a whole chain on top of
+`original_oid`), since detection only requires that HEAD descends from
+`original_oid`.
+
+The helper is extracted so both `ls` (report-only) and `restack` (integrate) use
+the same definition.
+
+### 2. `gg ls` reporting (read-only)
+
+When detection fires, `ls` / bare `gg` still walks the branch tip as today, but
+appends a clear callout. The orphan is *shown*, visually separated from the
+integrated stack:
+
+```
+testing (2 commits, 0 synced)
+
+  [1] e1de9de one       not pushed  (id: -)
+  [2] b9ba3d2 two       not pushed  (id: -)
+
+  ⚠ Un-integrated commit at HEAD (detached):
+      3fb873d inserted  — sits on top of [1] one
+    Run `gg restack` to fold it into the stack (it will become [2]).
+```
+
+- **No mutation.** `ls` stays a pure read.
+- The orphan is displayed with its SHA and the position it sits on, so the user
+  sees the work is safe.
+- `--json` output gains an `unintegrated_commits` array (`oid`, `subject`,
+  `sits_on_position`) alongside the normal `commits`, so agents/scripts see it too.
+
+Scoped to `ls` / bare `gg` for v1. The detection helper can be reused to surface the
+same callout from other read paths (e.g. `gg log`) later.
+
+### 3. `gg restack` integration
+
+`gg restack` gains an integration step that runs **before** its existing GG-Parent
+reattachment logic:
+
+1. **Detect** inserted commit(s) via the Section 1 helper. If none, `restack`
+   behaves exactly as today.
+2. **Integrate** via existing machinery:
+   `git rebase --onto <HEAD_oid> <original_oid> <branch>`. The upper commits
+   (`two`, …) replay on top of the inserted chain. The inserted commit's own oid is
+   unchanged (it is the new base of the rebase), so we retain it.
+3. **Stay in place:** re-checkout the inserted commit as detached HEAD and rewrite
+   the nav context to its new position (`saved_position + <#inserted>`). HEAD ends
+   on `inserted`.
+4. **GG-IDs:** the inserted commit has none. Leave it blank — matches the issue's
+   expected output (`id: -`); IDs are assigned lazily on `sync` / `reconcile`. The
+   one required fix: restack's guard that *all* commits must already have GG-IDs
+   (`restack.rs:70`) must not reject a freshly-integrated orphan. Integration runs
+   first; GG-Parent reattachment then proceeds over the now-linear stack,
+   tolerating the new commit's missing ID.
+5. **Amend-in-place too:** restack also picks up an *amended* mid-stack commit (HEAD
+   replaces `original_oid` rather than descending from it), integrating it and
+   staying in place — making `restack` the single "integrate my detached-HEAD
+   changes, keep my position" entry point.
+6. **Conflicts:** if the `rebase --onto` conflicts, reuse the existing path — print
+   the `gg continue` / `gg abort` guidance and return `RebaseConflict`. No new
+   conflict machinery.
+
+Net effect of `gg mv 1; git commit -m inserted; gg restack`: `one → inserted → two`,
+HEAD on `inserted` — the issue's exact expected output.
+
+## Affected code
+
+- `crates/gg-core/src/stack.rs` / `nav.rs` — extract the detection helper from the
+  logic currently inside `check_and_rebase_if_modified` (`nav.rs:285`).
+- `crates/gg-core/src/commands/ls.rs` — read-only detection + callout + JSON field.
+- `crates/gg-core/src/commands/restack.rs` — integration step before reattachment;
+  relax the all-IDs-present guard (`restack.rs:70`); stay-on-commit + nav-context
+  rewrite.
+
+## Testing
+
+Integration tests (temp repos, `run_gg` / `run_git`) covering:
+
+- `gg mv 1; git commit; gg ls` → reports the un-integrated commit; stack still shows
+  2 commits; exit success; no mutation.
+- `gg mv 1; git commit; gg restack` → stack is `one → inserted → two`; HEAD detached
+  on `inserted`; `gg ls` afterward shows 3 commits with HEAD on `[2]`.
+- Multiple inserted commits at the middle → all integrated in order.
+- Amend-in-place at detached middle HEAD + `gg restack` → amended commit integrated,
+  HEAD stays on it.
+- `gg restack` with no orphan → unchanged behavior (regression guard).
+- Conflict during integration → `RebaseConflict`, `gg continue` / `gg abort`
+  guidance shown.
+- `gg ls --json` → `unintegrated_commits` array populated/empty as appropriate.
+
+## Docs & skill updates
+
+- `docs/src` — document the insert-in-the-middle workflow (`gg mv N; git commit;
+  gg restack`) and the `ls` callout.
+- `skills/gg/SKILL.md` and `skills/gg/reference.md` — note the workflow, the `ls`
+  callout, the `unintegrated_commits` JSON field, and that `restack` integrates
+  detached-HEAD commits while staying in place.

--- a/skills/gg/SKILL.md
+++ b/skills/gg/SKILL.md
@@ -198,6 +198,31 @@ interrupted/pending records are never pruned.
 `git stash`), does **not** touch remotes, and does **not** support an
 `--all` / `--range` mode.
 
+## Inserting a commit in the middle of a stack
+
+To add a new commit between two existing stack entries, navigate to the target position with `gg mv`, make the commit, then run `gg restack`:
+
+```bash
+gg mv 1              # detach HEAD at position 1
+git add <files>
+git commit -m "inserted"
+gg restack           # folds "inserted" into the stack: ..., [1], inserted, [2], ...
+```
+
+After `gg restack`, HEAD is left on the just-inserted commit. Run `gg sync` to push the updated stack.
+
+The same flow works when you `git commit --amend` the navigated commit rather than creating a new one.
+
+**Detecting un-integrated commits:** `gg ls` is read-only — it never mutates the stack. When a commit exists at a detached HEAD that hasn't been folded in yet, `gg ls` shows a callout:
+
+```
+⚠ Un-integrated commit at HEAD (detached):
+    3fb873d inserted  — sits on top of [1]
+  Run `gg restack` to fold it into the stack.
+```
+
+`gg ls --json` surfaces this via the `unintegrated_commits` array on the stack object (omitted when empty). Each entry has `sha`, `subject`, `sits_on_position`, and `count` fields. Agents should check for this array and surface the callout to the user; `gg restack` is the only command that integrates these commits.
+
 ## Repairing stack ancestry (`gg restack`)
 
 `gg restack` detects and repairs ancestry drift — when a commit's `GG-Parent`

--- a/skills/gg/reference.md
+++ b/skills/gg/reference.md
@@ -201,7 +201,7 @@ Rebase current stack onto base or explicit target.
 - `-f, --force` (alias: `--ignore-immutable`) — bypass the [immutability guard](#immutable-commits)
 
 #### `gg restack [OPTIONS]`
-Repair stack ancestry after manual history changes (amend, cherry-pick, upstream rebase).
+Repair stack ancestry after manual history changes (amend, cherry-pick, upstream rebase). Also integrates commits made at a detached HEAD after `gg mv` — folds them into the stack and leaves HEAD on the inserted/amended commit.
 
 - `-n, --dry-run`: Show what would be done without making changes
 - `--from <TARGET>`: Repair only from this commit upward (position, SHA, or GG-ID)
@@ -355,6 +355,14 @@ All JSON payloads include `version` (`u32`, current value: `1`).
         "in_merge_train": false,
         "merge_train_position": null
       }
+    ],
+    "unintegrated_commits": [
+      {
+        "sha": "3fb873d",
+        "subject": "inserted",
+        "sits_on_position": 1,
+        "count": 1
+      }
     ]
   }
 }
@@ -370,6 +378,7 @@ Field types:
 - `ci_status`: `string | null`
 - `in_merge_train`: `boolean` *(GitLab-specific)*
 - `merge_train_position`: `number | null` *(GitLab-specific)*
+- `unintegrated_commits`: array, **omitted when empty** — commits at a detached HEAD that haven't been folded into the stack yet. Each entry: `sha` (string), `subject` (string), `sits_on_position` (number — the stack position this commit sits on top of), `count` (number — total un-integrated commits at HEAD). Run `gg restack` to integrate them.
 
 ### `gg ls --all --json` (all local stacks)
 


### PR DESCRIPTION
## Summary

Fixes #348. Previously, navigating into the middle of a stack with `gg mv <n>` and then `git commit` made the new commit appear lost: `gg ls` walks the branch tip, which still pointed past the detached HEAD, so the inserted commit was invisible (though never actually lost — it was in the reflog).

This makes the insert-in-the-middle workflow first-class:

- **`gg ls` / bare `gg` (read-only)** now detects the un-integrated commit at the detached HEAD and shows a clear callout (`⚠ Un-integrated commit at HEAD … Run \`gg restack\` to fold it in`) instead of appearing to drop it. `gg ls --json` gains a `stack.unintegrated_commits` array (`sha`, `subject`, `sits_on_position`, `count`), omitted when empty.
- **`gg restack`** folds the commit(s) into the stack via `git rebase --onto`, rebases the rest on top, and leaves HEAD on the just-inserted commit — matching the issue's expected output (`one → inserted → two`, HEAD on `inserted`). Handles both an inserted commit (committed on top) and an amended commit (navigated commit rewritten in place), and multiple inserted commits.

Integration reuses the existing detached-HEAD rebase machinery; GG-IDs for the new commit are assigned later on `gg sync`, as for any new commit. `gg ls` stays strictly read-only — only `gg restack` mutates.

**Known limitation:** if folding-in hits a conflict, after `gg continue` you land on the stack head rather than detached on the integrated commit (inherited from the existing nav-rebase path). The commit is still folded in correctly; documented in the restack docs.

## Test Plan

- [x] `cargo test --all-features` — 830 pass, 0 failures
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- New integration tests: inserted (single + multiple), amended, conflict path, no-orphan regression guard, and `ls` text + JSON detection.
- Docs (`docs/src`) and agent skill (`skills/gg`) updated.

Closes #348