### PR TITLE
fix: finalize interrupted operations on continue

### DIFF
--- a/crates/gg-cli/tests/integration_tests/continue_flow.rs
+++ b/crates/gg-cli/tests/integration_tests/continue_flow.rs
@@ -1,12 +1,9 @@
 use crate::helpers::{create_test_repo, create_test_repo_with_remote, run_gg, run_git};
 
+use serde_json::Value;
 use std::fs;
 
-#[test]
-fn test_gg_continue_fails_with_unstaged_changes() {
-    let (_temp_dir, repo_path) = create_test_repo();
-
-    // Set up config
+fn write_test_config(repo_path: &std::path::Path) {
     let gg_dir = repo_path.join(".git/gg");
     fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
     fs::write(
@@ -14,6 +11,37 @@ fn test_gg_continue_fails_with_unstaged_changes() {
         r#"{"defaults":{"branch_username":"testuser"}}"#,
     )
     .expect("Failed to write config");
+}
+
+fn head_sha(repo_path: &std::path::Path) -> String {
+    let (success, stdout) = run_git(repo_path, &["rev-parse", "HEAD"]);
+    assert!(success, "git rev-parse HEAD failed");
+    stdout.trim().to_string()
+}
+
+fn assert_next_undo_targets(repo_path: &std::path::Path, expected_kind: &str, expected_head: &str) {
+    let (success, stdout, stderr) = run_gg(repo_path, &["undo", "--json"]);
+    assert!(success, "undo failed: stdout={stdout} stderr={stderr}");
+
+    let parsed: Value = serde_json::from_str(&stdout).expect("stdout must be valid JSON");
+    assert_eq!(parsed["status"], "succeeded");
+    assert_eq!(
+        parsed["undone"]["kind"], expected_kind,
+        "gg continue should finalize the interrupted {expected_kind} operation"
+    );
+    assert_eq!(
+        head_sha(repo_path),
+        expected_head,
+        "undo should restore pre-{expected_kind} HEAD"
+    );
+}
+
+#[test]
+fn test_gg_continue_fails_with_unstaged_changes() {
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    // Set up config
+    write_test_config(&repo_path);
 
     // Create a stack
     run_gg(&repo_path, &["co", "continue-unstaged-test"]);
@@ -59,13 +87,7 @@ fn test_gg_continue_fails_with_unresolved_conflicts() {
     let (_temp_dir, repo_path) = create_test_repo();
 
     // Set up config
-    let gg_dir = repo_path.join(".git/gg");
-    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
-    fs::write(
-        gg_dir.join("config.json"),
-        r#"{"defaults":{"branch_username":"testuser"}}"#,
-    )
-    .expect("Failed to write config");
+    write_test_config(&repo_path);
 
     // Create a stack
     run_gg(&repo_path, &["co", "continue-conflict-test"]);
@@ -121,13 +143,7 @@ fn test_conflict_detection_from_stderr() {
     let (_temp_dir, repo_path, _remote_path) = create_test_repo_with_remote();
 
     // Set up config
-    let gg_dir = repo_path.join(".git/gg");
-    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
-    fs::write(
-        gg_dir.join("config.json"),
-        r#"{"defaults":{"branch_username":"testuser"}}"#,
-    )
-    .expect("Failed to write config");
+    write_test_config(&repo_path);
 
     // Create a stack with a commit
     run_gg(&repo_path, &["co", "stderr-conflict-test"]);
@@ -171,13 +187,7 @@ fn test_conflict_detection_from_stdout() {
     let (_temp_dir, repo_path, _remote_path) = create_test_repo_with_remote();
 
     // Set up config
-    let gg_dir = repo_path.join(".git/gg");
-    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
-    fs::write(
-        gg_dir.join("config.json"),
-        r#"{"defaults":{"branch_username":"testuser"}}"#,
-    )
-    .expect("Failed to write config");
+    write_test_config(&repo_path);
 
     // Create a stack
     run_gg(&repo_path, &["co", "stdout-conflict-test"]);
@@ -218,13 +228,7 @@ fn test_gg_continue_provides_actionable_error_messages() {
     let (_temp_dir, repo_path) = create_test_repo();
 
     // Set up config
-    let gg_dir = repo_path.join(".git/gg");
-    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
-    fs::write(
-        gg_dir.join("config.json"),
-        r#"{"defaults":{"branch_username":"testuser"}}"#,
-    )
-    .expect("Failed to write config");
+    write_test_config(&repo_path);
 
     // Try gg continue when no rebase is in progress
     let (success, stdout, stderr) = run_gg(&repo_path, &["continue"]);
@@ -237,6 +241,92 @@ fn test_gg_continue_provides_actionable_error_messages() {
         "Should mention no rebase in progress: {}",
         combined
     );
+}
+
+#[test]
+fn test_continue_finalizes_interrupted_rebase_for_undo() {
+    let (_temp_dir, repo_path, _remote_path) = create_test_repo_with_remote();
+    write_test_config(&repo_path);
+
+    let (success, _, stderr) = run_gg(&repo_path, &["co", "continue-rebase-undo"]);
+    assert!(success, "co failed: {stderr}");
+
+    fs::write(repo_path.join("README.md"), "stack version\n").unwrap();
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "Stack update"]);
+    let head_before_rebase = head_sha(&repo_path);
+
+    run_git(&repo_path, &["checkout", "main"]);
+    fs::write(repo_path.join("README.md"), "main version\n").unwrap();
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "Main update"]);
+    run_git(&repo_path, &["push", "origin", "main"]);
+    run_git(&repo_path, &["checkout", "testuser/continue-rebase-undo"]);
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["rebase"]);
+    assert!(
+        !success,
+        "rebase should conflict: stdout={stdout} stderr={stderr}"
+    );
+
+    fs::write(repo_path.join("README.md"), "resolved version\n").unwrap();
+    run_git(&repo_path, &["add", "."]);
+    let (success, stdout, stderr) = run_gg(&repo_path, &["continue"]);
+    assert!(
+        success,
+        "continue should complete: stdout={stdout} stderr={stderr}"
+    );
+
+    assert_next_undo_targets(&repo_path, "rebase", &head_before_rebase);
+}
+
+#[test]
+fn test_continue_finalizes_interrupted_restack_for_undo() {
+    let (_temp_dir, repo_path) = create_test_repo();
+    write_test_config(&repo_path);
+
+    let (success, _, stderr) = run_gg(&repo_path, &["co", "continue-restack-undo"]);
+    assert!(success, "co failed: {stderr}");
+
+    fs::write(repo_path.join("README.md"), "stack version\n").unwrap();
+    run_git(&repo_path, &["add", "."]);
+    run_git(
+        &repo_path,
+        &["commit", "-m", "Commit 1\n\nGG-ID: c-0000001"],
+    );
+    fs::write(repo_path.join("second.txt"), "second\n").unwrap();
+    run_git(&repo_path, &["add", "."]);
+    run_git(
+        &repo_path,
+        &[
+            "commit",
+            "-m",
+            "Commit 2\n\nGG-ID: c-0000002\nGG-Parent: c-deadbee",
+        ],
+    );
+    let head_before_restack = head_sha(&repo_path);
+
+    run_git(&repo_path, &["checkout", "main"]);
+    fs::write(repo_path.join("README.md"), "main version\n").unwrap();
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "Main update"]);
+    run_git(&repo_path, &["checkout", "testuser/continue-restack-undo"]);
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["restack"]);
+    assert!(
+        !success,
+        "restack should conflict: stdout={stdout} stderr={stderr}"
+    );
+
+    fs::write(repo_path.join("README.md"), "resolved version\n").unwrap();
+    run_git(&repo_path, &["add", "."]);
+    let (success, stdout, stderr) = run_gg(&repo_path, &["continue"]);
+    assert!(
+        success,
+        "continue should complete: stdout={stdout} stderr={stderr}"
+    );
+
+    assert_next_undo_targets(&repo_path, "restack", &head_before_restack);
 }
 
 // ==================== gg reconcile tests ====================

