### PR TITLE
feat(sync): add streaming jsonl output

### DIFF
--- a/crates/gg-cli/src/main.rs
+++ b/crates/gg-cli/src/main.rs
@@ -80,6 +80,10 @@ enum Commands {
         #[arg(long)]
         json: bool,
 
+        /// Output streaming NDJSON (one event per line; flushed after each)
+        #[arg(long = "jsonl", conflicts_with = "json")]
+        jsonl: bool,
+
         /// Skip checking whether base is behind origin/<base>
         #[arg(long)]
         no_rebase_check: bool,
@@ -495,10 +499,11 @@ enum Commands {
 fn main() {
     let cli = Cli::parse();
 
-    let (result, json_mode) = match cli.command {
+    let (result, json_mode, jsonl) = match cli.command {
         // No command = show stacks (like `gg ls`)
         None => (
             gg_core::commands::ls::run(false, false, false, false),
+            false,
             false,
         ),
 
@@ -509,17 +514,25 @@ fn main() {
         }) => (
             gg_core::commands::checkout::run(stack_name, base, worktree),
             false,
+            false,
         ),
         Some(Commands::List {
             all,
             refresh,
             remote,
             json,
-        }) => (gg_core::commands::ls::run(all, refresh, remote, json), json),
-        Some(Commands::Log { json, refresh }) => (gg_core::commands::log::run(json, refresh), json),
+        }) => (
+            gg_core::commands::ls::run(all, refresh, remote, json),
+            json,
+            false,
+        ),
+        Some(Commands::Log { json, refresh }) => {
+            (gg_core::commands::log::run(json, refresh), json, false)
+        }
         Some(Commands::Sync {
             draft,
             json,
+            jsonl,
             no_rebase_check,
             force,
             update_descriptions,
@@ -550,6 +563,7 @@ fn main() {
                 gg_core::commands::sync::run(
                     draft,
                     json,
+                    jsonl,
                     no_rebase_check,
                     force,
                     update_descriptions,
@@ -558,16 +572,17 @@ fn main() {
                     until,
                     no_verify,
                 ),
-                json,
+                json || jsonl,
+                jsonl,
             )
         }
-        Some(Commands::Move { target }) => (gg_core::commands::nav::move_to(&target), false),
-        Some(Commands::First) => (gg_core::commands::nav::first(), false),
-        Some(Commands::Last) => (gg_core::commands::nav::last(), false),
-        Some(Commands::Prev) => (gg_core::commands::nav::prev(), false),
-        Some(Commands::Next) => (gg_core::commands::nav::next(), false),
+        Some(Commands::Move { target }) => (gg_core::commands::nav::move_to(&target), false, false),
+        Some(Commands::First) => (gg_core::commands::nav::first(), false, false),
+        Some(Commands::Last) => (gg_core::commands::nav::last(), false, false),
+        Some(Commands::Prev) => (gg_core::commands::nav::prev(), false, false),
+        Some(Commands::Next) => (gg_core::commands::nav::next(), false, false),
         Some(Commands::Squash { all, force }) => {
-            (gg_core::commands::squash::run(all, force), false)
+            (gg_core::commands::squash::run(all, force), false, false)
         }
         Some(Commands::Drop {
             targets,
@@ -582,6 +597,7 @@ fn main() {
                 json,
             }),
             json,
+            false,
         ),
         Some(Commands::Reorder {
             order,
@@ -593,6 +609,7 @@ fn main() {
                 no_tui,
                 force,
             }),
+            false,
             false,
         ),
         Some(Commands::Split {
@@ -612,6 +629,7 @@ fn main() {
                 force,
             }),
             false,
+            false,
         ),
         Some(Commands::Unstack {
             target,
@@ -630,6 +648,7 @@ fn main() {
                 worktree,
             }),
             json,
+            false,
         ),
         Some(Commands::Land {
             all,
@@ -671,17 +690,21 @@ fn main() {
                     admin,
                 }),
                 json,
+                false,
             )
         }
-        Some(Commands::Clean { all, json }) => (gg_core::commands::clean::run(all, json), json),
-        Some(Commands::Rebase { target, force }) => {
-            (gg_core::commands::rebase::run(target, force), false)
+        Some(Commands::Clean { all, json }) => {
+            (gg_core::commands::clean::run(all, json), json, false)
         }
-        Some(Commands::Continue) => (gg_core::commands::rebase::continue_rebase(), false),
-        Some(Commands::Abort) => (gg_core::commands::rebase::abort_rebase(), false),
+        Some(Commands::Rebase { target, force }) => {
+            (gg_core::commands::rebase::run(target, force), false, false)
+        }
+        Some(Commands::Continue) => (gg_core::commands::rebase::continue_rebase(), false, false),
+        Some(Commands::Abort) => (gg_core::commands::rebase::abort_rebase(), false, false),
         Some(Commands::Lint { until, json }) => (
             gg_core::commands::lint::run(until, json, json).map(|_| ()),
             json,
+            false,
         ),
         Some(Commands::Run {
             command,
@@ -710,17 +733,17 @@ fn main() {
                 header_label: None,
                 jobs,
             }) {
-                Ok(true) => (Ok(()), json),
+                Ok(true) => (Ok(()), json, false),
                 // `execute` has already emitted the JSON run payload (when
                 // `json` is true) and/or the terminal output (when not).
                 // Exiting directly with code 1 avoids the generic error path
                 // appending a second `{"error":...}` document to stdout,
                 // which would break JSON consumers expecting one object.
                 Ok(false) => exit(1),
-                Err(e) => (Err(e), json),
+                Err(e) => (Err(e), json, false),
             }
         }
-        Some(Commands::Setup { all }) => (gg_core::commands::setup::run(all), false),
+        Some(Commands::Setup { all }) => (gg_core::commands::setup::run(all), false, false),
         Some(Commands::Absorb {
             dry_run,
             and_rebase,
@@ -740,6 +763,7 @@ fn main() {
                 force,
             }),
             false,
+            false,
         ),
         Some(Commands::Arrange {
             order,
@@ -752,19 +776,23 @@ fn main() {
                 force,
             }),
             false,
+            false,
         ),
         Some(Commands::Completions { shell }) => {
-            (gg_core::commands::completions::run(shell), false)
+            (gg_core::commands::completions::run(shell), false, false)
         }
-        Some(Commands::Init { shell }) => (gg_core::commands::init::run(shell), false),
+        Some(Commands::Init { shell }) => (gg_core::commands::init::run(shell), false, false),
         Some(Commands::Reconcile { dry_run, yes }) => (
             gg_core::commands::reconcile::run(gg_core::commands::reconcile::ReconcileOptions {
                 dry_run,
                 yes,
             }),
             false,
+            false,
         ),
-        Some(Commands::Inbox { all, json }) => (gg_core::commands::inbox::run(all, json), json),
+        Some(Commands::Inbox { all, json }) => {
+            (gg_core::commands::inbox::run(all, json), json, false)
+        }
         Some(Commands::Restack {
             dry_run,
             from,
@@ -776,6 +804,7 @@ fn main() {
                 json,
             }),
             json,
+            false,
         ),
         Some(Commands::Undo {
             list,
@@ -790,6 +819,7 @@ fn main() {
                 limit,
             }),
             json,
+            false,
         ),
     };
 
@@ -801,6 +831,18 @@ fn main() {
             exit(1);
         }
         if json_mode {
+            if jsonl {
+                gg_core::output::StreamingJson::emit_and_exit(
+                    &gg_core::output::SyncStreamingResponse {
+                        version: gg_core::output::OUTPUT_VERSION,
+                        command: "sync".to_string(),
+                        event: gg_core::output::SyncStreamingEvent::Error {
+                            message: e.to_string(),
+                        },
+                    },
+                    1,
+                );
+            }
             gg_core::output::print_json_error(&e.to_string());
         } else {
             eprintln!("{} {}", style("error:").red().bold(), e);

--- a/crates/gg-cli/tests/integration_tests/sync.rs
+++ b/crates/gg-cli/tests/integration_tests/sync.rs
@@ -28,6 +28,58 @@ fn test_gg_sync_json_help() {
 }
 
 #[test]
+fn test_gg_sync_jsonl_help() {
+    let (_temp_dir, repo_path) = create_test_repo();
+    let (success, stdout, _stderr) = run_gg(&repo_path, &["sync", "--help"]);
+
+    assert!(success);
+    assert!(stdout.contains("--jsonl"), "help should mention --jsonl");
+}
+
+#[test]
+fn test_gg_sync_jsonl_error_output_without_provider() {
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .expect("Failed to write config");
+
+    let (success, _stdout, stderr) = run_gg(&repo_path, &["co", "jsonl-sync-error"]);
+    assert!(success, "Failed to create stack: {}", stderr);
+
+    fs::write(repo_path.join("file.txt"), "content").expect("Failed to write file");
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "Test commit"]);
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["sync", "--jsonl"]);
+    assert!(!success, "sync --jsonl should fail without provider");
+    assert!(
+        stderr.trim().is_empty(),
+        "stderr should be empty in --jsonl mode: {stderr}"
+    );
+
+    let mut found_error = false;
+    for line in stdout.lines() {
+        let parsed: Value = serde_json::from_str(line)
+            .unwrap_or_else(|_| panic!("every --jsonl line must be valid JSON: {line}"));
+        assert_eq!(parsed["version"], 1);
+        assert_eq!(parsed["command"], "sync");
+        if parsed["event"] == "error" {
+            found_error = true;
+            assert!(
+                parsed["message"].is_string(),
+                "error message must be string"
+            );
+        }
+    }
+    assert!(found_error, "--jsonl output must contain an error event");
+}
+
+#[test]
 fn test_gg_sync_json_error_output_without_provider() {
     let (_temp_dir, repo_path) = create_test_repo();
 
@@ -56,6 +108,135 @@ fn test_gg_sync_json_error_output_without_provider() {
     let parsed: Value = serde_json::from_str(&stdout).expect("stdout must be valid JSON");
     assert_eq!(parsed["version"], 1);
     assert!(parsed["error"].is_string(), "error field must be string");
+}
+
+#[test]
+fn test_gg_sync_jsonl_success_emits_ndjson_events_and_summary() {
+    let (_temp_dir, repo_path, _remote_path) = create_test_repo_with_remote();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser","provider":"github","base":"main","sync_behind_threshold":0}}"#,
+    )
+    .expect("Failed to write config");
+
+    let (success, _, stderr) = run_gg(&repo_path, &["co", "jsonl-success"]);
+    assert!(success, "Failed to create stack: {}", stderr);
+
+    fs::write(repo_path.join("entry.txt"), "a\n").expect("Failed to write entry");
+    run_git(&repo_path, &["add", "entry.txt"]);
+    run_git(&repo_path, &["commit", "-m", "Entry\n\nGG-ID: c-8fd7581"]);
+
+    let fake_bin = repo_path.join("fake-bin");
+    fs::create_dir_all(&fake_bin).expect("Failed to create fake bin dir");
+    fs::write(
+        fake_bin.join("gh"),
+        r#"#!/bin/sh
+set -eu
+
+if [ "$1" = "--version" ]; then
+  echo "gh version 2.0.0"
+  exit 0
+fi
+
+if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
+  exit 0
+fi
+
+if [ "$1" = "pr" ] && [ "$2" = "create" ]; then
+  echo "https://github.com/test/repo/pull/101"
+  exit 0
+fi
+
+if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  echo '{"number":101,"title":"Entry","state":"OPEN","url":"https://github.com/test/repo/pull/101","headRefName":"testuser/jsonl-success--c-8fd7581","isDraft":false,"mergeable":"MERGEABLE","reviews":[]}'
+  exit 0
+fi
+
+if [ "$1" = "api" ] && [ "$2" = "-X" ] && [ "$3" = "POST" ]; then
+  exit 0
+fi
+
+echo "unexpected gh invocation: $@" >&2
+exit 1
+"#,
+    )
+    .expect("Failed to write fake gh");
+    #[cfg(unix)]
+    {
+        let mut perms = fs::metadata(fake_bin.join("gh"))
+            .expect("Failed to stat fake gh")
+            .permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(fake_bin.join("gh"), perms).expect("Failed to chmod fake gh");
+    }
+
+    let old_path = std::env::var_os("PATH").unwrap_or_default();
+    let mut new_path = std::ffi::OsString::from(fake_bin.as_os_str());
+    new_path.push(":");
+    new_path.push(old_path);
+
+    let (success, stdout, stderr) = run_gg_with_env(
+        &repo_path,
+        &["sync", "--jsonl", "--no-rebase-check"],
+        &[("PATH", new_path.as_os_str())],
+    );
+    assert!(
+        success,
+        "sync --jsonl failed\nstdout:\n{}\nstderr:\n{}",
+        stdout, stderr
+    );
+    assert!(
+        stderr.trim().is_empty(),
+        "stderr should be empty in --jsonl mode: {stderr}"
+    );
+
+    let mut events: Vec<Value> = Vec::new();
+    for line in stdout.lines() {
+        let parsed: Value = serde_json::from_str(line)
+            .unwrap_or_else(|_| panic!("every --jsonl line must be valid JSON: {line}"));
+        assert_eq!(parsed["version"], 1);
+        assert_eq!(parsed["command"], "sync");
+        events.push(parsed);
+    }
+
+    assert!(
+        !events.is_empty(),
+        "--jsonl output must contain at least one event"
+    );
+    assert_eq!(events[0]["event"], "start", "first event must be start");
+    assert!(
+        events[0]["total_entries"].is_number(),
+        "start event must include total_entries"
+    );
+
+    let summary = events.last().unwrap();
+    assert_eq!(summary["event"], "summary", "last event must be summary");
+    assert!(
+        summary["entries"].is_array(),
+        "summary must include entries"
+    );
+    assert_eq!(summary["entries"].as_array().unwrap().len(), 1);
+    assert_eq!(summary["entries"][0]["action"], "created");
+    assert_eq!(summary["entries"][0]["pr_number"], 101);
+
+    let events_before_summary = &events[..events.len() - 1];
+    let has_entry_started = events_before_summary
+        .iter()
+        .any(|e| e["event"] == "entry_started");
+    let has_pr_created = events_before_summary
+        .iter()
+        .any(|e| e["event"] == "pr_created");
+    assert!(has_entry_started, "must emit entry_started event");
+    assert!(has_pr_created, "must emit pr_created event");
+
+    let line_count = stdout.lines().count();
+    assert!(
+        line_count >= 3,
+        "expected at least start, entry_started/created, summary lines, got {line_count}"
+    );
 }
 
 #[test]

--- a/crates/gg-cli/tests/integration_tests/sync.rs
+++ b/crates/gg-cli/tests/integration_tests/sync.rs
@@ -80,6 +80,47 @@ fn test_gg_sync_jsonl_error_output_without_provider() {
 }
 
 #[test]
+fn test_gg_sync_jsonl_empty_stack_emits_summary_only() {
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .expect("Failed to write config");
+
+    let (success, _stdout, stderr) = run_gg(&repo_path, &["co", "jsonl-empty-stack"]);
+    assert!(success, "Failed to create stack: {}", stderr);
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["sync", "--jsonl"]);
+    assert!(
+        success,
+        "sync --jsonl on empty stack failed\nstdout:\n{}\nstderr:\n{}",
+        stdout, stderr
+    );
+    assert!(
+        stderr.trim().is_empty(),
+        "stderr should be empty in --jsonl mode: {stderr}"
+    );
+
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(lines.len(), 1, "empty stack should emit one summary event");
+    let parsed: Value = serde_json::from_str(lines[0])
+        .unwrap_or_else(|_| panic!("summary line must be valid JSON: {}", lines[0]));
+    assert_eq!(parsed["version"], 1);
+    assert_eq!(parsed["command"], "sync");
+    assert_eq!(parsed["event"], "summary");
+    assert_eq!(parsed["status"], "ok");
+    assert_eq!(parsed["stack"], "jsonl-empty-stack");
+    assert!(
+        parsed["entries"].as_array().unwrap().is_empty(),
+        "empty stack summary should include no entries"
+    );
+}
+
+#[test]
 fn test_gg_sync_json_error_output_without_provider() {
     let (_temp_dir, repo_path) = create_test_repo();
 
@@ -180,7 +221,7 @@ exit 1
 
     let (success, stdout, stderr) = run_gg_with_env(
         &repo_path,
-        &["sync", "--jsonl", "--no-rebase-check"],
+        &["sync", "--jsonl", "--lint", "--no-rebase-check"],
         &[("PATH", new_path.as_os_str())],
     );
     assert!(

--- a/crates/gg-core/src/commands/sync.rs
+++ b/crates/gg-core/src/commands/sync.rs
@@ -72,7 +72,7 @@ fn maybe_rebase_if_base_is_behind(
         // Internal auto-rebase during sync: the user hasn't been asked to
         // --force, so respect the immutability guard rather than silently
         // bypassing it.
-        match crate::commands::rebase::run_with_repo(repo, None, json && !jsonl, false) {
+        match crate::commands::rebase::run_with_repo(repo, None, json || jsonl, false) {
             Ok(()) => return Ok(true),
             Err(GgError::ImmutableTargets(msg)) => {
                 return Err(GgError::ImmutableTargetsDuringSync(msg));
@@ -102,7 +102,7 @@ fn maybe_rebase_if_base_is_behind(
         .unwrap_or(true);
 
     if should_rebase {
-        match crate::commands::rebase::run_with_repo(repo, None, json && !jsonl, false) {
+        match crate::commands::rebase::run_with_repo(repo, None, json || jsonl, false) {
             Ok(()) => return Ok(true),
             Err(GgError::ImmutableTargets(msg)) => {
                 return Err(GgError::ImmutableTargetsDuringSync(msg));
@@ -265,13 +265,28 @@ pub fn run(
                     stack: initial_stack.name.clone(),
                     base: initial_stack.base.clone(),
                     rebased_before_sync: false,
+                    warnings: warnings.clone(),
+                    metadata: SyncMetadataJson::default(),
+                    entries: vec![],
+                },
+            });
+        } else if !jsonl {
+            println!("{}", style("Stack is empty. Nothing to sync.").dim());
+        }
+        if jsonl {
+            let mut streamer = StreamingJson::new();
+            streamer.emit(&SyncStreamingResponse {
+                version: OUTPUT_VERSION,
+                command: "sync".to_string(),
+                event: SyncStreamingEvent::Summary {
+                    stack: initial_stack.name,
+                    base: initial_stack.base,
+                    rebased_before_sync: false,
                     warnings,
                     metadata: SyncMetadataJson::default(),
                     entries: vec![],
                 },
             });
-        } else {
-            println!("{}", style("Stack is empty. Nothing to sync.").dim());
         }
         guard.finalize_with_scope(
             &repo,
@@ -335,7 +350,8 @@ pub fn run(
         if !json && !jsonl {
             println!("{}", console::style("Running lint before sync...").dim());
         }
-        let lint_passed = crate::commands::lint::run_brief_no_commands(Some(end_pos), json, false)?;
+        let lint_passed =
+            crate::commands::lint::run_brief_no_commands(Some(end_pos), json || jsonl, false)?;
         if !lint_passed {
             restore_sync_start_position(
                 &repo,
@@ -369,7 +385,7 @@ pub fn run(
                     entries: vec![],
                 },
             });
-        } else {
+        } else if !jsonl {
             println!("{}", style("Stack is empty. Nothing to sync.").dim());
         }
         if let Some(s) = streamer.as_mut() {

--- a/crates/gg-core/src/commands/sync.rs
+++ b/crates/gg-core/src/commands/sync.rs
@@ -11,7 +11,8 @@ use crate::git::{self, get_commit_description, strip_gg_id_from_message};
 use crate::managed_body;
 use crate::operations::{OperationKind, RemoteEffect, SnapshotScope};
 use crate::output::{
-    print_json, SyncEntryResultJson, SyncMetadataJson, SyncResponse, SyncResultJson, OUTPUT_VERSION,
+    print_json, StreamingJson, SyncEntryResultJson, SyncMetadataJson, SyncResponse, SyncResultJson,
+    SyncStreamingEvent, SyncStreamingResponse, OUTPUT_VERSION,
 };
 use crate::provider::Provider;
 use crate::stack::{resolve_target, Stack};
@@ -33,6 +34,7 @@ fn maybe_rebase_if_base_is_behind(
     config: &Config,
     base_branch: &str,
     json: bool,
+    jsonl: bool,
 ) -> Result<bool> {
     let threshold = config.get_sync_behind_threshold();
     if threshold == 0 {
@@ -58,7 +60,7 @@ fn maybe_rebase_if_base_is_behind(
         .unwrap_or_else(|| "PRs/MRs".to_string());
 
     if config.get_sync_auto_rebase() {
-        if !json {
+        if !json && !jsonl {
             println!(
                 "{} Your stack is {} commits behind origin/{}. {} may show unrelated changes. Auto-rebasing...",
                 style("⚠").yellow().bold(),
@@ -70,7 +72,7 @@ fn maybe_rebase_if_base_is_behind(
         // Internal auto-rebase during sync: the user hasn't been asked to
         // --force, so respect the immutability guard rather than silently
         // bypassing it.
-        match crate::commands::rebase::run_with_repo(repo, None, json, false) {
+        match crate::commands::rebase::run_with_repo(repo, None, json && !jsonl, false) {
             Ok(()) => return Ok(true),
             Err(GgError::ImmutableTargets(msg)) => {
                 return Err(GgError::ImmutableTargetsDuringSync(msg));
@@ -79,7 +81,7 @@ fn maybe_rebase_if_base_is_behind(
         }
     }
 
-    if !json {
+    if !json && !jsonl {
         println!(
             "{} Your stack is {} commits behind origin/{}. {} may show unrelated changes. Run 'gg rebase' first to update.",
             style("⚠").yellow().bold(),
@@ -89,7 +91,7 @@ fn maybe_rebase_if_base_is_behind(
         );
     }
 
-    if json {
+    if json || jsonl {
         return Ok(false);
     }
 
@@ -100,7 +102,7 @@ fn maybe_rebase_if_base_is_behind(
         .unwrap_or(true);
 
     if should_rebase {
-        match crate::commands::rebase::run_with_repo(repo, None, json, false) {
+        match crate::commands::rebase::run_with_repo(repo, None, json && !jsonl, false) {
             Ok(()) => return Ok(true),
             Err(GgError::ImmutableTargets(msg)) => {
                 return Err(GgError::ImmutableTargetsDuringSync(msg));
@@ -204,6 +206,7 @@ fn compute_target_branch(
 pub fn run(
     draft: bool,
     json: bool,
+    jsonl: bool,
     no_rebase_check: bool,
     force: bool,
     update_descriptions: bool,
@@ -249,7 +252,7 @@ pub fn run(
         .map(|mismatch| mismatch.warning_message())
         .into_iter()
         .collect();
-    if !json {
+    if !json && !jsonl {
         for warning in &warnings {
             println!("{} {}", style("Warning:").yellow(), warning);
         }
@@ -297,9 +300,21 @@ pub fn run(
 
     let mut rebased_before_sync = false;
     if !no_rebase_check {
-        rebased_before_sync =
-            maybe_rebase_if_base_is_behind(&repo, &config, initial_stack.base.as_str(), json)?;
+        rebased_before_sync = maybe_rebase_if_base_is_behind(
+            &repo,
+            &config,
+            initial_stack.base.as_str(),
+            json,
+            jsonl,
+        )?;
     }
+
+    let streamer = if jsonl {
+        Some(StreamingJson::new())
+    } else {
+        None
+    };
+    let mut streamer = streamer;
 
     // Capture restore snapshot after optional pre-sync rebase. If lint fails,
     // we restore to this post-rebase state rather than silently undoing rebase.
@@ -317,7 +332,7 @@ pub fn run(
         let end_pos = lint_end_pos
             .map(|pos| pos.min(current_stack.len()))
             .unwrap_or(current_stack.len());
-        if !json {
+        if !json && !jsonl {
             println!("{}", console::style("Running lint before sync...").dim());
         }
         let lint_passed = crate::commands::lint::run_brief_no_commands(Some(end_pos), json, false)?;
@@ -327,13 +342,14 @@ pub fn run(
                 sync_start_branch.as_deref(),
                 sync_start_head,
                 json,
+                jsonl,
             )?;
             return Err(GgError::Other(
                 "Lint failed for one or more commits. Sync aborted; repository restored to its original state."
                     .to_string(),
             ));
         }
-        if !json {
+        if !json && !jsonl {
             println!();
         }
     }
@@ -356,6 +372,20 @@ pub fn run(
         } else {
             println!("{}", style("Stack is empty. Nothing to sync.").dim());
         }
+        if let Some(s) = streamer.as_mut() {
+            s.emit(&SyncStreamingResponse {
+                version: OUTPUT_VERSION,
+                command: "sync".to_string(),
+                event: SyncStreamingEvent::Summary {
+                    stack: stack.name,
+                    base: stack.base,
+                    rebased_before_sync,
+                    warnings: warnings.clone(),
+                    metadata: SyncMetadataJson::default(),
+                    entries: vec![],
+                },
+            });
+        }
         guard.finalize_with_scope(
             &repo,
             &config,
@@ -371,7 +401,7 @@ pub fn run(
         resolve_target(&stack, target)?;
     }
 
-    if !json {
+    if !json && !jsonl {
         println!("{}", style("Normalizing GG metadata...").dim());
     }
     // Intentional: sync always enforces GG-ID / GG-Parent invariants for the
@@ -396,7 +426,7 @@ pub fn run(
     let pr_template = template::load_template(git_dir);
 
     // Sync progress
-    let pb = if json {
+    let pb = if json || jsonl {
         ProgressBar::hidden()
     } else if atty::is(atty::Stream::Stderr) {
         let pb = ProgressBar::new(entries_to_sync.len() as u64);
@@ -421,11 +451,37 @@ pub fn run(
     // when computing their target branch (walk-back algorithm for stacked MRs).
     let mut entry_is_closed: Vec<bool> = Vec::with_capacity(entries_to_sync.len());
 
+    if let Some(s) = streamer.as_mut() {
+        s.emit(&SyncStreamingResponse {
+            version: OUTPUT_VERSION,
+            command: "sync".to_string(),
+            event: SyncStreamingEvent::Start {
+                stack: stack.name.clone(),
+                base: stack.base.clone(),
+                total_entries: entries_to_sync.len(),
+            },
+        });
+    }
+
     for (i, entry) in entries_to_sync.iter().enumerate() {
         let gg_id = entry.gg_id.as_ref().unwrap();
         let entry_branch = stack.entry_branch_name(entry).unwrap();
         let commit = repo.find_commit(entry.oid)?;
         let raw_title = strip_gg_id_from_message(&entry.title);
+
+        if let Some(s) = streamer.as_mut() {
+            s.emit(&SyncStreamingResponse {
+                version: OUTPUT_VERSION,
+                command: "sync".to_string(),
+                event: SyncStreamingEvent::EntryStarted {
+                    position: entry.position,
+                    sha: entry.short_sha.clone(),
+                    title: entry.title.clone(),
+                    gg_id: gg_id.clone(),
+                    branch: entry_branch.clone(),
+                },
+            });
+        }
 
         if !force_draft && is_wip_or_draft_prefix(&raw_title) {
             force_draft = true;
@@ -462,6 +518,16 @@ pub fn run(
 
         // Only push if the remote is different or doesn't exist
         if needs_push {
+            if let Some(s) = streamer.as_mut() {
+                s.emit(&SyncStreamingResponse {
+                    version: OUTPUT_VERSION,
+                    command: "sync".to_string(),
+                    event: SyncStreamingEvent::PushStarted {
+                        position: entry.position,
+                        branch: entry_branch.clone(),
+                    },
+                });
+            }
             pushed = true;
             // Push the branch (always force-push with lease because rebases change commit SHAs)
             // This is safe because each entry branch is owned by this stack
@@ -469,7 +535,18 @@ pub fn run(
             let push_result = git::push_branch(&entry_branch, true, force, no_verify);
             if let Err(e) = push_result {
                 pb.finish_and_clear();
-                if json {
+                if json || jsonl {
+                    if let Some(s) = streamer.as_mut() {
+                        s.emit(&SyncStreamingResponse {
+                            version: OUTPUT_VERSION,
+                            command: "sync".to_string(),
+                            event: SyncStreamingEvent::PushError {
+                                position: entry.position,
+                                branch: entry_branch.clone(),
+                                error: e.to_string(),
+                            },
+                        });
+                    }
                     action = "error".to_string();
                     entry_error = Some(e.to_string());
 
@@ -494,6 +571,18 @@ pub fn run(
 
                 format_push_error(&e, &entry_branch);
                 return Err(e);
+            }
+
+            if let Some(s) = streamer.as_mut() {
+                s.emit(&SyncStreamingResponse {
+                    version: OUTPUT_VERSION,
+                    command: "sync".to_string(),
+                    event: SyncStreamingEvent::PushDone {
+                        position: entry.position,
+                        branch: entry_branch.clone(),
+                        forced: force,
+                    },
+                });
             }
 
             // Record the push as a remote effect. `sync` always pushes with
@@ -543,8 +632,18 @@ pub fn run(
 
                 if is_closed {
                     action = "skipped_closed".to_string();
+                    if let Some(s) = streamer.as_mut() {
+                        s.emit(&SyncStreamingResponse {
+                            version: OUTPUT_VERSION,
+                            command: "sync".to_string(),
+                            event: SyncStreamingEvent::PrSkippedClosed {
+                                position: entry.position,
+                                pr_number: pr_num,
+                            },
+                        });
+                    }
                     // Skip updating closed/merged PRs
-                    if !json {
+                    if !json && !jsonl {
                         pb.println(format!(
                             "{} {} {}{} already closed/merged, skipping",
                             style("○").dim(),
@@ -573,6 +672,22 @@ pub fn run(
                         replacement_draft,
                     ) {
                         Ok(result) => {
+                            if let Some(s) = streamer.as_mut() {
+                                s.emit(&SyncStreamingResponse {
+                                    version: OUTPUT_VERSION,
+                                    command: "sync".to_string(),
+                                    event: SyncStreamingEvent::PrCreated {
+                                        position: entry.position,
+                                        pr_number: result.number,
+                                        pr_url: if result.url.is_empty() {
+                                            None
+                                        } else {
+                                            Some(result.url.clone())
+                                        },
+                                        draft: replacement_draft,
+                                    },
+                                });
+                            }
                             config.set_mr_for_entry(&stack.name, gg_id, result.number);
                             pr_number = Some(result.number);
                             pr_url = if result.url.is_empty() {
@@ -603,7 +718,7 @@ pub fn run(
                                 &result.url,
                             );
                             if let Err(e) = provider.create_pr_comment(pr_num, &close_comment) {
-                                if !json {
+                                if !json && !jsonl {
                                     pb.println(format!(
                                         "{} Could not comment on old {} {}{}: {}",
                                         style("Warning:").yellow(),
@@ -638,7 +753,7 @@ pub fn run(
                                     guard.record_remote_effect(closed_effect);
                                 }
                                 Err(e) => {
-                                    if !json {
+                                    if !json && !jsonl {
                                         pb.println(format!(
                                             "{} Could not close old {} {}{}: {}",
                                             style("Warning:").yellow(),
@@ -657,7 +772,7 @@ pub fn run(
                                 }
                             }
 
-                            if !json {
+                            if !json && !jsonl {
                                 let status_msg = if needs_push { "Pushed" } else { "Up to date" };
                                 pb.println(format!(
                                     "{} {} {} -> {} {}{} (recreated from {}{})",
@@ -681,7 +796,7 @@ pub fn run(
                         Err(e) => {
                             action = "error".to_string();
                             entry_error = Some(e.to_string());
-                            if !json {
+                            if !json && !jsonl {
                                 pb.println(format!(
                                     "{} Failed to recreate {} for {} after source branch changed from {}: {}",
                                     style("Error:").red().bold(),
@@ -696,7 +811,7 @@ pub fn run(
                 } else {
                     if update_title {
                         if let Err(e) = provider.update_pr_title(pr_num, &title) {
-                            if !json {
+                            if !json && !jsonl {
                                 pb.println(format!(
                                     "{} Could not update {} {}{} title: {}",
                                     style("Warning:").yellow(),
@@ -732,7 +847,7 @@ pub fn run(
                                             provider.pr_number_prefix(),
                                             pr_num
                                         );
-                                        if !json {
+                                        if !json && !jsonl {
                                             pb.println(format!(
                                                 "{} {}",
                                                 style("Warning:").yellow(),
@@ -749,7 +864,7 @@ pub fn run(
                                     if let Err(e) =
                                         provider.update_pr_description(pr_num, &new_body)
                                     {
-                                        if !json {
+                                        if !json && !jsonl {
                                             pb.println(format!(
                                                 "{} Could not update {} {}{} description: {}",
                                                 style("Warning:").yellow(),
@@ -768,7 +883,7 @@ pub fn run(
                             }
                             Err(e) => {
                                 // Could not read remote body — skip update to be safe
-                                if !json {
+                                if !json && !jsonl {
                                     pb.println(format!(
                                         "{} Could not read {} {}{} body, skipping description update: {}",
                                         style("Warning:").yellow(),
@@ -798,7 +913,7 @@ pub fn run(
                             guard.mark_touched_remote();
                         }
                         Err(e) => {
-                            if !json {
+                            if !json && !jsonl {
                                 pb.println(format!(
                                     "{} Could not update {} {}{}: {}",
                                     style("Warning:").yellow(),
@@ -820,7 +935,7 @@ pub fn run(
                     } else {
                         "Up to date"
                     };
-                    if !json {
+                    if !json && !jsonl {
                         pb.println(format!(
                             "{} {} {} -> {} {}{}",
                             style("OK").green().bold(),
@@ -833,6 +948,17 @@ pub fn run(
                     }
                     if needs_push || update_descriptions || update_title {
                         action = "updated".to_string();
+                    }
+                    if let Some(s) = streamer.as_mut() {
+                        s.emit(&SyncStreamingResponse {
+                            version: OUTPUT_VERSION,
+                            command: "sync".to_string(),
+                            event: SyncStreamingEvent::PrUpdated {
+                                position: entry.position,
+                                pr_number: pr_num,
+                                action: action.clone(),
+                            },
+                        });
                     }
                 }
             }
@@ -847,6 +973,22 @@ pub fn run(
                     entry_draft,
                 ) {
                     Ok(result) => {
+                        if let Some(s) = streamer.as_mut() {
+                            s.emit(&SyncStreamingResponse {
+                                version: OUTPUT_VERSION,
+                                command: "sync".to_string(),
+                                event: SyncStreamingEvent::PrCreated {
+                                    position: entry.position,
+                                    pr_number: result.number,
+                                    pr_url: if result.url.is_empty() {
+                                        None
+                                    } else {
+                                        Some(result.url.clone())
+                                    },
+                                    draft: entry_draft,
+                                },
+                            });
+                        }
                         config.set_mr_for_entry(&stack.name, gg_id, result.number);
                         pr_number = Some(result.number);
                         pr_url = if result.url.is_empty() {
@@ -868,7 +1010,7 @@ pub fn run(
                         touched_remote = true;
                         guard.record_remote_effect(effect);
 
-                        if !json {
+                        if !json && !jsonl {
                             let draft_label = if entry_draft { " (draft)" } else { "" };
                             let status_msg = if needs_push { "Pushed" } else { "Up to date" };
                             pb.println(format!(
@@ -893,7 +1035,7 @@ pub fn run(
                     Err(e) => {
                         action = "error".to_string();
                         entry_error = Some(e.to_string());
-                        if !json {
+                        if !json && !jsonl {
                             pb.println(format!(
                                 "{} Failed to create {} for {}: {}",
                                 style("Error:").red().bold(),
@@ -907,7 +1049,7 @@ pub fn run(
             }
         }
 
-        if json {
+        if json || jsonl {
             json_entries.push(SyncEntryResultJson {
                 position: entry.position,
                 sha: entry.short_sha.clone(),
@@ -947,7 +1089,7 @@ pub fn run(
             };
             // json_entries.len() - 1 = the index of the entry we just pushed (JSON mode).
             // In non-JSON mode, json_entries is empty — use a sentinel index.
-            let json_index = if json {
+            let json_index = if json || jsonl {
                 json_entries.len().saturating_sub(1)
             } else {
                 0
@@ -966,7 +1108,7 @@ pub fn run(
         pb.inc(1);
     }
 
-    if !json {
+    if !json && !jsonl {
         pb.finish_with_message("Done!");
     }
 
@@ -1010,7 +1152,7 @@ pub fn run(
             let existing = match provider.find_managed_comment(snap.pr_number) {
                 Ok(v) => v,
                 Err(e) => {
-                    if !json {
+                    if !json && !jsonl {
                         println!(
                             "{} Could not list comments on {} {}{}: {}",
                             style("Warning:").yellow(),
@@ -1020,7 +1162,7 @@ pub fn run(
                             e
                         );
                     }
-                    if json {
+                    if json || jsonl {
                         if let Some(entry_json) = json_entries.get_mut(snap.json_index) {
                             entry_json.nav_comment_action = Some("error".to_string());
                         }
@@ -1049,28 +1191,30 @@ pub fn run(
                         .collect();
                     let body = stack_nav::render(&stack.name, &nav_entries, number_prefix);
 
-                    match existing {
-                        Some(c) if c.body == body => Some("unchanged"),
-                        Some(c) => match provider.update_pr_comment(snap.pr_number, c.id, &body) {
-                            Ok(()) => Some("updated"),
-                            Err(e) => {
-                                if !json {
-                                    println!(
-                                        "{} Could not update nav comment on {} {}{}: {}",
-                                        style("Warning:").yellow(),
-                                        provider.pr_label(),
-                                        number_prefix,
-                                        snap.pr_number,
-                                        e
-                                    );
+                    let result = match existing {
+                        Some(ref c) if c.body == body => Some("unchanged"),
+                        Some(ref c) => {
+                            match provider.update_pr_comment(snap.pr_number, c.id, &body) {
+                                Ok(()) => Some("updated"),
+                                Err(e) => {
+                                    if !json && !jsonl {
+                                        println!(
+                                            "{} Could not update nav comment on {} {}{}: {}",
+                                            style("Warning:").yellow(),
+                                            provider.pr_label(),
+                                            number_prefix,
+                                            snap.pr_number,
+                                            e
+                                        );
+                                    }
+                                    Some("error")
                                 }
-                                Some("error")
                             }
-                        },
+                        }
                         None => match provider.create_pr_comment(snap.pr_number, &body) {
                             Ok(()) => Some("created"),
                             Err(e) => {
-                                if !json {
+                                if !json && !jsonl {
                                     println!(
                                         "{} Could not create nav comment on {} {}{}: {}",
                                         style("Warning:").yellow(),
@@ -1083,31 +1227,83 @@ pub fn run(
                                 Some("error")
                             }
                         },
+                    };
+                    if let Some(s) = streamer.as_mut() {
+                        let error = if result == Some("error") {
+                            Some(format!(
+                                "Could not {} nav comment on {} {}{}",
+                                if existing.is_some() {
+                                    "update"
+                                } else {
+                                    "create"
+                                },
+                                provider.pr_label(),
+                                number_prefix,
+                                snap.pr_number
+                            ))
+                        } else {
+                            None
+                        };
+                        s.emit(&SyncStreamingResponse {
+                            version: OUTPUT_VERSION,
+                            command: "sync".to_string(),
+                            event: SyncStreamingEvent::NavComment {
+                                position: snap.json_index + 1,
+                                pr_number: snap.pr_number,
+                                action: result.unwrap_or("skip").to_string(),
+                                error,
+                            },
+                        });
                     }
+                    result
                 }
-                stack_nav::NavAction::Delete => match existing {
-                    Some(c) => match provider.delete_pr_comment(snap.pr_number, c.id) {
-                        Ok(()) => Some("deleted"),
-                        Err(e) => {
-                            if !json {
-                                println!(
-                                    "{} Could not delete nav comment on {} {}{}: {}",
-                                    style("Warning:").yellow(),
-                                    provider.pr_label(),
-                                    number_prefix,
-                                    snap.pr_number,
-                                    e
-                                );
+                stack_nav::NavAction::Delete => {
+                    let result = match existing {
+                        Some(c) => match provider.delete_pr_comment(snap.pr_number, c.id) {
+                            Ok(()) => Some("deleted"),
+                            Err(e) => {
+                                if !json && !jsonl {
+                                    println!(
+                                        "{} Could not delete nav comment on {} {}{}: {}",
+                                        style("Warning:").yellow(),
+                                        provider.pr_label(),
+                                        number_prefix,
+                                        snap.pr_number,
+                                        e
+                                    );
+                                }
+                                Some("error")
                             }
-                            Some("error")
-                        }
-                    },
-                    None => None,
-                },
+                        },
+                        None => None,
+                    };
+                    if let Some(s) = streamer.as_mut() {
+                        s.emit(&SyncStreamingResponse {
+                            version: OUTPUT_VERSION,
+                            command: "sync".to_string(),
+                            event: SyncStreamingEvent::NavComment {
+                                position: snap.json_index + 1,
+                                pr_number: snap.pr_number,
+                                action: result.unwrap_or("skip").to_string(),
+                                error: if result == Some("error") {
+                                    Some(format!(
+                                        "Could not delete nav comment on {} {}{}",
+                                        provider.pr_label(),
+                                        number_prefix,
+                                        snap.pr_number
+                                    ))
+                                } else {
+                                    None
+                                },
+                            },
+                        });
+                    }
+                    result
+                }
             };
 
             if let Some(action) = action_result {
-                if json {
+                if json || jsonl {
                     if let Some(entry_json) = json_entries.get_mut(snap.json_index) {
                         entry_json.nav_comment_action = Some(action.to_string());
                     }
@@ -1123,18 +1319,37 @@ pub fn run(
         print_json(&SyncResponse {
             version: OUTPUT_VERSION,
             sync: SyncResultJson {
-                stack: stack.name,
-                base: stack.base,
+                stack: stack.name.clone(),
+                base: stack.base.clone(),
                 rebased_before_sync,
-                warnings,
+                warnings: warnings.clone(),
                 metadata: SyncMetadataJson {
                     gg_ids_added: metadata_counts.gg_ids_added,
                     gg_parents_updated: metadata_counts.gg_parents_updated,
                     gg_parents_removed: metadata_counts.gg_parents_removed,
                 },
-                entries: json_entries,
+                entries: json_entries.clone(),
             },
         });
+    } else if jsonl {
+        if let Some(s) = streamer.as_mut() {
+            s.emit(&SyncStreamingResponse {
+                version: OUTPUT_VERSION,
+                command: "sync".to_string(),
+                event: SyncStreamingEvent::Summary {
+                    stack: stack.name,
+                    base: stack.base,
+                    rebased_before_sync,
+                    warnings: warnings.clone(),
+                    metadata: SyncMetadataJson {
+                        gg_ids_added: metadata_counts.gg_ids_added,
+                        gg_parents_updated: metadata_counts.gg_parents_updated,
+                        gg_parents_removed: metadata_counts.gg_parents_removed,
+                    },
+                    entries: json_entries,
+                },
+            });
+        }
     } else {
         println!();
         println!(
@@ -1160,8 +1375,9 @@ fn restore_sync_start_position(
     start_branch: Option<&str>,
     start_head: git2::Oid,
     json: bool,
+    jsonl: bool,
 ) -> Result<()> {
-    if !json {
+    if !json && !jsonl {
         println!(
             "{} Restoring repository to pre-sync state...",
             style("→").cyan()
@@ -1178,7 +1394,7 @@ fn restore_sync_start_position(
         git::checkout_commit(repo, &commit)?;
     }
 
-    if !json {
+    if !json && !jsonl {
         println!("{} Repository restored", style("OK").green());
     }
 

--- a/crates/gg-core/src/output.rs
+++ b/crates/gg-core/src/output.rs
@@ -1,5 +1,7 @@
 //! Structured output helpers.
 
+use std::io::{self, Write};
+
 use serde::Serialize;
 
 pub const OUTPUT_VERSION: u32 = 1;
@@ -9,6 +11,47 @@ pub fn print_json<T: Serialize>(data: &T) {
         "{}",
         serde_json::to_string_pretty(data).expect("failed to serialize JSON output")
     );
+}
+
+/// Streaming NDJSON helper: emits one compact JSON object per line and flushes
+/// after every write so long-running commands can be consumed incrementally.
+#[derive(Debug)]
+pub struct StreamingJson {
+    stdout: io::Stdout,
+}
+
+impl Default for StreamingJson {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl StreamingJson {
+    pub fn new() -> Self {
+        Self {
+            stdout: io::stdout(),
+        }
+    }
+
+    /// Emit a single NDJSON line and flush immediately.
+    pub fn emit<T: Serialize>(&mut self, event: &T) {
+        let line = serde_json::to_string(event).expect("failed to serialize streaming event");
+        let mut lock = self.stdout.lock();
+        writeln!(lock, "{}", line).expect("failed to write streaming event");
+        lock.flush().expect("failed to flush streaming event");
+    }
+
+    /// Emit an event and terminate the process with the given exit code.
+    ///
+    /// This is the streaming equivalent of `print_json_error` + `exit(1)`: it
+    /// guarantees the consumer sees the error event before the process ends.
+    pub fn emit_and_exit<T: Serialize>(event: &T, code: i32) -> ! {
+        let line = serde_json::to_string(event).expect("failed to serialize streaming event");
+        let mut stdout = io::stdout();
+        writeln!(stdout, "{}", line).expect("failed to write streaming event");
+        stdout.flush().expect("failed to flush streaming event");
+        std::process::exit(code);
+    }
 }
 
 #[derive(Serialize)]
@@ -112,6 +155,77 @@ pub struct SyncResponse {
 }
 
 #[derive(Serialize)]
+pub struct SyncStreamingResponse {
+    pub version: u32,
+    pub command: String,
+    #[serde(flatten)]
+    pub event: SyncStreamingEvent,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "snake_case", tag = "event")]
+pub enum SyncStreamingEvent {
+    Start {
+        stack: String,
+        base: String,
+        total_entries: usize,
+    },
+    EntryStarted {
+        position: usize,
+        sha: String,
+        title: String,
+        gg_id: String,
+        branch: String,
+    },
+    PushStarted {
+        position: usize,
+        branch: String,
+    },
+    PushDone {
+        position: usize,
+        branch: String,
+        forced: bool,
+    },
+    PushError {
+        position: usize,
+        branch: String,
+        error: String,
+    },
+    PrCreated {
+        position: usize,
+        pr_number: u64,
+        pr_url: Option<String>,
+        draft: bool,
+    },
+    PrUpdated {
+        position: usize,
+        pr_number: u64,
+        action: String,
+    },
+    PrSkippedClosed {
+        position: usize,
+        pr_number: u64,
+    },
+    NavComment {
+        position: usize,
+        pr_number: u64,
+        action: String,
+        error: Option<String>,
+    },
+    Error {
+        message: String,
+    },
+    Summary {
+        stack: String,
+        base: String,
+        rebased_before_sync: bool,
+        warnings: Vec<String>,
+        metadata: SyncMetadataJson,
+        entries: Vec<SyncEntryResultJson>,
+    },
+}
+
+#[derive(Serialize)]
 pub struct SyncResultJson {
     pub stack: String,
     pub base: String,
@@ -128,7 +242,7 @@ pub struct SyncMetadataJson {
     pub gg_parents_removed: usize,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 pub struct SyncEntryResultJson {
     pub position: usize,
     pub sha: String,
@@ -458,6 +572,50 @@ mod tests {
         };
         let json = serde_json::to_value(&entry).unwrap();
         assert_eq!(json["nav_comment_action"], "created");
+    }
+
+    #[test]
+    fn sync_streaming_event_serializes_with_tag_and_version() {
+        let response = SyncStreamingResponse {
+            version: OUTPUT_VERSION,
+            command: "sync".to_string(),
+            event: SyncStreamingEvent::Start {
+                stack: "my-feature".to_string(),
+                base: "main".to_string(),
+                total_entries: 3,
+            },
+        };
+        let v = serde_json::to_value(&response).unwrap();
+        assert_eq!(v["version"], OUTPUT_VERSION);
+        assert_eq!(v["command"], "sync");
+        assert_eq!(v["event"], "start");
+        assert_eq!(v["stack"], "my-feature");
+        assert_eq!(v["base"], "main");
+        assert_eq!(v["total_entries"], 3);
+    }
+
+    #[test]
+    fn sync_streaming_summary_includes_entries() {
+        let response = SyncStreamingResponse {
+            version: OUTPUT_VERSION,
+            command: "sync".to_string(),
+            event: SyncStreamingEvent::Summary {
+                stack: "s".to_string(),
+                base: "main".to_string(),
+                rebased_before_sync: false,
+                warnings: vec!["w".to_string()],
+                metadata: SyncMetadataJson {
+                    gg_ids_added: 1,
+                    gg_parents_updated: 2,
+                    gg_parents_removed: 0,
+                },
+                entries: vec![],
+            },
+        };
+        let v = serde_json::to_value(&response).unwrap();
+        assert_eq!(v["event"], "summary");
+        assert_eq!(v["metadata"]["gg_ids_added"], 1);
+        assert_eq!(v["warnings"][0], "w");
     }
 }
 

--- a/crates/gg-core/src/output.rs
+++ b/crates/gg-core/src/output.rs
@@ -2,7 +2,7 @@
 
 use std::io::{self, Write};
 
-use serde::Serialize;
+use serde::{Serialize, Serializer};
 
 pub const OUTPUT_VERSION: u32 = 1;
 
@@ -154,12 +154,30 @@ pub struct SyncResponse {
     pub sync: SyncResultJson,
 }
 
-#[derive(Serialize)]
 pub struct SyncStreamingResponse {
     pub version: u32,
     pub command: String,
-    #[serde(flatten)]
     pub event: SyncStreamingEvent,
+}
+
+impl Serialize for SyncStreamingResponse {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let status = match &self.event {
+            SyncStreamingEvent::Error { .. } | SyncStreamingEvent::PushError { .. } => "error",
+            _ => "ok",
+        };
+        let mut value = serde_json::to_value(&self.event).map_err(serde::ser::Error::custom)?;
+        let object = value
+            .as_object_mut()
+            .ok_or_else(|| serde::ser::Error::custom("streaming event serialized non-object"))?;
+        object.insert("version".to_string(), serde_json::json!(self.version));
+        object.insert("command".to_string(), serde_json::json!(self.command));
+        object.insert("status".to_string(), serde_json::json!(status));
+        value.serialize(serializer)
+    }
 }
 
 #[derive(Serialize)]
@@ -588,6 +606,7 @@ mod tests {
         let v = serde_json::to_value(&response).unwrap();
         assert_eq!(v["version"], OUTPUT_VERSION);
         assert_eq!(v["command"], "sync");
+        assert_eq!(v["status"], "ok");
         assert_eq!(v["event"], "start");
         assert_eq!(v["stack"], "my-feature");
         assert_eq!(v["base"], "main");
@@ -614,8 +633,23 @@ mod tests {
         };
         let v = serde_json::to_value(&response).unwrap();
         assert_eq!(v["event"], "summary");
+        assert_eq!(v["status"], "ok");
         assert_eq!(v["metadata"]["gg_ids_added"], 1);
         assert_eq!(v["warnings"][0], "w");
+    }
+
+    #[test]
+    fn sync_streaming_error_status_serializes_as_error() {
+        let response = SyncStreamingResponse {
+            version: OUTPUT_VERSION,
+            command: "sync".to_string(),
+            event: SyncStreamingEvent::Error {
+                message: "boom".to_string(),
+            },
+        };
+        let v = serde_json::to_value(&response).unwrap();
+        assert_eq!(v["event"], "error");
+        assert_eq!(v["status"], "error");
     }
 }
 

--- a/docs/src/commands/sync.md
+++ b/docs/src/commands/sync.md
@@ -18,6 +18,7 @@ gg sync [OPTIONS]
 - `--no-verify`: Skip the pre-push hook for pushes performed by this sync (forwards `git push --no-verify`). Opt-in per invocation; does not affect other hooks.
 - `-u, --until <UNTIL>`: Sync up to target commit (position, GG-ID, or SHA)
 - `--json`: Output structured JSON for automation (suppresses human/progress output)
+- `--jsonl`: Output streaming NDJSON for automation (one JSON event per line, flushed after each; see Streaming Events below)
 
 Before pushing, `gg sync` checks whether your stack base is behind `origin/<base>`. If it is behind by at least the configured threshold, git-gud warns and suggests rebasing first (`gg rebase`).
 
@@ -111,9 +112,61 @@ re-syncing cleans up any previously-posted comments automatically.
 Merged or closed PRs are left alone — `gg sync` never modifies comments on
 historical PRs.
 
-When running with `--json`, each entry includes an optional `nav_comment_action`
-field (one of `"created"`, `"updated"`, `"unchanged"`, `"deleted"`, `"error"`)
-when a reconcile decision was made.
+When running with `--json` or `--jsonl`, each entry includes an optional
+`nav_comment_action` field (one of `"created"`, `"updated"`, `"unchanged"`,
+`"deleted"`, `"error"`) when a reconcile decision was made.
+
+## Streaming NDJSON (`--jsonl`)
+
+`gg sync --jsonl` emits one compact JSON object per line on stdout and flushes
+after each line. Human/progress output is suppressed on stdout but diagnostics
+may still appear on stderr. This mode is intended for agents and long-running
+pipelines that want incremental updates instead of waiting for a final aggregate
+payload.
+
+Every line is a valid JSON object with at least:
+
+- `version`: output schema version (`1`)
+- `command`: always `"sync"`
+- `event`: event kind (see below)
+
+Event kinds:
+
+| Event | Fields | Emitted when |
+|---|---|---|
+| `start` | `stack`, `base`, `total_entries` | Sync begins |
+| `entry_started` | `position`, `sha`, `title`, `gg_id`, `branch` | Processing begins for a stack entry |
+| `push_started` | `position`, `branch` | A push is about to start |
+| `push_done` | `position`, `branch`, `forced` | Push succeeded |
+| `push_error` | `position`, `branch`, `error` | Push failed (entry is skipped) |
+| `pr_created` | `position`, `pr_number`, `pr_url`, `draft` | New PR/MR created |
+| `pr_updated` | `position`, `pr_number`, `action` | Existing PR/MR updated (`updated`/`recreated`) |
+| `pr_skipped_closed` | `position`, `pr_number` | Existing PR/MR is merged/closed and skipped |
+| `nav_comment` | `position`, `pr_number`, `action`, `error` | Managed nav comment reconciled (`created`/`updated`/`unchanged`/`deleted`/`error`/`skip`) |
+| `error` | `message` | Fatal error before completion |
+| `summary` | same shape as `--json` `sync` object | Sync finished (success or partial failure) |
+
+The last event is always `summary`, so consumers can detect completion without
+reconstructing state. If an unrecoverable error happens before the summary,
+an `error` event is emitted and the process exits non-zero.
+
+### Example `--jsonl` output
+
+```ndjson
+{"version":1,"command":"sync","event":"start","stack":"my-stack","base":"main","total_entries":2}
+{"version":1,"command":"sync","event":"entry_started","position":1,"sha":"abc1234","title":"Add feature","gg_id":"c-abc1234","branch":"user/my-stack--c-abc1234"}
+{"version":1,"command":"sync","event":"push_started","position":1,"branch":"user/my-stack--c-abc1234"}
+{"version":1,"command":"sync","event":"push_done","position":1,"branch":"user/my-stack--c-abc1234","forced":false}
+{"version":1,"command":"sync","event":"pr_created","position":1,"pr_number":42,"pr_url":"https://github.com/org/repo/pull/42","draft":false}
+{"version":1,"command":"sync","event":"summary","stack":"my-stack","base":"main","rebased_before_sync":false,"warnings":[],"metadata":{"gg_ids_added":0,"gg_parents_updated":0,"gg_parents_removed":0},"entries":[{"position":1,"sha":"abc1234","title":"Add feature","gg_id":"c-abc1234","branch":"user/my-stack--c-abc1234","action":"created","pr_number":42,"pr_url":"https://github.com/org/repo/pull/42","draft":false,"pushed":true,"error":null}]}
+```
+
+### When to use `--json` vs `--jsonl`
+
+- Use `--json` when you want a single, complete aggregate payload at the end and
+  do not need progress while the command runs.
+- Use `--jsonl` when you want to stream events as they happen, monitor progress,
+  or pipe the output to a line-oriented consumer. Every line is self-contained.
 
 Example JSON (shape):
 

--- a/skills/gg/SKILL.md
+++ b/skills/gg/SKILL.md
@@ -136,7 +136,7 @@ gg land -a -c --json
 ## Agent operating rules (mandatory)
 
 1. **Never run `gg land` without explicit user confirmation.**
-2. **Always use `--json`** for `gg ls`, `gg sync`, `gg land`, `gg clean -a`, and `gg lint`.
+2. **Always use structured output**: use `--json` for `gg ls`, `gg land`, `gg clean -a`, and `gg lint`. Use `gg sync --json` when you need the final aggregate response, and prefer `gg sync --jsonl` for long-running agent pipelines that need streaming progress and a final summary event.
 3. **Prefer worktrees** for isolation (`gg co -w <stack>`). If shell integration is unavailable, manually `cd` to the printed worktree path before editing.
 4. Verify `approved: true` and `ci_status` success before landing. If the user requests `--admin`, skip the approval check (GitHub only — GitLab ignores the flag).
 5. If sync warns stack is behind base, run `gg rebase` first.
@@ -155,6 +155,7 @@ gg land -a -c --json
 - Reorder/drop stack (TUI): `gg reorder` (or `gg arrange`) — opens interactive TUI for visual reordering and dropping commits. Press `d` to mark a commit for dropping. Use `--no-tui` to fall back to text editor (delete lines to drop).
 - Reorder stack (direct): `gg reorder -o "3,1,2"`
 - Sync subset: `gg sync -u <position|gg-id|sha> --json`
+- Sync with streaming progress: `gg sync --jsonl`
 - Lint stack: `gg lint --json`
 - Run a command across the stack: `gg run -- <cmd...>` (see below)
 - Triage multiple stacks at once: `gg inbox --json`

--- a/skills/gg/reference.md
+++ b/skills/gg/reference.md
@@ -110,7 +110,9 @@ Push and create/update PRs/MRs.
 - `--no-rebase-check`
 - `--no-verify`: Skip the pre-push hook for pushes performed by this sync (forwards `git push --no-verify`)
 - `-u, --until <UNTIL>`
-- `--json`
+- `--json` — emit a single aggregate `SyncResponse` at the end
+- `--jsonl` — emit streaming NDJSON events (one per line, flushed after each); see
+  `docs/src/commands/sync.md` for the event schema
 
 If a mapped PR/MR's source branch no longer matches the current entry branch
 (for example after `gg unstack` moved entries to a new stack name), `gg sync`


### PR DESCRIPTION
## Summary
- add streaming NDJSON output infrastructure for gg sync via --jsonl
- emit structured sync progress, error, and final summary events while preserving --json output
- document --json vs --jsonl guidance for users and agents

## Tests
- cargo fmt --all
- cargo test -p gg-core output
- cargo test -p gg-cli --test integration_tests sync