--- a/crates/gg-cli/tests/integration_tests/restack.rs
+++ b/crates/gg-cli/tests/integration_tests/restack.rs
@@ -519,6 +519,8 @@ fn test_restack_integration_conflict_continue_finishes_integration() {
     fs::write(repo_path.join("conflict.txt"), "inserted\n").unwrap();
     run_git(&repo_path, &["add", "."]);
     run_git(&repo_path, &["commit", "-m", "inserted"]);
+    let (_ok, branch_before_restack) = run_git(&repo_path, &["rev-parse", "testuser/testing"]);
+    let branch_before_restack = branch_before_restack.trim().to_string();
 
     // Conflicts while replaying "two" onto "inserted".
     let (ok, _out, _err) = run_gg(&repo_path, &["restack"]);
@@ -549,6 +551,16 @@ fn test_restack_integration_conflict_continue_finishes_integration() {
         out.contains("consistent"),
         "follow-up restack should be a no-op: {out}"
     );
+
+    let (ok, out, err) = run_gg(&repo_path, &["undo", "--json"]);
+    assert!(ok, "undo failed: {out}{err}");
+    let v: Value = serde_json::from_str(&out).expect("valid json");
+    assert_eq!(
+        v["undone"]["kind"], "restack",
+        "continued restack should be finalized for undo: {out}"
+    );
+    let (_ok, branch_after_undo) = run_git(&repo_path, &["rev-parse", "testuser/testing"]);
+    assert_eq!(branch_after_undo.trim(), branch_before_restack);
 }
 
 #[test]

--- a/crates/gg-cli/tests/integration_tests/squash.rs
+++ b/crates/gg-cli/tests/integration_tests/squash.rs
@@ -2,6 +2,12 @@ use crate::helpers::{create_test_repo, run_gg, run_git};
 
 use std::fs;
 
+fn head_sha(repo_path: &std::path::Path) -> String {
+    let (success, stdout) = run_git(repo_path, &["rev-parse", "HEAD"]);
+    assert!(success, "git rev-parse HEAD failed");
+    stdout.trim().to_string()
+}
+
 #[test]
 fn test_gg_squash_with_staged_changes() {
     let (_temp_dir, repo_path) = create_test_repo();
@@ -225,6 +231,85 @@ fn test_gg_squash_rejects_unstaged_when_needs_rebase() {
         "gg sc should reject unstaged changes when rebase is needed. stdout={}, stderr={}",
         stdout,
         stderr
+    );
+}
+
+#[test]
+fn test_gg_squash_continue_restores_squashed_commit_navigation() {
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .expect("Failed to write config");
+
+    let branch_name = "testuser/squash-continue-nav";
+    run_gg(&repo_path, &["co", "squash-continue-nav"]);
+
+    fs::write(repo_path.join("README.md"), "one\n").expect("Failed to write file");
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "Commit 1"]);
+
+    fs::write(repo_path.join("README.md"), "two\n").expect("Failed to write file");
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "Commit 2"]);
+
+    let (success, _, _) = run_gg(&repo_path, &["mv", "1"]);
+    assert!(success, "Failed to navigate to first commit");
+    let head_before_squash = head_sha(&repo_path);
+
+    fs::write(repo_path.join("README.md"), "amended one\n").expect("Failed to write file");
+    run_git(&repo_path, &["add", "README.md"]);
+    let (success, stdout, stderr) = run_gg(&repo_path, &["sc"]);
+    assert!(
+        !success,
+        "squash should conflict while rebasing descendants: stdout={stdout} stderr={stderr}"
+    );
+
+    fs::write(repo_path.join("README.md"), "resolved two\n").expect("Failed to write file");
+    run_git(&repo_path, &["add", "README.md"]);
+    let (success, stdout, stderr) = run_gg(&repo_path, &["continue"]);
+    assert!(
+        success,
+        "continue should complete interrupted squash: stdout={stdout} stderr={stderr}"
+    );
+
+    let (success, stdout) = run_git(&repo_path, &["log", "-1", "--pretty=%s"]);
+    assert!(success, "git log failed");
+    assert_eq!(
+        stdout.trim(),
+        "Commit 1",
+        "continued squash should leave HEAD on the squashed commit"
+    );
+
+    let (success, stdout) = run_git(
+        &repo_path,
+        &[
+            "log",
+            "-1",
+            "--pretty=%s",
+            &format!("refs/heads/{branch_name}"),
+        ],
+    );
+    assert!(success, "git log branch tip failed");
+    assert_eq!(
+        stdout.trim(),
+        "Commit 2",
+        "stack branch tip should remain on the rebased descendant"
+    );
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["undo", "--json"]);
+    assert!(success, "undo failed: stdout={stdout} stderr={stderr}");
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("stdout must be JSON");
+    assert_eq!(parsed["status"], "succeeded");
+    assert_eq!(parsed["undone"]["kind"], "squash");
+    assert_eq!(
+        head_sha(&repo_path),
+        head_before_squash,
+        "undo should restore pre-squash HEAD"
     );
 }
 

--- a/crates/gg-core/src/commands/drop_cmd.rs
+++ b/crates/gg-core/src/commands/drop_cmd.rs
@@ -4,12 +4,13 @@ use std::io::Write;
 
 use console::style;
 use dialoguer::Confirm;
+use serde_json::json;
 
 use crate::config::Config;
 use crate::error::{GgError, Result};
 use crate::git;
 use crate::immutability::{self, ImmutabilityPolicy};
-use crate::operations::{OperationKind, SnapshotScope};
+use crate::operations::{self, OperationKind, SnapshotScope};
 use crate::output::{print_json, DropResponse, DropResultJson, DroppedEntryJson, OUTPUT_VERSION};
 use crate::stack::{self, Stack};
 
@@ -141,7 +142,7 @@ pub fn run(options: DropOptions) -> Result<()> {
     // is not required) — now write the Pending op-log record. Any later
     // failure leaves a Pending record that the sweep promotes to Interrupted,
     // which `gg undo` will refuse.
-    let guard = git::begin_recorded_op(
+    let mut guard = git::begin_recorded_op(
         &repo,
         &config,
         OperationKind::Drop,
@@ -149,6 +150,16 @@ pub fn run(options: DropOptions) -> Result<()> {
         None,
         SnapshotScope::AllUserBranches,
     )?;
+    let dropped_entry_branches: Vec<String> = dropped_entries
+        .iter()
+        .filter_map(|entry| stack_obj.get_entry_by_position(entry.position))
+        .filter_map(|entry| stack_obj.entry_branch_name(entry))
+        .collect();
+    guard.set_pending_plan(json!({
+        "drop": {
+            "entry_branches": dropped_entry_branches,
+        }
+    }));
 
     // Build the rebase todo list, omitting dropped commits
     let drop_indices: Vec<usize> = drop_positions.iter().map(|p| p - 1).collect();
@@ -200,6 +211,7 @@ pub fn run(options: DropOptions) -> Result<()> {
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         if stderr.contains("CONFLICT") || stderr.contains("conflict") {
+            let _ = operations::remember_interrupted_rebase_operation(&repo, guard.id());
             return Err(GgError::RebaseConflict);
         }
         return Err(GgError::Other(format!("Rebase failed: {}", stderr)));
@@ -210,16 +222,11 @@ pub fn run(options: DropOptions) -> Result<()> {
     git::normalize_stack_metadata(&repo, &rewritten_stack)?;
 
     // Clean up per-commit branches for dropped commits
-    for entry in &dropped_entries {
-        // Find the matching stack entry to get the GG-ID for branch name
-        if let Some(stack_entry) = stack_obj.get_entry_by_position(entry.position) {
-            if let Some(branch_name) = stack_obj.entry_branch_name(stack_entry) {
-                // Delete local branch (ignore errors if it doesn't exist)
-                let _ = repo
-                    .find_branch(&branch_name, git2::BranchType::Local)
-                    .and_then(|mut b| b.delete());
-            }
-        }
+    for branch_name in &dropped_entry_branches {
+        // Delete local branch (ignore errors if it doesn't exist)
+        let _ = repo
+            .find_branch(branch_name, git2::BranchType::Local)
+            .and_then(|mut b| b.delete());
     }
 
     let remaining = stack_obj.len() - dropped_entries.len();

--- a/crates/gg-core/src/commands/nav.rs
+++ b/crates/gg-core/src/commands/nav.rs
@@ -5,7 +5,7 @@ use console::style;
 use crate::config::Config;
 use crate::error::{GgError, Result};
 use crate::git;
-use crate::operations::{OperationKind, SnapshotScope};
+use crate::operations::{self, OperationKind, SnapshotScope};
 use crate::stack::{self, Stack, StackEntry};
 
 /// Acquire the operation lock, record a Pending Nav op, run the given
@@ -26,7 +26,12 @@ where
         None,
         SnapshotScope::AllUserBranches,
     )?;
-    f(&repo, &config)?;
+    if let Err(e) = f(&repo, &config) {
+        if matches!(e, GgError::RebaseConflict) {
+            let _ = operations::remember_interrupted_rebase_operation(&repo, guard.id());
+        }
+        return Err(e);
+    }
     guard.finalize_with_scope(
         &repo,
         &config,

--- a/crates/gg-core/src/commands/rebase.rs
+++ b/crates/gg-core/src/commands/rebase.rs
@@ -7,8 +7,8 @@ use crate::config::Config;
 use crate::error::{GgError, Result};
 use crate::git;
 use crate::immutability::{self, ImmutabilityPolicy};
-use crate::operations::{OperationKind, SnapshotScope};
-use crate::stack::Stack;
+use crate::operations::{self, OperationKind, SnapshotScope};
+use crate::stack::{self, Stack};
 
 /// Run the rebase command
 pub fn run(target: Option<String>, force: bool) -> Result<()> {
@@ -37,15 +37,20 @@ pub fn run(target: Option<String>, force: bool) -> Result<()> {
         SnapshotScope::AllUserBranches,
     )?;
 
-    execute_rebase(&repo, &target_branch, false)?;
-
-    guard.finalize_with_scope(
-        &repo,
-        &config,
-        SnapshotScope::AllUserBranches,
-        vec![],
-        false,
-    )
+    match execute_rebase(&repo, &target_branch, false) {
+        Ok(()) => guard.finalize_with_scope(
+            &repo,
+            &config,
+            SnapshotScope::AllUserBranches,
+            vec![],
+            false,
+        ),
+        Err(GgError::RebaseConflict) => {
+            let _ = operations::remember_interrupted_rebase_operation(&repo, guard.id());
+            Err(GgError::RebaseConflict)
+        }
+        Err(e) => Err(e),
+    }
 }
 
 /// Run rebase with an already-open repository (no lock acquisition)
@@ -301,10 +306,13 @@ fn update_local_branch(branch: &str) -> Result<()> {
 /// Continue a paused rebase
 pub fn continue_rebase() -> Result<()> {
     let repo = git::open_repo()?;
+    let config = Config::load_with_global(repo.commondir())?;
 
     if !git::is_rebase_in_progress(&repo) {
         return Err(GgError::NoRebaseInProgress);
     }
+
+    let _lock = git::acquire_operation_lock(&repo, "continue")?;
 
     // Check for unstaged changes before continuing
     let statuses = repo.statuses(None)?;
@@ -332,6 +340,8 @@ pub fn continue_rebase() -> Result<()> {
             "You have unresolved conflicts. Resolve them and stage with `git add` before running `gg continue`.".to_string()
         ));
     }
+
+    let continued_operation = operations::interrupted_rebase_operation(&repo)?;
 
     match git::rebase_continue() {
         Ok(_) => {
@@ -368,9 +378,11 @@ pub fn continue_rebase() -> Result<()> {
                     "  {}",
                     style("Run `gg sync` to push the updated stack.").dim()
                 );
+                finalize_continued_operation(&repo, &config, continued_operation)?;
                 return Ok(());
             }
 
+            finalize_continued_operation(&repo, &config, continued_operation)?;
             println!(
                 "{} Rebase continued successfully",
                 style("OK").green().bold()
@@ -411,6 +423,7 @@ pub fn abort_rebase() -> Result<()> {
     }
 
     git::rebase_abort()?;
+    operations::clear_interrupted_rebase_operation(&repo)?;
 
     // Discard any pending mid-stack integration: the fold-in is cancelled.
     crate::stack::clear_pending_integration(repo.path())?;
@@ -418,4 +431,348 @@ pub fn abort_rebase() -> Result<()> {
     println!("{} Rebase aborted", style("OK").green().bold());
 
     Ok(())
+}
+
+fn finalize_continued_operation(
+    repo: &Repository,
+    config: &Config,
+    operation: Option<operations::OperationRecord>,
+) -> Result<()> {
+    let Some(operation) = operation else {
+        return Ok(());
+    };
+
+    if operation_needs_metadata_normalization_after_continue(operation.kind) {
+        let rewritten_stack = Stack::load(repo, config)?;
+        git::normalize_stack_metadata(repo, &rewritten_stack)?;
+    }
+    if operation.kind == OperationKind::Drop {
+        cleanup_continued_drop_branches(repo, &operation);
+    }
+    if operation.kind == OperationKind::Split {
+        restore_continued_split_navigation(repo, config, &operation)?;
+    }
+    if operation.kind == OperationKind::Squash {
+        restore_continued_squash_navigation(repo, config, &operation)?;
+    }
+
+    operations::finalize_operation_by_id(
+        repo,
+        config,
+        &operation.id,
+        SnapshotScope::AllUserBranches,
+        vec![],
+        false,
+    )?;
+    operations::clear_interrupted_rebase_operation(repo)?;
+    Ok(())
+}
+
+fn operation_needs_metadata_normalization_after_continue(kind: OperationKind) -> bool {
+    matches!(
+        kind,
+        OperationKind::Drop
+            | OperationKind::Reorder
+            | OperationKind::Restack
+            | OperationKind::Split
+    )
+}
+
+fn restore_continued_split_navigation(
+    repo: &Repository,
+    config: &Config,
+    operation: &operations::OperationRecord,
+) -> Result<()> {
+    let Some(split_plan) = operation
+        .pending_plan
+        .as_ref()
+        .and_then(|plan| plan.get("split"))
+    else {
+        return Ok(());
+    };
+
+    let branch_name = split_plan
+        .get("branch_name")
+        .and_then(|branch| branch.as_str())
+        .map(ToString::to_string);
+
+    if let Some(branch_name) = &branch_name {
+        git::ensure_branch_attached(repo, branch_name)?;
+        git::checkout_branch(repo, branch_name)?;
+    }
+
+    let stack = Stack::load(repo, config)?;
+    let Some(entry) = continued_split_target_entry(&stack, split_plan) else {
+        return Ok(());
+    };
+
+    let branch_name = branch_name.unwrap_or_else(|| stack.branch_name());
+    let entry_position = entry.position;
+    let entry_oid = entry.oid;
+    stack::save_nav_context(repo.path(), &branch_name, entry_position - 1, entry_oid)?;
+    let commit = repo.find_commit(entry_oid)?;
+    git::checkout_commit(repo, &commit)?;
+    Ok(())
+}
+
+fn restore_continued_squash_navigation(
+    repo: &Repository,
+    config: &Config,
+    operation: &operations::OperationRecord,
+) -> Result<()> {
+    let Some(squash_plan) = operation
+        .pending_plan
+        .as_ref()
+        .and_then(|plan| plan.get("squash"))
+    else {
+        return Ok(());
+    };
+
+    let branch_name = squash_plan
+        .get("branch_name")
+        .and_then(|branch| branch.as_str())
+        .map(ToString::to_string);
+
+    if let Some(branch_name) = &branch_name {
+        git::ensure_branch_attached(repo, branch_name)?;
+        git::checkout_branch(repo, branch_name)?;
+    }
+
+    let stack = Stack::load(repo, config)?;
+    let Some(entry) = continued_squash_target_entry(&stack, squash_plan) else {
+        return Ok(());
+    };
+
+    let branch_name = branch_name.unwrap_or_else(|| stack.branch_name());
+    let entry_position = entry.position;
+    let entry_oid = entry.oid;
+    stack::save_nav_context(repo.path(), &branch_name, entry_position - 1, entry_oid)?;
+    let commit = repo.find_commit(entry_oid)?;
+    git::checkout_commit(repo, &commit)?;
+    Ok(())
+}
+
+fn continued_split_target_entry<'a>(
+    stack: &'a Stack,
+    split_plan: &serde_json::Value,
+) -> Option<&'a stack::StackEntry> {
+    continued_plan_target_entry(stack, split_plan, "remainder_gg_id", "remainder_position")
+}
+
+fn continued_squash_target_entry<'a>(
+    stack: &'a Stack,
+    squash_plan: &serde_json::Value,
+) -> Option<&'a stack::StackEntry> {
+    continued_plan_target_entry(stack, squash_plan, "target_gg_id", "target_position")
+}
+
+fn continued_plan_target_entry<'a>(
+    stack: &'a Stack,
+    plan: &serde_json::Value,
+    gg_id_key: &str,
+    position_key: &str,
+) -> Option<&'a stack::StackEntry> {
+    plan.get(gg_id_key)
+        .and_then(|gg_id| gg_id.as_str())
+        .and_then(|gg_id| stack.get_entry_by_gg_id(gg_id))
+        .or_else(|| {
+            plan.get(position_key)
+                .and_then(|position| position.as_u64())
+                .and_then(|position| usize::try_from(position).ok())
+                .and_then(|position| stack.get_entry_by_position(position))
+        })
+}
+
+fn cleanup_continued_drop_branches(repo: &Repository, operation: &operations::OperationRecord) {
+    let Some(branches) = operation
+        .pending_plan
+        .as_ref()
+        .and_then(|plan| plan.get("drop"))
+        .and_then(|drop| drop.get("entry_branches"))
+        .and_then(|branches| branches.as_array())
+    else {
+        return;
+    };
+
+    for branch_name in branches.iter().filter_map(|branch| branch.as_str()) {
+        let _ = repo
+            .find_branch(branch_name, git2::BranchType::Local)
+            .and_then(|mut branch| branch.delete());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+    use std::fs;
+    use std::process::Command;
+
+    use super::*;
+
+    fn run_git_command(repo_path: &std::path::Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(repo_path)
+            .output()
+            .expect("git command should run");
+        assert!(
+            output.status.success(),
+            "git {:?} failed\nstdout={}\nstderr={}",
+            args,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn fake_entry(position: usize, gg_id: Option<&str>) -> stack::StackEntry {
+        stack::StackEntry {
+            oid: git2::Oid::from_str(&format!("{position:040x}")).unwrap(),
+            short_sha: format!("{position:07x}"),
+            title: format!("Commit {position}"),
+            gg_id: gg_id.map(ToString::to_string),
+            gg_parent: None,
+            mr_number: None,
+            mr_state: None,
+            approved: false,
+            changes_requested: false,
+            mergeable: false,
+            ci_status: None,
+            position,
+            in_merge_train: false,
+            merge_train_position: None,
+        }
+    }
+
+    fn fake_stack() -> Stack {
+        Stack {
+            name: "test".to_string(),
+            username: "user".to_string(),
+            base: "main".to_string(),
+            entries: vec![
+                fake_entry(1, Some("c-one111")),
+                fake_entry(2, Some("c-two222")),
+                fake_entry(3, Some("c-three3")),
+            ],
+            current_position: Some(2),
+        }
+    }
+
+    #[test]
+    fn continued_split_navigation_reattaches_branch_before_loading_stack() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let repo_path = temp_dir.path().join("repo");
+        fs::create_dir(&repo_path).unwrap();
+
+        run_git_command(&repo_path, &["init", "--initial-branch=main"]);
+        run_git_command(&repo_path, &["config", "user.email", "test@test.com"]);
+        run_git_command(&repo_path, &["config", "user.name", "Test User"]);
+        fs::write(repo_path.join("README.md"), "base\n").unwrap();
+        run_git_command(&repo_path, &["add", "."]);
+        run_git_command(&repo_path, &["commit", "-m", "Initial"]);
+        run_git_command(&repo_path, &["checkout", "-b", "testuser/split-wt"]);
+
+        fs::write(repo_path.join("one.txt"), "one\n").unwrap();
+        run_git_command(&repo_path, &["add", "."]);
+        run_git_command(&repo_path, &["commit", "-m", "Commit 1\n\nGG-ID: c-one111"]);
+        fs::write(repo_path.join("two.txt"), "two\n").unwrap();
+        run_git_command(&repo_path, &["add", "."]);
+        run_git_command(&repo_path, &["commit", "-m", "Commit 2\n\nGG-ID: c-two222"]);
+
+        let repo = Repository::open(&repo_path).unwrap();
+        let branch_tip = repo
+            .revparse_single("refs/heads/testuser/split-wt")
+            .unwrap()
+            .peel_to_commit()
+            .unwrap();
+        repo.set_head_detached(branch_tip.id()).unwrap();
+        assert!(repo.head_detached().unwrap());
+
+        let mut config = Config::default();
+        config.defaults.base = Some("main".to_string());
+        config.defaults.branch_username = Some("testuser".to_string());
+        let operation = operations::OperationRecord {
+            id: operations::new_id(),
+            schema_version: operations::SCHEMA_VERSION,
+            kind: OperationKind::Split,
+            status: operations::OperationStatus::Pending,
+            created_at_ms: operations::now_ms(),
+            args: vec!["split".to_string()],
+            stack_name: Some("split-wt".to_string()),
+            refs_before: vec![],
+            refs_after: vec![],
+            remote_effects: vec![],
+            touched_remote: false,
+            undoes: None,
+            pending_plan: Some(json!({
+                "split": {
+                    "branch_name": "testuser/split-wt",
+                    "remainder_position": 2,
+                    "remainder_gg_id": "c-two222",
+                }
+            })),
+        };
+
+        let previous_dir = std::env::current_dir().unwrap();
+        std::env::set_current_dir(&repo_path).unwrap();
+        let result = restore_continued_split_navigation(&repo, &config, &operation);
+        std::env::set_current_dir(previous_dir).unwrap();
+
+        result.unwrap();
+        let (branch_name, position, oid) = stack::read_nav_context(repo.path()).unwrap();
+        assert_eq!(branch_name, "testuser/split-wt");
+        assert_eq!(position, 1);
+        assert_eq!(oid, branch_tip.id());
+    }
+
+    #[test]
+    fn continued_split_target_prefers_remainder_gg_id() {
+        let stack = fake_stack();
+        let split_plan = json!({
+            "remainder_position": 2,
+            "remainder_gg_id": "c-three3",
+        });
+
+        let entry = continued_split_target_entry(&stack, &split_plan).unwrap();
+
+        assert_eq!(entry.position, 3);
+    }
+
+    #[test]
+    fn continued_split_target_falls_back_to_remainder_position() {
+        let stack = fake_stack();
+        let split_plan = json!({
+            "remainder_position": 2,
+            "remainder_gg_id": null,
+        });
+
+        let entry = continued_split_target_entry(&stack, &split_plan).unwrap();
+
+        assert_eq!(entry.gg_id.as_deref(), Some("c-two222"));
+    }
+
+    #[test]
+    fn continued_squash_target_prefers_target_gg_id() {
+        let stack = fake_stack();
+        let squash_plan = json!({
+            "target_position": 2,
+            "target_gg_id": "c-three3",
+        });
+
+        let entry = continued_squash_target_entry(&stack, &squash_plan).unwrap();
+
+        assert_eq!(entry.position, 3);
+    }
+
+    #[test]
+    fn continued_squash_target_falls_back_to_target_position() {
+        let stack = fake_stack();
+        let squash_plan = json!({
+            "target_position": 2,
+            "target_gg_id": null,
+        });
+
+        let entry = continued_squash_target_entry(&stack, &squash_plan).unwrap();
+
+        assert_eq!(entry.gg_id.as_deref(), Some("c-two222"));
+    }
 }

--- a/crates/gg-core/src/commands/reorder.rs
+++ b/crates/gg-core/src/commands/reorder.rs
@@ -10,7 +10,7 @@ use crate::config::Config;
 use crate::error::{GgError, Result};
 use crate::git;
 use crate::immutability::{self, ImmutabilityPolicy};
-use crate::operations::{OperationKind, SnapshotScope};
+use crate::operations::{self, OperationKind, SnapshotScope};
 use crate::stack::Stack;
 
 /// Options for the reorder command
@@ -123,7 +123,12 @@ pub fn run(options: ReorderOptions) -> Result<()> {
     }
 
     // Perform the rebase with the new order
-    perform_reorder(&repo, &stack, &new_order)?;
+    if let Err(e) = perform_reorder(&repo, &stack, &new_order) {
+        if matches!(e, GgError::RebaseConflict) {
+            let _ = operations::remember_interrupted_rebase_operation(&repo, guard.id());
+        }
+        return Err(e);
+    }
 
     // Ensure GG metadata reflects the new stack order
     let rewritten_stack = Stack::load(&repo, &config)?;

--- a/crates/gg-core/src/commands/restack.rs
+++ b/crates/gg-core/src/commands/restack.rs
@@ -7,7 +7,7 @@ use console::style;
 use crate::config::Config;
 use crate::error::{GgError, Result};
 use crate::git;
-use crate::operations::{OperationKind, SnapshotScope};
+use crate::operations::{self, OperationKind, SnapshotScope};
 use crate::output::{
     print_json, RestackResponse, RestackResultJson, RestackStepJson, OUTPUT_VERSION,
 };
@@ -256,6 +256,7 @@ fn integrate_unintegrated(
                 &unintegrated.branch_name,
                 unintegrated.head_oid,
             )?;
+            let _ = operations::remember_interrupted_rebase_operation(repo, guard.id());
             return Err(GgError::RebaseConflict);
         }
         return Err(GgError::Other(format!(
@@ -524,6 +525,7 @@ pub fn run(options: RestackOptions) -> Result<()> {
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         if stderr.contains("CONFLICT") || stderr.contains("conflict") {
+            let _ = operations::remember_interrupted_rebase_operation(&repo, guard.id());
             return Err(GgError::RebaseConflict);
         }
         return Err(GgError::Other(format!("Rebase failed: {}", stderr)));

--- a/crates/gg-core/src/commands/run.rs
+++ b/crates/gg-core/src/commands/run.rs
@@ -8,7 +8,7 @@ use git2::Oid;
 
 use crate::error::{GgError, Result};
 use crate::git;
-use crate::operations::{OperationKind, SnapshotScope};
+use crate::operations::{self, OperationKind, SnapshotScope};
 use crate::output::{
     self, RunCommandResult, RunCommitResult, RunResponse, RunResultJson, OUTPUT_VERSION,
 };
@@ -147,14 +147,22 @@ pub fn execute(options: RunOptions) -> Result<bool> {
     // Finalize only on success. On error the guard is dropped without
     // finalize; the sweep promotes the Pending record to Interrupted on the
     // next lock acquisition.
-    if let (Ok(_), Some((_lock, guard))) = (&result, recorded) {
-        guard.finalize_with_scope(
-            &repo,
-            &config,
-            SnapshotScope::AllUserBranches,
-            vec![],
-            false,
-        )?;
+    if let Some((_lock, guard)) = recorded {
+        match &result {
+            Ok(_) => {
+                guard.finalize_with_scope(
+                    &repo,
+                    &config,
+                    SnapshotScope::AllUserBranches,
+                    vec![],
+                    false,
+                )?;
+            }
+            Err(_) if git::is_rebase_in_progress(&repo) => {
+                let _ = operations::remember_interrupted_rebase_operation(&repo, guard.id());
+            }
+            Err(_) => {}
+        }
     }
 
     let result = result?;

--- a/crates/gg-core/src/commands/split.rs
+++ b/crates/gg-core/src/commands/split.rs
@@ -6,12 +6,13 @@ use std::process::Command;
 
 use console::{style, Term};
 use dialoguer::Editor;
+use serde_json::json;
 
 use crate::config::Config;
 use crate::error::{GgError, Result};
 use crate::git;
 use crate::immutability::{self, ImmutabilityPolicy};
-use crate::operations::{OperationKind, SnapshotScope};
+use crate::operations::{self, OperationKind, SnapshotScope};
 use crate::stack::{self, Stack};
 
 /// Options for the split command
@@ -268,7 +269,7 @@ pub fn run(options: SplitOptions) -> Result<()> {
     // before the first actual repo mutation. A failure beyond this point
     // leaves a Pending record the sweep promotes to Interrupted, which
     // `gg undo` refuses (avoiding an unsafe partial-state rewind).
-    let guard = git::begin_recorded_op(
+    let mut guard = git::begin_recorded_op(
         &repo,
         &config,
         OperationKind::Split,
@@ -276,6 +277,13 @@ pub fn run(options: SplitOptions) -> Result<()> {
         None,
         SnapshotScope::AllUserBranches,
     )?;
+    guard.set_pending_plan(json!({
+        "split": {
+            "branch_name": stack.branch_name(),
+            "remainder_position": target_pos + 1,
+            "remainder_gg_id": original_gg_id.clone(),
+        }
+    }));
 
     // 2. Create the first (new, lower) commit
     let sig = git::get_signature(&repo)?;
@@ -310,14 +318,21 @@ pub fn run(options: SplitOptions) -> Result<()> {
     let second_commit = repo.find_commit(second_oid)?;
 
     // 4. Rebase descendants onto second commit
-    let num_rebased = rebase_descendants(
+    let num_rebased = match rebase_descendants(
         &repo,
         &stack,
         &config,
         target_pos,
         &target_commit,
         &second_commit,
-    )?;
+    ) {
+        Ok(num_rebased) => num_rebased,
+        Err(GgError::RebaseConflict) => {
+            let _ = operations::remember_interrupted_rebase_operation(&repo, guard.id());
+            return Err(GgError::RebaseConflict);
+        }
+        Err(e) => return Err(e),
+    };
 
     // Print results
     println!("{} Split complete!", style("✔").green().bold());
@@ -574,16 +589,8 @@ fn rebase_descendants(
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        if stderr.contains("CONFLICT") || stderr.contains("conflict") {
-            // Abort the rebase to leave repo in clean state
-            let _ = Command::new("git").args(["rebase", "--abort"]).output();
-            return Err(GgError::Other(
-                "Split aborted: merge conflict during descendant rebase. \
-                 The original commit has been left unchanged."
-                    .to_string(),
-            ));
-        }
-        return Err(GgError::Other(format!("Rebase failed: {}", stderr)));
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        return Err(rebase_descendants_error(&stdout, &stderr));
     }
 
     // Re-attach HEAD if needed
@@ -604,6 +611,18 @@ fn rebase_descendants(
     }
 
     Ok(remaining)
+}
+
+fn rebase_descendants_error(stdout: &str, stderr: &str) -> GgError {
+    if stderr.contains("CONFLICT")
+        || stderr.contains("conflict")
+        || stdout.contains("CONFLICT")
+        || stdout.contains("conflict")
+    {
+        GgError::RebaseConflict
+    } else {
+        GgError::Other(format!("Rebase failed: {}", stderr))
+    }
 }
 
 /// Update branch pointer when splitting the stack head
@@ -1328,6 +1347,20 @@ mod tests {
         assert!(opts.files.is_empty());
         assert!(opts.message.is_none());
         assert!(!opts.no_edit);
+    }
+
+    #[test]
+    fn test_rebase_descendants_conflict_stays_continuable() {
+        let err = rebase_descendants_error("", "CONFLICT (content): Merge conflict");
+
+        assert!(matches!(err, GgError::RebaseConflict));
+    }
+
+    #[test]
+    fn test_rebase_descendants_non_conflict_preserves_git_error() {
+        let err = rebase_descendants_error("", "fatal: bad revision");
+
+        assert!(matches!(err, GgError::Other(message) if message.contains("bad revision")));
     }
 
     #[test]

--- a/crates/gg-core/src/commands/squash.rs
+++ b/crates/gg-core/src/commands/squash.rs
@@ -4,12 +4,13 @@ use std::process::Command;
 
 use console::{style, Term};
 use dialoguer::Select;
+use serde_json::json;
 
 use crate::config::{Config, UnstagedAction};
 use crate::error::{GgError, Result};
 use crate::git;
 use crate::immutability::{self, ImmutabilityPolicy};
-use crate::operations::{OperationKind, SnapshotScope};
+use crate::operations::{self, OperationKind, SnapshotScope};
 use crate::stack;
 use crate::stack::Stack;
 
@@ -229,7 +230,7 @@ pub fn run(all: bool, force: bool) -> Result<()> {
     // All validation passed and we are about to mutate: write the Pending
     // op-log record now so a failure beyond this point leaves a record the
     // sweep can promote to Interrupted.
-    let guard = git::begin_recorded_op(
+    let mut guard = git::begin_recorded_op(
         &repo,
         &config,
         OperationKind::Squash,
@@ -285,6 +286,17 @@ pub fn run(all: bool, force: bool) -> Result<()> {
 
         // Get the stack branch name
         let branch_name = stack.branch_name();
+        let target_position = stack.current_position.unwrap() + 1;
+        let target_gg_id = stack
+            .get_entry_by_position(target_position)
+            .and_then(|entry| entry.gg_id.clone());
+        guard.set_pending_plan(json!({
+            "squash": {
+                "branch_name": branch_name,
+                "target_position": target_position,
+                "target_gg_id": target_gg_id,
+            }
+        }));
 
         // Use git rebase to rebase remaining commits
         // git rebase --onto <new_head> <old_head> <branch>
@@ -315,6 +327,7 @@ pub fn run(all: bool, force: bool) -> Result<()> {
                 if auto_stashed {
                     restore_auto_stash();
                 }
+                let _ = operations::remember_interrupted_rebase_operation(&repo, guard.id());
                 return Err(GgError::RebaseConflict);
             }
 

--- a/crates/gg-core/src/operations.rs
+++ b/crates/gg-core/src/operations.rs
@@ -44,6 +44,7 @@ pub(crate) const PENDING_STALENESS_MS: u64 = 30_000;
 /// Reserved top-level branch names that never belong to a user namespace,
 /// excluded from `SnapshotScope::AllUserBranches`.
 const TRUNK_EXCLUSIONS: &[&str] = &["main", "master", "trunk"];
+const INTERRUPTED_REBASE_MARKER: &str = "interrupted-rebase-operation.json";
 
 // ---------------------------------------------------------------------------
 // Record schema
@@ -155,6 +156,23 @@ pub struct OperationRecord {
     /// use (e.g. partial-rebase state).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pending_plan: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct InterruptedRebaseMarker {
+    operation_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    rebase_state: Option<RebaseStateMarker>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct RebaseStateMarker {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    head_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    orig_head: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    onto: Option<String>,
 }
 
 impl OperationRecord {
@@ -357,6 +375,127 @@ impl OperationStore {
 }
 
 // ---------------------------------------------------------------------------
+// Cross-invocation finalization for interrupted rebases
+// ---------------------------------------------------------------------------
+
+fn interrupted_rebase_marker_path(repo: &Repository) -> PathBuf {
+    repo.path().join("gg").join(INTERRUPTED_REBASE_MARKER)
+}
+
+fn current_rebase_state(repo: &Repository) -> Option<RebaseStateMarker> {
+    let git_dir = repo.path();
+    let rebase_dir = if git_dir.join("rebase-merge").exists() {
+        git_dir.join("rebase-merge")
+    } else if git_dir.join("rebase-apply").exists() {
+        git_dir.join("rebase-apply")
+    } else {
+        return None;
+    };
+
+    Some(RebaseStateMarker {
+        head_name: read_trimmed_file(&rebase_dir.join("head-name")),
+        orig_head: read_trimmed_file(&rebase_dir.join("orig-head")),
+        onto: read_trimmed_file(&rebase_dir.join("onto")),
+    })
+}
+
+fn read_trimmed_file(path: &Path) -> Option<String> {
+    let value = fs::read_to_string(path).ok()?;
+    let value = value.trim();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.to_string())
+    }
+}
+
+/// Remember which operation owns the current Git rebase state.
+///
+/// Commands call this when a recorded operation stops on a rebase conflict.
+/// A later `gg continue` invocation uses the marker to finalize the original
+/// operation record after `git rebase --continue` completes.
+pub fn remember_interrupted_rebase_operation(repo: &Repository, operation_id: &str) -> Result<()> {
+    if !is_valid_operation_id(operation_id) {
+        return Err(GgError::OperationRecordNotFound(operation_id.to_string()));
+    }
+
+    let path = interrupted_rebase_marker_path(repo);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let tmp = path.with_extension("json.tmp");
+    let marker = InterruptedRebaseMarker {
+        operation_id: operation_id.to_string(),
+        rebase_state: current_rebase_state(repo),
+    };
+    let json = serde_json::to_vec_pretty(&marker)?;
+    {
+        let mut f = fs::File::create(&tmp)?;
+        f.write_all(&json)?;
+        f.sync_all()?;
+    }
+    fs::rename(&tmp, &path)?;
+    Ok(())
+}
+
+/// Load the operation record associated with the current interrupted rebase.
+pub fn interrupted_rebase_operation(repo: &Repository) -> Result<Option<OperationRecord>> {
+    let path = interrupted_rebase_marker_path(repo);
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let bytes = fs::read(&path)?;
+    let marker: InterruptedRebaseMarker = serde_json::from_slice(&bytes)?;
+    if let Some(expected) = &marker.rebase_state {
+        if current_rebase_state(repo).as_ref() != Some(expected) {
+            clear_interrupted_rebase_operation(repo)?;
+            return Ok(None);
+        }
+    }
+    let store = OperationStore::new(&crate::git::gg_dir(repo));
+    Ok(Some(store.load(&marker.operation_id)?))
+}
+
+/// Remove the interrupted-rebase marker.
+pub fn clear_interrupted_rebase_operation(repo: &Repository) -> Result<()> {
+    match fs::remove_file(interrupted_rebase_marker_path(repo)) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(GgError::Io(e)),
+    }
+}
+
+/// Finalize an existing Pending/Interrupted operation record by id.
+///
+/// This is used by `gg continue`: the operation guard that wrote the record
+/// belonged to the earlier invocation that hit the conflict, so the success
+/// path must reopen and commit that record directly.
+pub fn finalize_operation_by_id(
+    repo: &Repository,
+    config: &Config,
+    operation_id: &str,
+    scope: SnapshotScope<'_>,
+    remote_effects: Vec<RemoteEffect>,
+    touched_remote: bool,
+) -> Result<OperationRecord> {
+    let store = OperationStore::new(&crate::git::gg_dir(repo));
+    let mut record = store.load(operation_id)?;
+
+    match record.status {
+        OperationStatus::Pending | OperationStatus::Interrupted => {}
+        OperationStatus::Committed => return Ok(record),
+    }
+
+    record.status = OperationStatus::Committed;
+    record.refs_after = snapshot_refs(repo, config, scope)?;
+    record.remote_effects = remote_effects;
+    record.touched_remote = touched_remote;
+    store.save(&record)?;
+    Ok(record)
+}
+
+// ---------------------------------------------------------------------------
 // snapshot_refs + SnapshotScope
 // ---------------------------------------------------------------------------
 
@@ -532,6 +671,13 @@ impl OperationGuard {
             return;
         }
         self.record.touched_remote = true;
+        let _ = self.store.save(&self.record);
+    }
+
+    /// Persist command-specific state needed to finish a conflict-resumed
+    /// operation from a later `gg continue` invocation.
+    pub fn set_pending_plan(&mut self, pending_plan: serde_json::Value) {
+        self.record.pending_plan = Some(pending_plan);
         let _ = self.store.save(&self.record);
     }
 
@@ -1029,6 +1175,77 @@ pub(crate) mod tests {
         let fresh_loaded = store.load(&fresh.id).unwrap();
         assert_eq!(stale_loaded.status, OperationStatus::Interrupted);
         assert_eq!(fresh_loaded.status, OperationStatus::Pending);
+    }
+
+    #[test]
+    fn interrupted_rebase_marker_is_scoped_to_worktree_git_dir() {
+        let parent = tempfile::tempdir().unwrap();
+        let repo_path = parent.path().join("repo");
+        let worktree_path = parent.path().join("linked");
+        let repo = Repository::init(&repo_path).unwrap();
+        let sig = git2::Signature::now("gg-test", "gg@test").unwrap();
+        let tree_oid = repo.index().unwrap().write_tree().unwrap();
+        let tree = repo.find_tree(tree_oid).unwrap();
+        let commit_oid = repo
+            .commit(Some("HEAD"), &sig, &sig, "init", &tree, &[])
+            .unwrap();
+        let commit = repo.find_commit(commit_oid).unwrap();
+        repo.branch("linked-branch", &commit, true).unwrap();
+
+        let status = std::process::Command::new("git")
+            .args([
+                "-C",
+                repo_path.to_str().unwrap(),
+                "worktree",
+                "add",
+                worktree_path.to_str().unwrap(),
+                "linked-branch",
+            ])
+            .status()
+            .unwrap();
+        assert!(status.success());
+        let worktree_repo = Repository::open(&worktree_path).unwrap();
+
+        let gg_dir = crate::git::gg_dir(&repo);
+        let store = OperationStore::new(&gg_dir);
+        let mut main_record = make_record(OperationKind::Rebase, 11);
+        let mut worktree_record = make_record(OperationKind::Restack, 12);
+        main_record.status = OperationStatus::Pending;
+        worktree_record.status = OperationStatus::Pending;
+        store.save(&main_record).unwrap();
+        store.save(&worktree_record).unwrap();
+
+        write_rebase_state(&repo, "refs/heads/main", "aaaaaaaa", "bbbbbbbb");
+        write_rebase_state(
+            &worktree_repo,
+            "refs/heads/linked-branch",
+            "cccccccc",
+            "dddddddd",
+        );
+
+        remember_interrupted_rebase_operation(&repo, &main_record.id).unwrap();
+        remember_interrupted_rebase_operation(&worktree_repo, &worktree_record.id).unwrap();
+
+        let main_marker = interrupted_rebase_marker_path(&repo);
+        let worktree_marker = interrupted_rebase_marker_path(&worktree_repo);
+        assert_ne!(main_marker, worktree_marker);
+        assert!(main_marker.exists());
+        assert!(worktree_marker.exists());
+
+        let loaded_main = interrupted_rebase_operation(&repo).unwrap().unwrap();
+        let loaded_worktree = interrupted_rebase_operation(&worktree_repo)
+            .unwrap()
+            .unwrap();
+        assert_eq!(loaded_main.id, main_record.id);
+        assert_eq!(loaded_worktree.id, worktree_record.id);
+    }
+
+    fn write_rebase_state(repo: &Repository, head_name: &str, orig_head: &str, onto: &str) {
+        let rebase_dir = repo.path().join("rebase-merge");
+        fs::create_dir_all(&rebase_dir).unwrap();
+        fs::write(rebase_dir.join("head-name"), head_name).unwrap();
+        fs::write(rebase_dir.join("orig-head"), orig_head).unwrap();
+        fs::write(rebase_dir.join("onto"), onto).unwrap();
     }
 
     #[test]

--- a/docs/src/commands/continue-abort.md
+++ b/docs/src/commands/continue-abort.md
@@ -9,3 +9,7 @@ gg abort
 
 Use `gg continue` after resolving conflicts and staging files.
 Use `gg abort` when you want to stop and roll back the in-progress operation.
+
+When a recorded `gg` operation stops on a rebase conflict, `gg continue`
+finalizes that original operation in the undo log after the rebase completes.
+That means the completed operation can still be reversed with `gg undo`.

--- a/docs/src/commands/undo.md
+++ b/docs/src/commands/undo.md
@@ -32,6 +32,11 @@ will touch before mutating and finalises the record on success. `gg
 undo` replays the `refs_before` snapshot of the target record, moving
 refs back to where they were.
 
+If one of those operations pauses on a rebase conflict, resolving the
+conflict and running `gg continue` finalises the original operation
+record. The completed operation then appears as undoable in `gg undo
+--list`.
+
 A second `gg undo` redoes the first — because `undo` is itself
 recorded as an operation, running it twice reverses the reversal.
 Entries created by `gg undo` appear in `--list` with a `↶` marker and
@@ -44,7 +49,7 @@ an `undoes` field pointing at the original operation id.
 | Reason | Condition | What to do |
 |---|---|---|
 | `remote` | The target op pushed/merged/closed/created a PR or MR. | Use the printed provider hint (`gh pr close <n>`, `glab mr close <n>`, `git push --delete …`). Local state is unchanged. |
-| `interrupted` | The op crashed or was Ctrl-C'd mid-flight and has `status: Interrupted`. | Fix the underlying state manually; the stale Pending record is swept into Interrupted on the next lock-acquiring op. |
+| `interrupted` | The op crashed, was Ctrl-C'd, or was aborted before completion and has `status: Interrupted`. | Fix the underlying state manually; the stale Pending record is swept into Interrupted on the next lock-acquiring op. |
 | `stale` | Refs have moved since the target op finalised. | Run `gg undo --list` and target a more recent record instead. The error names the ref, the expected OID, and the actual OID. |
 | `unsupported_schema` | The record was written by a newer `gg` with a schema version this binary does not understand. | Upgrade `gg` or delete the offending record. |
 

--- a/skills/gg/SKILL.md
+++ b/skills/gg/SKILL.md
@@ -183,13 +183,18 @@ and `run --amend`) snapshots the refs it will touch before mutating and
 records the operation on success. The log keeps the last 100 records;
 interrupted/pending records are never pruned.
 
+If a recorded operation pauses on a rebase conflict, resolve the conflict,
+stage the files, and run `gg continue`; completion finalizes the original
+operation record so it remains available to `gg undo`.
+
 **Refusal modes** (exit 1, no refs touched, JSON includes `refusal.reason`):
 
 - `remote` — target operation pushed/merged/closed/created a PR/MR.
   gg prints a provider-specific revert hint (`gh pr close <n>`,
   `glab mr close <n>`, `git push --delete …`). Agents must surface the
   hint to the user rather than attempt silent remote rollback.
-- `interrupted` — operation crashed or was Ctrl-C'd mid-flight.
+- `interrupted` — operation crashed, was Ctrl-C'd, or was aborted before
+  completion.
 - `stale` — refs moved since the target operation finalised. The error
   names the ref, expected OID, and actual OID.
 - `unsupported_schema` — record was written by a newer `gg` binary.

--- a/skills/gg/reference.md
+++ b/skills/gg/reference.md
@@ -256,12 +256,16 @@ Every mutating command (`sc`, `drop`, `split`, `unstack`, `rebase`, `reorder`,
 and records the operation on success. A second `gg undo` redoes the
 first — `undo` itself is recorded.
 
+When a recorded operation pauses on a rebase conflict, `gg continue`
+finalizes that same operation record after the rebase completes, so the
+completed operation is still undoable.
+
 **Refusals** (exit 1, no refs touched):
 
 | `refusal.reason` | Condition | Handling |
 |---|---|---|
 | `remote` | Op pushed/merged/closed/created a PR or MR | Use the printed provider hint (`gh pr close <n>`, `glab mr close <n>`, `git push --delete …`). |
-| `interrupted` | Op was Ctrl-C'd or crashed mid-flight | Fix state manually; stale Pending records are swept on the next lock-acquiring op. |
+| `interrupted` | Op was Ctrl-C'd, crashed, or aborted before completion | Fix state manually; stale Pending records are swept on the next lock-acquiring op. |
 | `stale` | Refs moved since the target op finalised | Run `gg undo --list` and pick a more recent record. Error names the ref, expected OID, actual OID. |
 | `unsupported_schema` | Record was written by a newer `gg` binary | Upgrade `gg` or delete the record. |
 


### PR DESCRIPTION
## Summary

Fixes #352.

- Persist the operation id for recorded commands that stop on a rebase conflict.
- Finalize that original operation record when `gg continue` successfully completes the rebase, so the completed operation appears in `gg undo --list` and can be undone.
- Clear the interrupted marker on `gg abort`.
- Cover conflict-resumable recorded paths including `rebase`, `restack`, `drop`, `squash`, `split`, `reorder`, `nav`, `run --amend`, and `unstack`.
- Update docs and the packaged gg skill reference.

## Validation

Passed:

- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p gg-core --all-features`
- `cargo test -p gg-core interrupted_rebase_marker_is_scoped_to_worktree_git_dir --all-features`
- `cargo test -p gg-core continued_split_navigation_reattaches_branch_before_loading_stack --all-features`
- `cargo test -p gg-cli --test integration_tests continue_flow --all-features`
- `cargo test -p gg-cli --test integration_tests test_gg_squash_continue_restores_squashed_commit_navigation --all-features`
- `cargo test -p gg-cli --test integration_tests split --all-features`
- `cargo test -p gg-cli --test integration_tests restack --all-features`
- `cargo test -p gg-cli --test integration_tests undo --all-features`

Caveats:

- `cargo test --all-features`, `cargo test -p gg-cli --test integration_tests rebase --all-features`, `cargo test -p gg-cli --test integration_tests worktree --all-features`, and `cargo test -p gg-cli --test integration_tests squash --all-features` hung with no output after several minutes in this environment and were stopped or left inconclusive.
- `mdbook build docs` could not run because `mdbook` is not installed in this environment.