### PR TITLE
Add native client protocols for stacked workflows

### DIFF
--- a/crates/gg-cli/src/main.rs
+++ b/crates/gg-cli/src/main.rs
@@ -215,9 +215,18 @@ enum Commands {
         #[arg(
             long,
             requires = "json",
-            conflicts_with_all = ["message", "no_edit", "no_tui", "files"]
+            conflicts_with_all = ["plan_json", "message", "no_edit", "no_tui", "files"]
         )]
         describe: bool,
+
+        /// Apply a previously described split plan from JSON
+        #[arg(
+            long,
+            value_name = "PATH",
+            requires = "json",
+            conflicts_with_all = ["describe", "message", "no_edit", "no_tui", "files"]
+        )]
+        plan_json: Option<std::path::PathBuf>,
 
         /// Emit machine-readable JSON output
         #[arg(long)]
@@ -631,6 +640,7 @@ fn main() {
             no_tui,
             force,
             describe,
+            plan_json,
             json,
             files,
         }) => (
@@ -642,9 +652,10 @@ fn main() {
                 no_tui,
                 force,
                 describe,
+                plan_json: plan_json.clone(),
                 json,
             }),
-            describe,
+            describe || plan_json.is_some(),
             false,
         ),
         Some(Commands::Unstack {

--- a/crates/gg-cli/src/main.rs
+++ b/crates/gg-cli/src/main.rs
@@ -180,6 +180,10 @@ enum Commands {
         #[arg(short, long)]
         all: bool,
 
+        /// Squash staged changes only, ignoring defaults.unstaged_action
+        #[arg(long, conflicts_with = "all")]
+        staged_only: bool,
+
         /// Override the immutability check and rewrite merged/base commits anyway
         #[arg(short = 'f', long = "force", alias = "ignore-immutable")]
         force: bool,
@@ -639,9 +643,15 @@ fn main() {
         Some(Commands::Last) => (gg_core::commands::nav::last(), false, false),
         Some(Commands::Prev) => (gg_core::commands::nav::prev(), false, false),
         Some(Commands::Next) => (gg_core::commands::nav::next(), false, false),
-        Some(Commands::Squash { all, force }) => {
-            (gg_core::commands::squash::run(all, force), false, false)
-        }
+        Some(Commands::Squash {
+            all,
+            staged_only,
+            force,
+        }) => (
+            gg_core::commands::squash::run(all, staged_only, force),
+            false,
+            false,
+        ),
         Some(Commands::Drop {
             targets,
             force,

--- a/crates/gg-cli/src/main.rs
+++ b/crates/gg-cli/src/main.rs
@@ -252,6 +252,7 @@ enum Commands {
         #[arg(
             long,
             requires = "json",
+            group = "structured_split",
             conflicts_with_all = ["plan_json", "message", "no_edit", "no_tui", "files"]
         )]
         describe: bool,
@@ -261,12 +262,13 @@ enum Commands {
             long,
             value_name = "PATH",
             requires = "json",
+            group = "structured_split",
             conflicts_with_all = ["describe", "message", "no_edit", "no_tui", "files"]
         )]
         plan_json: Option<std::path::PathBuf>,
 
-        /// Emit machine-readable JSON output
-        #[arg(long)]
+        /// Emit machine-readable output for --describe or --plan-json
+        #[arg(long, requires = "structured_split")]
         json: bool,
 
         /// Files to include in the new commit

--- a/crates/gg-cli/src/main.rs
+++ b/crates/gg-cli/src/main.rs
@@ -16,8 +16,41 @@ use console::style;
     long_about = None
 )]
 struct Cli {
+    /// Add a native-client token to an operation record, if this command creates one
+    #[arg(
+        long,
+        global = true,
+        value_name = "ID",
+        value_parser = parse_client_operation_id
+    )]
+    _client_operation_id: Option<String>,
+
     #[clap(subcommand)]
     command: Option<Commands>,
+}
+
+const MAX_CLIENT_OPERATION_ID_LEN: usize = 128;
+
+fn parse_client_operation_id(value: &str) -> Result<String, String> {
+    if value.is_empty() {
+        return Err("client operation id must not be empty".to_string());
+    }
+    if value.len() > MAX_CLIENT_OPERATION_ID_LEN {
+        return Err(format!(
+            "client operation id must be at most {MAX_CLIENT_OPERATION_ID_LEN} characters"
+        ));
+    }
+    if !value
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b':'))
+    {
+        return Err(
+            "client operation id may contain only ASCII letters, digits, '-', '_', '.', and ':'"
+                .to_string(),
+        );
+    }
+
+    Ok(value.to_string())
 }
 
 #[derive(Subcommand, Debug)]

--- a/crates/gg-cli/src/main.rs
+++ b/crates/gg-cli/src/main.rs
@@ -266,6 +266,10 @@ enum Commands {
         /// Create or reuse a managed worktree for the new stack
         #[arg(long = "worktree", short = 'w', alias = "wt")]
         worktree: bool,
+
+        /// Leave this worktree on the lower stack without creating an upper worktree
+        #[arg(long, conflicts_with = "worktree")]
+        keep_current: bool,
     },
 
     /// Land (merge) approved PRs/MRs starting from the first commit
@@ -665,6 +669,7 @@ fn main() {
             force,
             json,
             worktree,
+            keep_current,
         }) => (
             gg_core::commands::unstack::run(gg_core::commands::unstack::UnstackOptions {
                 target,
@@ -673,6 +678,7 @@ fn main() {
                 force,
                 json,
                 worktree,
+                keep_current,
             }),
             json,
             false,

--- a/crates/gg-cli/src/main.rs
+++ b/crates/gg-cli/src/main.rs
@@ -211,6 +211,18 @@ enum Commands {
         #[arg(short = 'f', long = "force", alias = "ignore-immutable")]
         force: bool,
 
+        /// Describe the target commit's split hunks as JSON
+        #[arg(
+            long,
+            requires = "json",
+            conflicts_with_all = ["message", "no_edit", "no_tui", "files"]
+        )]
+        describe: bool,
+
+        /// Emit machine-readable JSON output
+        #[arg(long)]
+        json: bool,
+
         /// Files to include in the new commit
         #[arg(value_name = "FILES")]
         files: Vec<String>,
@@ -618,6 +630,8 @@ fn main() {
             no_edit,
             no_tui,
             force,
+            describe,
+            json,
             files,
         }) => (
             gg_core::commands::split::run(gg_core::commands::split::SplitOptions {
@@ -627,8 +641,10 @@ fn main() {
                 no_edit,
                 no_tui,
                 force,
+                describe,
+                json,
             }),
-            false,
+            describe,
             false,
         ),
         Some(Commands::Unstack {

--- a/crates/gg-cli/tests/integration_tests/clean.rs
+++ b/crates/gg-cli/tests/integration_tests/clean.rs
@@ -785,6 +785,268 @@ exit 1
 }
 
 #[test]
+fn test_land_already_merged_auto_clean_records_branch_deletion_and_refuses_undo() {
+    let (_temp_dir, repo_path, remote_path) = create_test_repo_with_remote();
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).unwrap();
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser","base":"main","provider":"github"}}"#,
+    )
+    .unwrap();
+    let (success, _, stderr) = run_gg(&repo_path, &["co", "land-already-merged-clean"]);
+    assert!(success, "checkout failed: {stderr}");
+    fs::write(repo_path.join("feature.txt"), "feature\n").unwrap();
+    run_git(&repo_path, &["add", "."]);
+    run_git(
+        &repo_path,
+        &["commit", "-m", "feat: already merged\n\nGG-ID: c-b1c2d3e"],
+    );
+
+    let entry_branch = "testuser/land-already-merged-clean--c-b1c2d3e";
+    run_git(&repo_path, &["branch", entry_branch]);
+    let (success, _, stderr) = run_git_full(&repo_path, &["push", "-u", "origin", entry_branch]);
+    assert!(success, "entry push failed: {stderr}");
+    let (_, prior_oid) = run_git(&repo_path, &["rev-parse", entry_branch]);
+    let prior_oid = prior_oid.trim().to_string();
+
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{
+  "defaults": {
+    "branch_username": "testuser",
+    "base": "main",
+    "provider": "github"
+  },
+  "stacks": {
+    "land-already-merged-clean": {
+      "base": "main",
+      "mrs": { "c-b1c2d3e": 77 }
+    }
+  }
+}"#,
+    )
+    .unwrap();
+
+    let fake_bin = repo_path.join("fake-bin-land-already-merged");
+    fs::create_dir_all(&fake_bin).unwrap();
+    fs::write(
+        fake_bin.join("gh"),
+        r#"#!/bin/sh
+set -eu
+if [ "$1" = "--version" ]; then
+  echo "gh version 2.0.0"
+  exit 0
+fi
+if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
+  exit 0
+fi
+if [ "$1" = "pr" ] && [ "$2" = "view" ] && [ "$3" = "77" ]; then
+  echo '{"number":77,"title":"Already merged","state":"MERGED","url":"https://github.com/test/repo/pull/77","headRefName":"testuser/land-already-merged-clean--c-b1c2d3e","isDraft":false,"mergeable":"MERGEABLE","reviews":[]}'
+  exit 0
+fi
+echo "unexpected gh invocation: $@" >&2
+exit 1
+"#,
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        let mut permissions = fs::metadata(fake_bin.join("gh")).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(fake_bin.join("gh"), permissions).unwrap();
+    }
+    let old_path = std::env::var_os("PATH").unwrap_or_default();
+    let mut path = std::ffi::OsString::from(fake_bin.as_os_str());
+    path.push(":");
+    path.push(old_path);
+
+    let (success, stdout, stderr) = run_gg_with_env(
+        &repo_path,
+        &["land", "--all", "--clean", "--json"],
+        &[("PATH", path.as_os_str())],
+    );
+    assert!(success, "land failed: stdout={stdout} stderr={stderr}");
+    let land_result: Value = serde_json::from_str(&stdout).expect("land output must be JSON");
+    assert_eq!(land_result["land"]["cleaned"], true);
+
+    let remote_ref = format!("refs/heads/{entry_branch}");
+    let output = Command::new("git")
+        .args([
+            "--git-dir",
+            remote_path.to_str().unwrap(),
+            "show-ref",
+            &remote_ref,
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !output.status.success(),
+        "auto-clean must delete remote entry branch"
+    );
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["undo", "--list", "--json"]);
+    assert!(success, "undo list failed: {stderr}");
+    let listed: Value = serde_json::from_str(&stdout).unwrap();
+    let land_record = listed["operations"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|record| record["kind"] == "land")
+        .expect("Land operation must be recorded");
+    assert_eq!(land_record["touched_remote"], true);
+    assert_eq!(land_record["is_undoable"], false);
+    let deletion = land_record["remote_effects"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|effect| effect["kind"] == "branch_deleted")
+        .expect("Land must retain auto-clean branch deletion effect");
+    assert_eq!(deletion["branch"], entry_branch);
+    assert_eq!(deletion["prior_oid"], prior_oid);
+    let operation_id = land_record["id"].as_str().unwrap();
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["undo", operation_id, "--json"]);
+    assert!(!success, "undo must refuse Land remote effect: {stderr}");
+    let refused: Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(refused["refusal"]["reason"], "remote");
+}
+
+#[test]
+fn test_clean_records_remote_branch_deletion_and_undo_refuses_with_recovery_hint() {
+    let (_temp_dir, repo_path, remote_path) = create_test_repo_with_remote();
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser","base":"main","provider":"github"}}"#,
+    )
+    .expect("Failed to write config");
+
+    let (success, _, stderr) = run_gg(&repo_path, &["co", "clean-remote-effect"]);
+    assert!(success, "Failed to create stack: {stderr}");
+    fs::write(repo_path.join("feature.txt"), "feature\n").unwrap();
+    run_git(&repo_path, &["add", "."]);
+    run_git(
+        &repo_path,
+        &["commit", "-m", "feat: remote effect\n\nGG-ID: c-a1b2c3d"],
+    );
+
+    let entry_branch = "testuser/clean-remote-effect--c-a1b2c3d";
+    run_git(&repo_path, &["branch", entry_branch]);
+    let (success, _, stderr) = run_git_full(&repo_path, &["push", "-u", "origin", entry_branch]);
+    assert!(success, "Failed to push entry branch: {stderr}");
+    let (success, prior_oid) = run_git(&repo_path, &["rev-parse", entry_branch]);
+    assert!(success);
+    let prior_oid = prior_oid.trim().to_string();
+
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{
+  "defaults": {
+    "branch_username": "testuser",
+    "base": "main",
+    "provider": "github"
+  },
+  "stacks": {
+    "clean-remote-effect": {
+      "base": "main",
+      "mrs": { "c-a1b2c3d": 42 }
+    }
+  }
+}"#,
+    )
+    .unwrap();
+
+    let fake_bin = repo_path.join("fake-bin-clean-effect");
+    fs::create_dir_all(&fake_bin).unwrap();
+    fs::write(
+        fake_bin.join("gh"),
+        r#"#!/bin/sh
+set -eu
+if [ "$1" = "--version" ]; then
+  echo "gh version 2.0.0"
+  exit 0
+fi
+if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
+  exit 0
+fi
+if [ "$1" = "pr" ] && [ "$2" = "view" ] && [ "$3" = "42" ]; then
+  echo '{"number":42,"title":"Remote effect","state":"MERGED","url":"https://github.com/test/repo/pull/42","headRefName":"testuser/clean-remote-effect--c-a1b2c3d","isDraft":false,"mergeable":"MERGEABLE","reviews":[]}'
+  exit 0
+fi
+echo "unexpected gh invocation: $@" >&2
+exit 1
+"#,
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        let mut permissions = fs::metadata(fake_bin.join("gh")).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(fake_bin.join("gh"), permissions).unwrap();
+    }
+    let old_path = std::env::var_os("PATH").unwrap_or_default();
+    let mut path = std::ffi::OsString::from(fake_bin.as_os_str());
+    path.push(":");
+    path.push(old_path);
+
+    let (success, stdout, stderr) = run_gg_with_env(
+        &repo_path,
+        &["clean", "--all", "--json"],
+        &[("PATH", path.as_os_str())],
+    );
+    assert!(success, "clean failed: stdout={stdout} stderr={stderr}");
+
+    let remote_ref = format!("refs/heads/{entry_branch}");
+    let output = Command::new("git")
+        .args([
+            "--git-dir",
+            remote_path.to_str().unwrap(),
+            "show-ref",
+            &remote_ref,
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !output.status.success(),
+        "remote entry branch must be deleted"
+    );
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["undo", "--list", "--json"]);
+    assert!(success, "undo list failed: {stderr}");
+    let listed: Value = serde_json::from_str(&stdout).expect("undo list must be JSON");
+    let clean_record = listed["operations"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|record| record["kind"] == "clean")
+        .expect("clean operation must be listed");
+    assert_eq!(clean_record["touched_remote"], true);
+    assert_eq!(clean_record["is_undoable"], false);
+    assert_eq!(clean_record["remote_effects"][0]["kind"], "branch_deleted");
+    assert_eq!(clean_record["remote_effects"][0]["remote"], "origin");
+    assert_eq!(clean_record["remote_effects"][0]["branch"], entry_branch);
+    assert_eq!(clean_record["remote_effects"][0]["prior_oid"], prior_oid);
+    let operation_id = clean_record["id"].as_str().unwrap().to_string();
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["undo", &operation_id, "--json"]);
+    assert!(!success, "undo must refuse remote deletion: {stderr}");
+    let refused: Value = serde_json::from_str(&stdout).expect("undo refusal must be JSON");
+    assert_eq!(refused["status"], "refused");
+    assert_eq!(refused["refusal"]["reason"], "remote");
+    let hints = refused["refusal"]["hints"].as_array().unwrap();
+    let restore = format!("git push origin {prior_oid}:refs/heads/{entry_branch}");
+    assert!(
+        hints
+            .iter()
+            .filter_map(Value::as_str)
+            .any(|hint| hint.contains(&restore)),
+        "recovery hint must preserve the deleted branch restore command: {hints:?}"
+    );
+}
+
+#[test]
 fn test_gg_clean_current_branch_with_main_in_linked_worktree() {
     // Regression: gg clean crashed when user is on the stack branch and
     // main is checked out in a linked worktree.

--- a/crates/gg-cli/tests/integration_tests/ls.rs
+++ b/crates/gg-cli/tests/integration_tests/ls.rs
@@ -114,6 +114,10 @@ fn test_gg_ls_json_current_stack() {
 
     let parsed: Value = serde_json::from_str(&stdout).expect("stdout must be valid JSON");
     assert_eq!(parsed["version"], 1);
+    assert!(
+        parsed.get("operation_id").is_none(),
+        "normal stack output must omit operation_id: {parsed:?}"
+    );
     assert_eq!(parsed["stack"]["name"], "json-stack");
     let base = parsed["stack"]["base"]
         .as_str()
@@ -130,6 +134,268 @@ fn test_gg_ls_json_current_stack() {
     assert_eq!(entries.len(), 1);
     assert_eq!(entries[0]["position"], 1);
     assert_eq!(entries[0]["title"], "Add file1");
+}
+
+#[test]
+fn test_gg_ls_json_reports_valid_interrupted_rebase_operation_id() {
+    let (_temp_dir, repo_path) = create_test_repo();
+    setup_json_stack(&repo_path, "paused-json-stack");
+
+    let operation_id = latest_operation_id(&repo_path);
+    set_operation_status(&repo_path, &operation_id, "pending");
+    write_rebase_state(
+        &repo_path,
+        "refs/heads/testuser/paused-json-stack",
+        "aaaa",
+        "bbbb",
+    );
+    write_interrupted_rebase_marker(
+        &repo_path,
+        &operation_id,
+        "refs/heads/testuser/paused-json-stack",
+        "aaaa",
+        "bbbb",
+    );
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["ls", "--json"]);
+    assert!(success, "gg ls --json failed: {stderr}");
+
+    let parsed: Value = serde_json::from_str(&stdout).expect("stdout must be valid JSON");
+    assert_eq!(parsed["operation_id"], operation_id);
+}
+
+#[test]
+fn test_gg_ls_json_clears_legacy_interrupted_rebase_marker_without_state() {
+    let (_temp_dir, repo_path) = create_test_repo();
+    setup_json_stack(&repo_path, "legacy-marker-json-stack");
+
+    let operation_id = latest_operation_id(&repo_path);
+    set_operation_status(&repo_path, &operation_id, "pending");
+    write_raw_interrupted_rebase_marker(
+        &repo_path,
+        serde_json::to_vec_pretty(&serde_json::json!({
+            "operation_id": operation_id,
+        }))
+        .expect("marker must serialize"),
+    );
+
+    assert_stale_marker_is_omitted_and_cleared(&repo_path);
+}
+
+#[test]
+fn test_gg_ls_json_clears_malformed_interrupted_rebase_marker() {
+    let (_temp_dir, repo_path) = create_test_repo();
+    setup_json_stack(&repo_path, "malformed-marker-json-stack");
+    write_raw_interrupted_rebase_marker(&repo_path, b"{not json".to_vec());
+
+    assert_stale_marker_is_omitted_and_cleared(&repo_path);
+}
+
+#[test]
+fn test_gg_ls_json_clears_interrupted_rebase_marker_with_missing_record() {
+    let (_temp_dir, repo_path) = create_test_repo();
+    setup_json_stack(&repo_path, "missing-record-json-stack");
+    write_rebase_state(
+        &repo_path,
+        "refs/heads/testuser/missing-record-json-stack",
+        "aaaa",
+        "bbbb",
+    );
+    write_interrupted_rebase_marker(
+        &repo_path,
+        "op_1000000000000_00000000000000000000000000000000",
+        "refs/heads/testuser/missing-record-json-stack",
+        "aaaa",
+        "bbbb",
+    );
+
+    assert_stale_marker_is_omitted_and_cleared(&repo_path);
+}
+
+#[test]
+fn test_gg_ls_json_clears_interrupted_rebase_marker_for_committed_record() {
+    let (_temp_dir, repo_path) = create_test_repo();
+    setup_json_stack(&repo_path, "committed-record-json-stack");
+
+    let operation_id = latest_operation_id(&repo_path);
+    write_rebase_state(
+        &repo_path,
+        "refs/heads/testuser/committed-record-json-stack",
+        "aaaa",
+        "bbbb",
+    );
+    write_interrupted_rebase_marker(
+        &repo_path,
+        &operation_id,
+        "refs/heads/testuser/committed-record-json-stack",
+        "aaaa",
+        "bbbb",
+    );
+
+    assert_stale_marker_is_omitted_and_cleared(&repo_path);
+}
+
+#[test]
+fn test_gg_ls_json_clears_interrupted_rebase_marker_for_unsupported_record_schema() {
+    let (_temp_dir, repo_path) = create_test_repo();
+    setup_json_stack(&repo_path, "future-record-json-stack");
+
+    let operation_id = latest_operation_id(&repo_path);
+    set_operation_status(&repo_path, &operation_id, "pending");
+    set_operation_schema(&repo_path, &operation_id, 999);
+    write_rebase_state(
+        &repo_path,
+        "refs/heads/testuser/future-record-json-stack",
+        "aaaa",
+        "bbbb",
+    );
+    write_interrupted_rebase_marker(
+        &repo_path,
+        &operation_id,
+        "refs/heads/testuser/future-record-json-stack",
+        "aaaa",
+        "bbbb",
+    );
+
+    assert_stale_marker_is_omitted_and_cleared(&repo_path);
+}
+
+#[test]
+fn test_gg_ls_json_omits_stale_interrupted_rebase_operation_id() {
+    let (_temp_dir, repo_path) = create_test_repo();
+    setup_json_stack(&repo_path, "stale-json-stack");
+
+    let operation_id = latest_operation_id(&repo_path);
+    write_rebase_state(
+        &repo_path,
+        "refs/heads/testuser/stale-json-stack",
+        "aaaa",
+        "current",
+    );
+    write_interrupted_rebase_marker(
+        &repo_path,
+        &operation_id,
+        "refs/heads/testuser/stale-json-stack",
+        "aaaa",
+        "stale",
+    );
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["ls", "--json"]);
+    assert!(success, "gg ls --json failed: {stderr}");
+
+    let parsed: Value = serde_json::from_str(&stdout).expect("stdout must be valid JSON");
+    assert!(
+        parsed.get("operation_id").is_none(),
+        "stale operation markers must be omitted: {parsed:?}"
+    );
+    assert!(
+        !repo_path
+            .join(".git/gg/interrupted-rebase-operation.json")
+            .exists(),
+        "validating a stale marker must clear it"
+    );
+}
+
+fn setup_json_stack(repo_path: &std::path::Path, stack_name: &str) {
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .expect("Failed to write config");
+
+    let (success, _stdout, stderr) = run_gg(repo_path, &["co", stack_name]);
+    assert!(success, "Failed to create stack: {stderr}");
+}
+
+fn latest_operation_id(repo_path: &std::path::Path) -> String {
+    fs::read_dir(repo_path.join(".git/gg/operations"))
+        .expect("checkout must create an operation record")
+        .filter_map(|entry| entry.ok())
+        .filter_map(|entry| fs::read(entry.path()).ok())
+        .filter_map(|bytes| serde_json::from_slice::<Value>(&bytes).ok())
+        .filter_map(|record| record["id"].as_str().map(ToOwned::to_owned))
+        .max()
+        .expect("checkout operation id must exist")
+}
+
+fn set_operation_status(repo_path: &std::path::Path, operation_id: &str, status: &str) {
+    let path = repo_path
+        .join(".git/gg/operations")
+        .join(format!("{operation_id}.json"));
+    let mut record: Value =
+        serde_json::from_slice(&fs::read(&path).expect("operation record must be readable"))
+            .expect("operation record must be valid JSON");
+    record["status"] = Value::String(status.to_string());
+    fs::write(
+        path,
+        serde_json::to_vec_pretty(&record).expect("operation record must serialize"),
+    )
+    .expect("Failed to update operation status");
+}
+
+fn set_operation_schema(repo_path: &std::path::Path, operation_id: &str, schema_version: u32) {
+    let path = repo_path
+        .join(".git/gg/operations")
+        .join(format!("{operation_id}.json"));
+    let mut record: Value = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+    record["schema_version"] = Value::from(schema_version);
+    fs::write(path, serde_json::to_vec_pretty(&record).unwrap()).unwrap();
+}
+
+fn write_rebase_state(repo_path: &std::path::Path, head_name: &str, orig_head: &str, onto: &str) {
+    let rebase_dir = repo_path.join(".git/rebase-merge");
+    fs::create_dir_all(&rebase_dir).expect("Failed to create rebase state");
+    fs::write(rebase_dir.join("head-name"), head_name).expect("Failed to write head-name");
+    fs::write(rebase_dir.join("orig-head"), orig_head).expect("Failed to write orig-head");
+    fs::write(rebase_dir.join("onto"), onto).expect("Failed to write onto");
+}
+
+fn write_interrupted_rebase_marker(
+    repo_path: &std::path::Path,
+    operation_id: &str,
+    head_name: &str,
+    orig_head: &str,
+    onto: &str,
+) {
+    let marker = serde_json::json!({
+        "operation_id": operation_id,
+        "rebase_state": {
+            "head_name": head_name,
+            "orig_head": orig_head,
+            "onto": onto,
+        }
+    });
+    write_raw_interrupted_rebase_marker(
+        repo_path,
+        serde_json::to_vec_pretty(&marker).expect("marker must serialize"),
+    );
+}
+
+fn write_raw_interrupted_rebase_marker(repo_path: &std::path::Path, bytes: Vec<u8>) {
+    fs::write(
+        repo_path.join(".git/gg/interrupted-rebase-operation.json"),
+        bytes,
+    )
+    .expect("Failed to write interrupted rebase marker");
+}
+
+fn assert_stale_marker_is_omitted_and_cleared(repo_path: &std::path::Path) {
+    let (success, stdout, stderr) = run_gg(repo_path, &["ls", "--json"]);
+    assert!(success, "gg ls --json failed: {stderr}");
+
+    let parsed: Value = serde_json::from_str(&stdout).expect("stdout must be valid JSON");
+    assert!(
+        parsed.get("operation_id").is_none(),
+        "stale operation markers must be omitted: {parsed:?}"
+    );
+    assert!(
+        !repo_path
+            .join(".git/gg/interrupted-rebase-operation.json")
+            .exists(),
+        "validating a stale marker must clear it"
+    );
 }
 
 #[test]

--- a/crates/gg-cli/tests/integration_tests/ls.rs
+++ b/crates/gg-cli/tests/integration_tests/ls.rs
@@ -165,6 +165,38 @@ fn test_gg_ls_json_reports_valid_interrupted_rebase_operation_id() {
 }
 
 #[test]
+fn test_gg_ls_json_reports_interrupted_rebase_operation_id_while_head_is_detached() {
+    let (_temp_dir, repo_path) = create_test_repo();
+    setup_json_stack(&repo_path, "detached-paused-json-stack");
+
+    let operation_id = latest_operation_id(&repo_path);
+    set_operation_status(&repo_path, &operation_id, "pending");
+    write_rebase_state(
+        &repo_path,
+        "refs/heads/testuser/detached-paused-json-stack",
+        "aaaa",
+        "bbbb",
+    );
+    write_interrupted_rebase_marker(
+        &repo_path,
+        &operation_id,
+        "refs/heads/testuser/detached-paused-json-stack",
+        "aaaa",
+        "bbbb",
+    );
+    run_git(&repo_path, &["checkout", "--detach"]);
+    let _ = fs::remove_file(repo_path.join(".git/gg/current_stack"));
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["ls", "--json"]);
+    assert!(success, "gg ls --json failed: {stderr}");
+
+    let parsed: Value = serde_json::from_str(&stdout).expect("stdout must be valid JSON");
+    assert_eq!(parsed["current_stack"], Value::Null);
+    assert!(parsed["stacks"].is_array(), "expected all-stacks response");
+    assert_eq!(parsed["operation_id"], operation_id);
+}
+
+#[test]
 fn test_gg_ls_json_clears_legacy_interrupted_rebase_marker_without_state() {
     let (_temp_dir, repo_path) = create_test_repo();
     setup_json_stack(&repo_path, "legacy-marker-json-stack");

--- a/crates/gg-cli/tests/integration_tests/misc.rs
+++ b/crates/gg-cli/tests/integration_tests/misc.rs
@@ -12,6 +12,106 @@ fn test_gg_help() {
     assert!(stdout.contains("co"));
     assert!(stdout.contains("sync"));
     assert!(stdout.contains("ls"));
+    assert!(
+        stdout.contains("--client-operation-id <ID>"),
+        "root help must advertise native-client operation correlation: {stdout}"
+    );
+}
+
+#[test]
+fn test_client_operation_id_help_is_truthful_for_non_recording_commands() {
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    for args in [
+        vec!["--help"],
+        vec!["ls", "--help"],
+        vec!["continue", "--help"],
+        vec!["abort", "--help"],
+    ] {
+        let (success, stdout, stderr) = run_gg(&repo_path, &args);
+        assert!(success, "help failed for {args:?}: {stderr}");
+        assert!(
+            stdout.contains("--client-operation-id <ID>"),
+            "global option missing from help for {args:?}: {stdout}"
+        );
+        assert!(
+            stdout.contains("if this command") && stdout.contains("creates one"),
+            "help must not promise an operation record for {args:?}: {stdout}"
+        );
+    }
+}
+
+#[test]
+fn test_client_operation_id_is_preserved_in_mutation_record() {
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .expect("Failed to write config");
+
+    let client_id = "alas:018f84c0-3a14-7b45-a397-93c87266391d";
+    let (success, _stdout, stderr) = run_gg(
+        &repo_path,
+        &[
+            "co",
+            "correlated-operation",
+            "--client-operation-id",
+            client_id,
+        ],
+    );
+    assert!(success, "checkout mutation should succeed: {stderr}");
+
+    let operations_dir = gg_dir.join("operations");
+    let record = fs::read_dir(&operations_dir)
+        .expect("mutation must create the operation directory")
+        .filter_map(|entry| entry.ok())
+        .filter_map(|entry| fs::read(entry.path()).ok())
+        .filter_map(|bytes| serde_json::from_slice::<serde_json::Value>(&bytes).ok())
+        .find(|record| {
+            record["args"]
+                .as_array()
+                .is_some_and(|args| args.iter().any(|arg| arg == client_id))
+        })
+        .expect("mutation record must preserve the client operation id in raw args");
+
+    assert_eq!(
+        record["args"],
+        serde_json::json!([
+            "co",
+            "correlated-operation",
+            "--client-operation-id",
+            client_id
+        ])
+    );
+    assert!(
+        record["id"].as_str().is_some_and(
+            |operation_id| operation_id.starts_with("op_") && operation_id != client_id
+        ),
+        "the client token must not override GG's operation id: {record:?}"
+    );
+}
+
+#[test]
+fn test_client_operation_id_rejects_unsafe_tokens() {
+    let (_temp_dir, repo_path) = create_test_repo();
+    let oversized = "a".repeat(129);
+
+    for invalid in ["", "unsafe/value", "contains space", oversized.as_str()] {
+        let (success, stdout, stderr) =
+            run_gg(&repo_path, &["--client-operation-id", invalid, "ls"]);
+        assert!(
+            !success,
+            "unsafe client operation id must be rejected: {invalid:?}; stdout={stdout} stderr={stderr}"
+        );
+        assert!(
+            stderr.contains("client operation id"),
+            "validation error should identify the invalid field: {stderr}"
+        );
+    }
 }
 
 #[test]
@@ -31,16 +131,28 @@ fn test_completions() {
     let (success, stdout, _) = run_gg(&repo_path, &["completions", "bash"]);
     assert!(success);
     assert!(stdout.contains("_gg") || stdout.contains("complete"));
+    assert!(
+        stdout.contains("--client-operation-id"),
+        "bash completions must advertise the global native-client flag"
+    );
 
     // Test zsh completions
     let (success, stdout, _) = run_gg(&repo_path, &["completions", "zsh"]);
     assert!(success);
     assert!(stdout.contains("#compdef") || stdout.contains("_gg"));
+    assert!(
+        stdout.contains("--client-operation-id"),
+        "zsh completions must advertise the global native-client flag"
+    );
 
     // Test fish completions
     let (success, stdout, _) = run_gg(&repo_path, &["completions", "fish"]);
     assert!(success);
     assert!(stdout.contains("complete") || stdout.contains("gg"));
+    assert!(
+        stdout.contains("client-operation-id"),
+        "fish completions must advertise the global native-client flag"
+    );
 }
 
 #[test]

--- a/crates/gg-cli/tests/integration_tests/split.rs
+++ b/crates/gg-cli/tests/integration_tests/split.rs
@@ -48,6 +48,13 @@ fn create_two_hunk_split_commit() -> (tempfile::TempDir, std::path::PathBuf) {
     (temp_dir, repo_path)
 }
 
+fn create_text_only_two_hunk_split_commit() -> (tempfile::TempDir, std::path::PathBuf) {
+    let (temp_dir, repo_path) = create_two_hunk_split_commit();
+    assert!(run_git(&repo_path, &["rm", "binary.dat"]).0);
+    assert!(run_git(&repo_path, &["commit", "--amend", "--no-edit"]).0);
+    (temp_dir, repo_path)
+}
+
 fn create_byte_content_split_commit(
     stack_name: &str,
     file_name: &str,
@@ -842,6 +849,39 @@ fn test_split_plan_applies_selected_hunk_and_undo_restores_stack() {
 }
 
 #[test]
+fn test_split_plan_allows_all_text_hunks_when_non_textual_changes_remain() {
+    let (_temp_dir, repo_path) = create_two_hunk_split_commit();
+    let describe = describe_split(&repo_path, "1");
+    let selected = describe["hunks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|hunk| hunk["id"].clone())
+        .collect();
+    let plan_path = write_split_plan(&repo_path, &describe, selected);
+
+    let (success, stdout, stderr) = apply_split_plan(&repo_path, &plan_path);
+    assert!(success, "apply failed: stdout={stdout} stderr={stderr}");
+    let result: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let first_sha = result["first"]["sha"].as_str().unwrap();
+    let remainder_sha = result["remainder"]["sha"].as_str().unwrap();
+    assert!(
+        !run_git(
+            &repo_path,
+            &["cat-file", "-e", &format!("{first_sha}:binary.dat")]
+        )
+        .0
+    );
+    assert!(
+        run_git(
+            &repo_path,
+            &["cat-file", "-e", &format!("{remainder_sha}:binary.dat")]
+        )
+        .0
+    );
+}
+
+#[test]
 fn test_split_plan_rejects_stale_target_without_mutation() {
     let (_temp_dir, repo_path) = create_two_hunk_split_commit();
     let describe = describe_split(&repo_path, "1");
@@ -967,7 +1007,11 @@ fn test_split_plan_rejects_invalid_inputs_before_mutation() {
     ];
 
     for (name, selected_template) in invalid_cases {
-        let (_temp_dir, repo_path) = create_two_hunk_split_commit();
+        let (_temp_dir, repo_path) = if name == "all selected hunks" {
+            create_text_only_two_hunk_split_commit()
+        } else {
+            create_two_hunk_split_commit()
+        };
         let describe = describe_split(&repo_path, "1");
         let first_id = describe["hunks"][0]["id"].clone();
         let second_id = describe["hunks"][1]["id"].clone();

--- a/crates/gg-cli/tests/integration_tests/split.rs
+++ b/crates/gg-cli/tests/integration_tests/split.rs
@@ -975,6 +975,75 @@ fn test_split_plan_keeps_same_file_mode_change_in_remainder() {
 }
 
 #[test]
+#[cfg(unix)]
+fn test_split_plan_allows_metadata_only_remainder_for_selected_file() {
+    let (_temp_dir, repo_path) = create_test_repo();
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).unwrap();
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .unwrap();
+
+    fs::write(repo_path.join("script.sh"), "echo parent\n").unwrap();
+    run_git(&repo_path, &["add", "script.sh"]);
+    run_git(&repo_path, &["commit", "--amend", "--no-edit"]);
+    let (success, _, stderr) = run_gg(&repo_path, &["co", "metadata-only-remainder"]);
+    assert!(success, "create stack failed: {stderr}");
+
+    fs::write(repo_path.join("script.sh"), "echo target\n").unwrap();
+    let mut permissions = fs::metadata(repo_path.join("script.sh"))
+        .unwrap()
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(repo_path.join("script.sh"), permissions).unwrap();
+    run_git(&repo_path, &["add", "script.sh"]);
+    run_git(
+        &repo_path,
+        &[
+            "commit",
+            "-m",
+            "Content and mode change\n\nGG-ID: c-meta123",
+        ],
+    );
+
+    let describe = describe_split(&repo_path, "1");
+    assert_eq!(describe["hunks"].as_array().unwrap().len(), 1);
+    let plan_path = write_split_plan(
+        &repo_path,
+        &describe,
+        vec![describe["hunks"][0]["id"].clone()],
+    );
+
+    let (success, stdout, stderr) = apply_split_plan(&repo_path, &plan_path);
+    assert!(success, "apply failed: stdout={stdout} stderr={stderr}");
+    let result: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let first_sha = result["first"]["sha"].as_str().unwrap();
+    let remainder_sha = result["remainder"]["sha"].as_str().unwrap();
+    assert_eq!(
+        run_git_full(&repo_path, &["show", &format!("{first_sha}:script.sh")]).1,
+        "echo target\n"
+    );
+    assert_eq!(
+        run_git_full(&repo_path, &["show", &format!("{remainder_sha}:script.sh")]).1,
+        "echo target\n"
+    );
+    assert!(
+        run_git_full(&repo_path, &["ls-tree", first_sha, "script.sh"])
+            .1
+            .starts_with("100644 "),
+        "first commit must retain the parent file mode"
+    );
+    assert!(
+        run_git_full(&repo_path, &["ls-tree", remainder_sha, "script.sh"])
+            .1
+            .starts_with("100755 "),
+        "remainder must contain the target file mode"
+    );
+}
+
+#[test]
 fn test_split_plan_rejects_stale_target_without_mutation() {
     let (_temp_dir, repo_path) = create_two_hunk_split_commit();
     let describe = describe_split(&repo_path, "1");

--- a/crates/gg-cli/tests/integration_tests/split.rs
+++ b/crates/gg-cli/tests/integration_tests/split.rs
@@ -3,7 +3,7 @@ use crate::helpers::{create_test_repo, run_gg, run_gg_with_env, run_git, run_git
 use std::fs;
 use std::io::Write;
 #[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{symlink, PermissionsExt};
 use std::path::Path;
 use std::process::{Command, Stdio};
 
@@ -46,6 +46,223 @@ fn create_two_hunk_split_commit() -> (tempfile::TempDir, std::path::PathBuf) {
     );
 
     (temp_dir, repo_path)
+}
+
+fn create_byte_content_split_commit(
+    stack_name: &str,
+    file_name: &str,
+    initial: &[u8],
+    modified: &[u8],
+) -> (tempfile::TempDir, std::path::PathBuf) {
+    let (temp_dir, repo_path) = create_test_repo();
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).unwrap();
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .unwrap();
+    run_git(&repo_path, &["config", "core.autocrlf", "false"]);
+
+    fs::write(repo_path.join(file_name), initial).unwrap();
+    run_git(&repo_path, &["add", file_name]);
+    run_git(&repo_path, &["commit", "--amend", "--no-edit"]);
+    let (success, _, stderr) = run_gg(&repo_path, &["co", stack_name]);
+    assert!(success, "create stack failed: {stderr}");
+
+    fs::write(repo_path.join(file_name), modified).unwrap();
+    run_git(&repo_path, &["add", file_name]);
+    run_git(
+        &repo_path,
+        &["commit", "-m", "Byte-sensitive change\n\nGG-ID: c-byt1234"],
+    );
+    (temp_dir, repo_path)
+}
+
+fn create_directory_to_file_split_commit(
+    stack_name: &str,
+) -> (tempfile::TempDir, std::path::PathBuf) {
+    let (temp_dir, repo_path) = create_test_repo();
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).unwrap();
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .unwrap();
+
+    let node_dir = repo_path.join("node");
+    fs::create_dir_all(&node_dir).unwrap();
+    fs::write(node_dir.join("last.txt"), "nested parent\n").unwrap();
+    fs::write(repo_path.join("remainder.txt"), "remainder parent\n").unwrap();
+    run_git(&repo_path, &["add", "node/last.txt", "remainder.txt"]);
+    run_git(&repo_path, &["commit", "--amend", "--no-edit"]);
+
+    let (success, _, stderr) = run_gg(&repo_path, &["co", stack_name]);
+    assert!(success, "create stack failed: {stderr}");
+    fs::remove_file(node_dir.join("last.txt")).unwrap();
+    fs::remove_dir(&node_dir).unwrap();
+    fs::write(&node_dir, "top-level target\n").unwrap();
+    fs::write(repo_path.join("remainder.txt"), "remainder target\n").unwrap();
+    run_git(&repo_path, &["add", "-A"]);
+    run_git(
+        &repo_path,
+        &["commit", "-m", "Directory to file\n\nGG-ID: c-node123"],
+    );
+
+    (temp_dir, repo_path)
+}
+
+fn create_file_to_directory_split_commit(
+    stack_name: &str,
+) -> (tempfile::TempDir, std::path::PathBuf) {
+    let (temp_dir, repo_path) = create_test_repo();
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).unwrap();
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .unwrap();
+
+    fs::write(repo_path.join("node"), "top-level parent\n").unwrap();
+    fs::write(repo_path.join("remainder.txt"), "remainder parent\n").unwrap();
+    run_git(&repo_path, &["add", "node", "remainder.txt"]);
+    run_git(&repo_path, &["commit", "--amend", "--no-edit"]);
+
+    let (success, _, stderr) = run_gg(&repo_path, &["co", stack_name]);
+    assert!(success, "create stack failed: {stderr}");
+    fs::remove_file(repo_path.join("node")).unwrap();
+    fs::create_dir(repo_path.join("node")).unwrap();
+    fs::write(repo_path.join("node/last.txt"), "nested target\n").unwrap();
+    fs::write(repo_path.join("remainder.txt"), "remainder target\n").unwrap();
+    run_git(&repo_path, &["add", "-A"]);
+    run_git(
+        &repo_path,
+        &["commit", "-m", "File to directory\n\nGG-ID: c-dir1234"],
+    );
+
+    (temp_dir, repo_path)
+}
+
+fn create_file_to_directory_with_non_textual_addition() -> (tempfile::TempDir, std::path::PathBuf) {
+    let (temp_dir, repo_path) = create_test_repo();
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).unwrap();
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .unwrap();
+
+    fs::write(repo_path.join("node"), "top-level parent\n").unwrap();
+    fs::write(repo_path.join("remainder.txt"), "remainder parent\n").unwrap();
+    run_git(&repo_path, &["add", "node", "remainder.txt"]);
+    run_git(&repo_path, &["commit", "--amend", "--no-edit"]);
+
+    let (success, _, stderr) = run_gg(&repo_path, &["co", "file-to-directory-non-textual"]);
+    assert!(success, "create stack failed: {stderr}");
+    fs::remove_file(repo_path.join("node")).unwrap();
+    fs::create_dir(repo_path.join("node")).unwrap();
+    fs::write(repo_path.join("node/last.bin"), b"invalid: \xff\n").unwrap();
+    fs::write(repo_path.join("remainder.txt"), "remainder target\n").unwrap();
+    run_git(&repo_path, &["add", "-A"]);
+    run_git(
+        &repo_path,
+        &[
+            "commit",
+            "-m",
+            "File to non-textual directory\n\nGG-ID: c-non1234",
+        ],
+    );
+
+    (temp_dir, repo_path)
+}
+
+fn create_directory_to_file_with_non_textual_deletion() -> (tempfile::TempDir, std::path::PathBuf) {
+    let (temp_dir, repo_path) = create_test_repo();
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).unwrap();
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .unwrap();
+
+    fs::create_dir(repo_path.join("node")).unwrap();
+    fs::write(repo_path.join("node/last.bin"), b"invalid: \xff\n").unwrap();
+    fs::write(repo_path.join("remainder.txt"), "remainder parent\n").unwrap();
+    run_git(&repo_path, &["add", "node/last.bin", "remainder.txt"]);
+    run_git(&repo_path, &["commit", "--amend", "--no-edit"]);
+
+    let (success, _, stderr) = run_gg(&repo_path, &["co", "non-textual-transition"]);
+    assert!(success, "create stack failed: {stderr}");
+    fs::remove_file(repo_path.join("node/last.bin")).unwrap();
+    fs::remove_dir(repo_path.join("node")).unwrap();
+    fs::write(repo_path.join("node"), "top-level target\n").unwrap();
+    fs::write(repo_path.join("remainder.txt"), "remainder target\n").unwrap();
+    run_git(&repo_path, &["add", "-A"]);
+    run_git(
+        &repo_path,
+        &["commit", "-m", "Non-textual transition\n\nGG-ID: c-bin1234"],
+    );
+
+    (temp_dir, repo_path)
+}
+
+fn eof_fixture_content(modified_line: bool, trailing_newline: bool) -> Vec<u8> {
+    let mut content = (1..=20)
+        .map(|line| {
+            if line == 2 && modified_line {
+                "line 2 modified".to_string()
+            } else {
+                format!("line {line}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+        .into_bytes();
+    if trailing_newline {
+        content.push(b'\n');
+    }
+    content
+}
+
+fn assert_structured_eof_newline_selection(parent_newline: bool, target_newline: bool) {
+    let parent = eof_fixture_content(false, parent_newline);
+    let target = eof_fixture_content(true, target_newline);
+    let (_temp_dir, repo_path) = create_byte_content_split_commit(
+        if target_newline {
+            "eof-newline-add"
+        } else {
+            "eof-newline-remove"
+        },
+        "eof.txt",
+        &parent,
+        &target,
+    );
+    let describe = describe_split(&repo_path, "1");
+    let eof_hunk = describe["hunks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|hunk| hunk["patch"].as_str().unwrap().contains("line 20"))
+        .expect("Describe should expose the EOF-newline hunk");
+    assert_eq!(describe["hunks"].as_array().unwrap().len(), 2);
+    let plan_path = write_split_plan(&repo_path, &describe, vec![eof_hunk["id"].clone()]);
+
+    let (success, stdout, stderr) = apply_split_plan(&repo_path, &plan_path);
+    assert!(success, "apply failed: stdout={stdout} stderr={stderr}");
+    let result: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let first_sha = result["first"]["sha"].as_str().unwrap();
+    let first_content = run_git_full(&repo_path, &["show", &format!("{first_sha}:eof.txt")])
+        .1
+        .into_bytes();
+    assert_eq!(
+        first_content,
+        eof_fixture_content(false, target_newline),
+        "first commit must contain only the selected EOF-newline change"
+    );
 }
 
 fn describe_split(repo_path: &Path, target: &str) -> serde_json::Value {
@@ -98,6 +315,472 @@ fn apply_split_plan(repo_path: &Path, plan_path: &Path) -> (bool, String, String
             "--json",
         ],
     )
+}
+
+fn assert_path_dependent_plan_rejected(
+    repo_path: &Path,
+    describe: &serde_json::Value,
+    selected_path: &str,
+) {
+    let selected_hunk = describe["hunks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|hunk| hunk["path"] == selected_path)
+        .unwrap_or_else(|| panic!("Describe should expose {selected_path}"));
+    let plan_path = write_split_plan(repo_path, describe, vec![selected_hunk["id"].clone()]);
+    let refs_before = run_git_full(repo_path, &["show-ref"]).1;
+    let operations_before = operation_records(repo_path);
+
+    let (success, stdout, stderr) = apply_split_plan(repo_path, &plan_path);
+    assert!(!success, "dependent plan unexpectedly applied: {stdout}");
+    let error: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(error["version"], 1);
+    assert!(
+        error["error"].as_str().unwrap().contains("path-dependent"),
+        "error should explain the dependency: {stdout}"
+    );
+    assert!(
+        stderr.is_empty(),
+        "structured error should use stdout: {stderr}"
+    );
+    assert_eq!(run_git_full(repo_path, &["show-ref"]).1, refs_before);
+    assert_eq!(operation_records(repo_path), operations_before);
+}
+
+fn assert_file_to_directory_deletion_only(
+    repo_path: &Path,
+    describe: &serde_json::Value,
+    target_child: &str,
+) {
+    let deletion_hunk = describe["hunks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|hunk| hunk["path"] == "node")
+        .expect("Describe should expose the top-level deletion hunk");
+    let plan_path = write_split_plan(repo_path, describe, vec![deletion_hunk["id"].clone()]);
+    let original_head = run_git_full(repo_path, &["rev-parse", "HEAD"]).1;
+    let operations_before = operation_records(repo_path);
+
+    let (success, stdout, stderr) = apply_split_plan(repo_path, &plan_path);
+    assert!(success, "apply failed: stdout={stdout} stderr={stderr}");
+    let result: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let first_sha = result["first"]["sha"].as_str().unwrap();
+    let remainder_sha = result["remainder"]["sha"].as_str().unwrap();
+    assert!(
+        !run_git(repo_path, &["cat-file", "-e", &format!("{first_sha}:node")]).0,
+        "deletion-only first commit must not copy the replacement directory"
+    );
+    assert_eq!(
+        run_git_full(
+            repo_path,
+            &["rev-parse", &format!("{remainder_sha}^{{tree}}")]
+        )
+        .1
+        .trim(),
+        describe["target"]["tree"].as_str().unwrap()
+    );
+    assert!(
+        run_git(
+            repo_path,
+            &["cat-file", "-e", &format!("{remainder_sha}:{target_child}")],
+        )
+        .0
+    );
+    assert_eq!(
+        operation_records(repo_path).len(),
+        operations_before.len() + 1
+    );
+
+    let operation_id = result["operation_id"].as_str().unwrap();
+    let (success, stdout, stderr) = run_gg(repo_path, &["undo", operation_id, "--json"]);
+    assert!(success, "undo failed: stdout={stdout} stderr={stderr}");
+    assert_eq!(
+        run_git_full(repo_path, &["rev-parse", "HEAD"]).1,
+        original_head
+    );
+}
+
+#[cfg(unix)]
+fn assert_same_path_type_change_is_non_textual(
+    stack_name: &str,
+    parent_is_symlink: bool,
+    invalid_regular: bool,
+) {
+    let (_temp_dir, repo_path) = create_test_repo();
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).unwrap();
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .unwrap();
+
+    let node_path = repo_path.join("node");
+    if parent_is_symlink {
+        symlink("parent-link-target", &node_path).unwrap();
+    } else if invalid_regular {
+        fs::write(&node_path, b"invalid parent: \xff\n").unwrap();
+    } else {
+        fs::write(&node_path, "regular parent\n").unwrap();
+    }
+    fs::write(repo_path.join("selected.txt"), "selected parent\n").unwrap();
+    fs::write(repo_path.join("remainder.txt"), "remainder parent\n").unwrap();
+    run_git(
+        &repo_path,
+        &["add", "node", "selected.txt", "remainder.txt"],
+    );
+    run_git(&repo_path, &["commit", "--amend", "--no-edit"]);
+
+    let (success, _, stderr) = run_gg(&repo_path, &["co", stack_name]);
+    assert!(success, "create stack failed: {stderr}");
+    fs::remove_file(&node_path).unwrap();
+    if parent_is_symlink {
+        fs::write(&node_path, "regular target\n").unwrap();
+    } else {
+        symlink("target-link-destination", &node_path).unwrap();
+    }
+    fs::write(repo_path.join("selected.txt"), "selected target\n").unwrap();
+    fs::write(repo_path.join("remainder.txt"), "remainder target\n").unwrap();
+    run_git(&repo_path, &["add", "-A"]);
+    run_git(
+        &repo_path,
+        &["commit", "-m", "Same-path type change\n\nGG-ID: c-type123"],
+    );
+
+    let original_head = run_git_full(&repo_path, &["rev-parse", "HEAD"]).1;
+    let describe = describe_split(&repo_path, "1");
+    assert!(!describe["hunks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|hunk| hunk["path"] == "node"));
+    assert_eq!(
+        describe["non_textual_files"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|path| **path == "node")
+            .count(),
+        1,
+        "type-change path must be classified exactly once"
+    );
+    let selected_hunk = describe["hunks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|hunk| hunk["path"] == "selected.txt")
+        .unwrap();
+    let plan_path = write_split_plan(&repo_path, &describe, vec![selected_hunk["id"].clone()]);
+
+    let (success, stdout, stderr) = apply_split_plan(&repo_path, &plan_path);
+    assert!(success, "apply failed: stdout={stdout} stderr={stderr}");
+    let result: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let first_sha = result["first"]["sha"].as_str().unwrap();
+    let remainder_sha = result["remainder"]["sha"].as_str().unwrap();
+    assert_eq!(
+        run_git_full(&repo_path, &["rev-parse", &format!("{first_sha}:node")]).1,
+        run_git_full(&repo_path, &["rev-parse", "main:node"]).1,
+        "type change must stay out of the first commit"
+    );
+    assert_eq!(
+        run_git_full(&repo_path, &["ls-tree", first_sha, "node"]).1,
+        run_git_full(&repo_path, &["ls-tree", "main", "node"]).1,
+        "first commit must preserve the parent node mode"
+    );
+    assert_eq!(
+        run_git_full(
+            &repo_path,
+            &["rev-parse", &format!("{remainder_sha}^{{tree}}")],
+        )
+        .1
+        .trim(),
+        describe["target"]["tree"].as_str().unwrap()
+    );
+
+    let operation_id = result["operation_id"].as_str().unwrap();
+    let (success, stdout, stderr) = run_gg(&repo_path, &["undo", operation_id, "--json"]);
+    assert!(success, "undo failed: stdout={stdout} stderr={stderr}");
+    assert_eq!(
+        run_git_full(&repo_path, &["rev-parse", "HEAD"]).1,
+        original_head
+    );
+}
+
+#[test]
+fn test_split_describe_classifies_crlf_file_as_non_textual() {
+    let initial = b"line 1\r\nline 2\r\nline 3\r\n";
+    let modified = b"line 1\r\nline 2 changed\r\nline 3\r\n";
+    let (_temp_dir, repo_path) =
+        create_byte_content_split_commit("crlf", "crlf.txt", initial, modified);
+
+    let describe = describe_split(&repo_path, "1");
+    assert!(describe["hunks"].as_array().unwrap().is_empty());
+    assert_eq!(
+        describe["non_textual_files"],
+        serde_json::json!(["crlf.txt"])
+    );
+}
+
+#[test]
+fn test_split_describe_classifies_invalid_utf8_file_as_non_textual() {
+    let initial = b"line 1\ninvalid: \xff\nline 3\n";
+    let modified = b"line 1 changed\ninvalid: \xff\nline 3\n";
+    let (_temp_dir, repo_path) =
+        create_byte_content_split_commit("invalid-utf8", "invalid.txt", initial, modified);
+
+    let describe = describe_split(&repo_path, "1");
+    assert!(describe["hunks"].as_array().unwrap().is_empty());
+    assert_eq!(
+        describe["non_textual_files"],
+        serde_json::json!(["invalid.txt"])
+    );
+}
+
+#[test]
+fn test_split_plan_selects_eof_newline_addition_exactly() {
+    assert_structured_eof_newline_selection(false, true);
+}
+
+#[test]
+fn test_split_plan_selects_eof_newline_removal_exactly() {
+    assert_structured_eof_newline_selection(true, false);
+}
+
+#[test]
+fn test_split_plan_composes_selected_nested_file_hunks_and_undoes() {
+    let (temp_dir, repo_path) = create_test_repo();
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).unwrap();
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .unwrap();
+
+    let nested_dir = repo_path.join("src/shared/deeper");
+    fs::create_dir_all(&nested_dir).unwrap();
+    fs::write(nested_dir.join("a.txt"), "a parent\n").unwrap();
+    fs::write(nested_dir.join("b.txt"), "b parent\n").unwrap();
+    fs::write(repo_path.join("remainder.txt"), "remainder parent\n").unwrap();
+    run_git(&repo_path, &["add", "src", "remainder.txt"]);
+    run_git(&repo_path, &["commit", "--amend", "--no-edit"]);
+
+    let (success, _, stderr) = run_gg(&repo_path, &["co", "nested-compose"]);
+    assert!(success, "create stack failed: {stderr}");
+    fs::write(nested_dir.join("a.txt"), "a selected\n").unwrap();
+    fs::write(nested_dir.join("b.txt"), "b selected\n").unwrap();
+    fs::write(repo_path.join("remainder.txt"), "remainder target\n").unwrap();
+    run_git(&repo_path, &["add", "src", "remainder.txt"]);
+    run_git(
+        &repo_path,
+        &["commit", "-m", "Nested siblings\n\nGG-ID: c-nest123"],
+    );
+    let original_head = run_git_full(&repo_path, &["rev-parse", "HEAD"]).1;
+    let describe = describe_split(&repo_path, "1");
+    let selected = describe["hunks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|hunk| {
+            hunk["path"]
+                .as_str()
+                .unwrap()
+                .starts_with("src/shared/deeper/")
+        })
+        .map(|hunk| hunk["id"].clone())
+        .collect::<Vec<_>>();
+    assert_eq!(selected.len(), 2);
+    assert_eq!(describe["hunks"].as_array().unwrap().len(), 3);
+    let plan_path = write_split_plan(&repo_path, &describe, selected);
+
+    let (success, stdout, stderr) = apply_split_plan(&repo_path, &plan_path);
+    assert!(success, "apply failed: stdout={stdout} stderr={stderr}");
+    let result: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let first_sha = result["first"]["sha"].as_str().unwrap();
+    let remainder_sha = result["remainder"]["sha"].as_str().unwrap();
+    for (path, expected) in [
+        ("src/shared/deeper/a.txt", "a selected\n"),
+        ("src/shared/deeper/b.txt", "b selected\n"),
+        ("remainder.txt", "remainder parent\n"),
+    ] {
+        assert_eq!(
+            run_git_full(&repo_path, &["show", &format!("{first_sha}:{path}")]).1,
+            expected,
+            "unexpected first-commit content for {path}"
+        );
+    }
+    for (path, expected) in [
+        ("src/shared/deeper/a.txt", "a selected\n"),
+        ("src/shared/deeper/b.txt", "b selected\n"),
+        ("remainder.txt", "remainder target\n"),
+    ] {
+        assert_eq!(
+            run_git_full(&repo_path, &["show", &format!("{remainder_sha}:{path}")],).1,
+            expected,
+            "unexpected remainder content for {path}"
+        );
+    }
+
+    let operation_id = result["operation_id"].as_str().unwrap();
+    let (success, stdout, stderr) = run_gg(&repo_path, &["undo", operation_id, "--json"]);
+    assert!(success, "undo failed: stdout={stdout} stderr={stderr}");
+    assert_eq!(
+        run_git_full(&repo_path, &["rev-parse", "HEAD"]).1,
+        original_head
+    );
+    drop(temp_dir);
+}
+
+#[test]
+fn test_split_plan_prunes_empty_nested_directory_before_file_transition() {
+    let (_temp_dir, repo_path) = create_directory_to_file_split_commit("directory-to-file");
+    let original_head = run_git_full(&repo_path, &["rev-parse", "HEAD"]).1;
+    let describe = describe_split(&repo_path, "1");
+    let deletion_hunk = describe["hunks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|hunk| hunk["path"] == "node/last.txt")
+        .expect("Describe should expose the nested deletion hunk");
+    assert!(describe["hunks"].as_array().unwrap().len() >= 2);
+    let plan_path = write_split_plan(&repo_path, &describe, vec![deletion_hunk["id"].clone()]);
+
+    let (success, stdout, stderr) = apply_split_plan(&repo_path, &plan_path);
+    assert!(success, "apply failed: stdout={stdout} stderr={stderr}");
+    let result: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let first_sha = result["first"]["sha"].as_str().unwrap();
+    let remainder_sha = result["remainder"]["sha"].as_str().unwrap();
+    assert!(
+        !run_git(
+            &repo_path,
+            &["cat-file", "-e", &format!("{first_sha}:node")]
+        )
+        .0,
+        "selected deletion must prune the empty node/ tree"
+    );
+    assert_eq!(
+        run_git_full(&repo_path, &["show", &format!("{remainder_sha}:node")]).1,
+        "top-level target\n"
+    );
+
+    let operation_id = result["operation_id"].as_str().unwrap();
+    let (success, stdout, stderr) = run_gg(&repo_path, &["undo", operation_id, "--json"]);
+    assert!(success, "undo failed: stdout={stdout} stderr={stderr}");
+    assert_eq!(
+        run_git_full(&repo_path, &["rev-parse", "HEAD"]).1,
+        original_head
+    );
+}
+
+#[test]
+fn test_split_plan_keeps_selected_file_when_nested_deletion_is_already_applied() {
+    let (_temp_dir, repo_path) = create_directory_to_file_split_commit("directory-to-file-both");
+    let describe = describe_split(&repo_path, "1");
+    let selected = describe["hunks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|hunk| matches!(hunk["path"].as_str().unwrap(), "node" | "node/last.txt"))
+        .map(|hunk| hunk["id"].clone())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        selected.len(),
+        2,
+        "Describe must expose both transition sides"
+    );
+    assert!(describe["hunks"].as_array().unwrap().len() >= 3);
+    let plan_path = write_split_plan(&repo_path, &describe, selected);
+
+    let (success, stdout, stderr) = apply_split_plan(&repo_path, &plan_path);
+    assert!(success, "apply failed: stdout={stdout} stderr={stderr}");
+    let result: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let first_sha = result["first"]["sha"].as_str().unwrap();
+    let remainder_sha = result["remainder"]["sha"].as_str().unwrap();
+    assert_eq!(
+        run_git_full(&repo_path, &["show", &format!("{first_sha}:node")]).1,
+        "top-level target\n"
+    );
+    assert_eq!(
+        run_git_full(&repo_path, &["show", &format!("{first_sha}:remainder.txt")]).1,
+        "remainder parent\n"
+    );
+    assert_eq!(
+        run_git_full(&repo_path, &["show", &format!("{remainder_sha}:node")]).1,
+        "top-level target\n"
+    );
+}
+
+#[test]
+fn test_split_plan_rejects_directory_to_file_addition_without_deletion() {
+    let (_temp_dir, repo_path) =
+        create_directory_to_file_split_commit("directory-to-file-addition-only");
+    let describe = describe_split(&repo_path, "1");
+
+    assert_path_dependent_plan_rejected(&repo_path, &describe, "node");
+}
+
+#[test]
+fn test_split_plan_rejects_file_to_directory_addition_without_deletion() {
+    let (_temp_dir, repo_path) =
+        create_file_to_directory_split_commit("file-to-directory-addition-only");
+    let describe = describe_split(&repo_path, "1");
+
+    assert_path_dependent_plan_rejected(&repo_path, &describe, "node/last.txt");
+}
+
+#[test]
+fn test_split_plan_file_to_directory_deletion_only_does_not_copy_text_child() {
+    let (_temp_dir, repo_path) =
+        create_file_to_directory_split_commit("file-to-directory-deletion-only");
+    let describe = describe_split(&repo_path, "1");
+
+    assert_file_to_directory_deletion_only(&repo_path, &describe, "node/last.txt");
+}
+
+#[test]
+fn test_split_plan_file_to_directory_deletion_only_does_not_copy_non_textual_child() {
+    let (_temp_dir, repo_path) = create_file_to_directory_with_non_textual_addition();
+    let describe = describe_split(&repo_path, "1");
+    assert!(describe["non_textual_files"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|path| path == "node/last.bin"));
+
+    assert_file_to_directory_deletion_only(&repo_path, &describe, "node/last.bin");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_split_plan_regular_to_symlink_type_change_stays_non_textual() {
+    assert_same_path_type_change_is_non_textual("regular-to-symlink", false, false);
+}
+
+#[cfg(unix)]
+#[test]
+fn test_split_plan_symlink_to_regular_type_change_stays_non_textual() {
+    assert_same_path_type_change_is_non_textual("symlink-to-regular", true, false);
+}
+
+#[cfg(unix)]
+#[test]
+fn test_split_plan_invalid_utf8_regular_to_symlink_stays_non_textual() {
+    assert_same_path_type_change_is_non_textual("invalid-regular-to-symlink", false, true);
+}
+
+#[test]
+fn test_split_plan_rejects_addition_with_non_textual_dependent_deletion() {
+    let (_temp_dir, repo_path) = create_directory_to_file_with_non_textual_deletion();
+    let describe = describe_split(&repo_path, "1");
+    assert!(describe["non_textual_files"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|path| path == "node/last.bin"));
+
+    assert_path_dependent_plan_rejected(&repo_path, &describe, "node");
 }
 
 #[test]

--- a/crates/gg-cli/tests/integration_tests/split.rs
+++ b/crates/gg-cli/tests/integration_tests/split.rs
@@ -882,6 +882,99 @@ fn test_split_plan_allows_all_text_hunks_when_non_textual_changes_remain() {
 }
 
 #[test]
+#[cfg(unix)]
+fn test_split_plan_keeps_same_file_mode_change_in_remainder() {
+    let (_temp_dir, repo_path) = create_test_repo();
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).unwrap();
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .unwrap();
+
+    fs::write(repo_path.join("script.sh"), "echo parent\n").unwrap();
+    fs::write(repo_path.join("other.txt"), "other parent\n").unwrap();
+    run_git(&repo_path, &["add", "script.sh", "other.txt"]);
+    run_git(&repo_path, &["commit", "--amend", "--no-edit"]);
+    let (success, _, stderr) = run_gg(&repo_path, &["co", "mode-change-split"]);
+    assert!(success, "create stack failed: {stderr}");
+
+    fs::write(repo_path.join("script.sh"), "echo target\n").unwrap();
+    let mut permissions = fs::metadata(repo_path.join("script.sh"))
+        .unwrap()
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(repo_path.join("script.sh"), permissions).unwrap();
+    fs::write(repo_path.join("other.txt"), "other target\n").unwrap();
+    run_git(&repo_path, &["add", "script.sh", "other.txt"]);
+    run_git(
+        &repo_path,
+        &[
+            "commit",
+            "-m",
+            "Content and mode change\n\nGG-ID: c-mode123",
+        ],
+    );
+
+    let describe = describe_split(&repo_path, "1");
+    let selected = describe["hunks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|hunk| hunk["path"] == "script.sh")
+        .map(|hunk| hunk["id"].clone())
+        .collect();
+    let plan_path = write_split_plan(&repo_path, &describe, selected);
+
+    let (success, stdout, stderr) = apply_split_plan(&repo_path, &plan_path);
+    assert!(success, "apply failed: stdout={stdout} stderr={stderr}");
+    let result: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let first_sha = result["first"]["sha"].as_str().unwrap();
+    let remainder_sha = result["remainder"]["sha"].as_str().unwrap();
+    assert_eq!(
+        run_git_full(&repo_path, &["show", &format!("{first_sha}:script.sh")]).1,
+        "echo target\n"
+    );
+    assert_eq!(
+        run_git_full(&repo_path, &["show", &format!("{first_sha}:other.txt")]).1,
+        "other parent\n"
+    );
+    assert_eq!(
+        run_git_full(&repo_path, &["show", &format!("{remainder_sha}:other.txt")],).1,
+        "other target\n"
+    );
+    assert!(
+        run_git_full(&repo_path, &["ls-tree", first_sha, "script.sh"])
+            .1
+            .starts_with("100644 "),
+        "first commit must retain the parent file mode"
+    );
+    assert!(
+        run_git_full(&repo_path, &["ls-tree", remainder_sha, "script.sh"])
+            .1
+            .starts_with("100755 "),
+        "remainder must contain the target file mode"
+    );
+    assert!(
+        run_git_full(
+            &repo_path,
+            &[
+                "diff-tree",
+                "--summary",
+                first_sha,
+                remainder_sha,
+                "--",
+                "script.sh",
+            ],
+        )
+        .1
+        .contains("mode change 100644 => 100755 script.sh"),
+        "remainder must retain the executable-bit change"
+    );
+}
+
+#[test]
 fn test_split_plan_rejects_stale_target_without_mutation() {
     let (_temp_dir, repo_path) = create_two_hunk_split_commit();
     let describe = describe_split(&repo_path, "1");

--- a/crates/gg-cli/tests/integration_tests/split.rs
+++ b/crates/gg-cli/tests/integration_tests/split.rs
@@ -1,7 +1,10 @@
-use crate::helpers::{create_test_repo, run_gg, run_git, run_git_full};
+use crate::helpers::{create_test_repo, run_gg, run_gg_with_env, run_git, run_git_full};
 
 use std::fs;
 use std::io::Write;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
 use std::process::{Command, Stdio};
 
 fn create_two_hunk_split_commit() -> (tempfile::TempDir, std::path::PathBuf) {
@@ -21,7 +24,7 @@ fn create_two_hunk_split_commit() -> (tempfile::TempDir, std::path::PathBuf) {
     fs::write(repo_path.join("multi_hunk.txt"), initial_content)
         .expect("Failed to write initial file");
     run_git(&repo_path, &["add", "multi_hunk.txt"]);
-    run_git(&repo_path, &["commit", "-m", "Add multi-hunk fixture"]);
+    run_git(&repo_path, &["commit", "--amend", "--no-edit"]);
 
     let (success, _, stderr) = run_gg(&repo_path, &["co", "test-split-describe"]);
     assert!(success, "Failed to create stack: {stderr}");
@@ -35,13 +38,405 @@ fn create_two_hunk_split_commit() -> (tempfile::TempDir, std::path::PathBuf) {
         .collect::<String>();
     fs::write(repo_path.join("multi_hunk.txt"), modified_content)
         .expect("Failed to write modified file");
-    run_git(&repo_path, &["add", "multi_hunk.txt"]);
+    fs::write(repo_path.join("binary.dat"), [0, 159, 146, 150]).expect("write binary fixture");
+    run_git(&repo_path, &["add", "multi_hunk.txt", "binary.dat"]);
     run_git(
         &repo_path,
         &["commit", "-m", "Two separated hunks\n\nGG-ID: c-abc1234"],
     );
 
     (temp_dir, repo_path)
+}
+
+fn describe_split(repo_path: &Path, target: &str) -> serde_json::Value {
+    let (success, stdout, stderr) = run_gg(
+        repo_path,
+        &["split", "--describe", "--commit", target, "--json"],
+    );
+    assert!(success, "describe failed: {stderr}");
+    serde_json::from_str(&stdout).expect("describe should return JSON")
+}
+
+fn write_split_plan(
+    repo_path: &Path,
+    describe: &serde_json::Value,
+    selected_hunk_ids: Vec<serde_json::Value>,
+) -> std::path::PathBuf {
+    let path = repo_path.join(".git/gg/test-split-plan.json");
+    let plan = serde_json::json!({
+        "version": 1,
+        "plan_token": describe["plan_token"],
+        "target": describe["target"],
+        "selected_hunk_ids": selected_hunk_ids,
+        "first_message": "Structured first",
+        "remainder_message": "Structured remainder",
+    });
+    fs::write(&path, serde_json::to_vec_pretty(&plan).unwrap()).expect("write split plan");
+    path
+}
+
+fn operation_records(repo_path: &Path) -> Vec<std::ffi::OsString> {
+    let operations_dir = repo_path.join(".git/gg/operations");
+    if !operations_dir.exists() {
+        return Vec::new();
+    }
+    let mut records = fs::read_dir(operations_dir)
+        .expect("read operation records")
+        .map(|entry| entry.expect("read operation record").file_name())
+        .collect::<Vec<_>>();
+    records.sort();
+    records
+}
+
+fn apply_split_plan(repo_path: &Path, plan_path: &Path) -> (bool, String, String) {
+    run_gg(
+        repo_path,
+        &[
+            "split",
+            "--plan-json",
+            plan_path.to_str().unwrap(),
+            "--json",
+        ],
+    )
+}
+
+#[test]
+fn test_split_plan_applies_selected_hunk_and_undo_restores_stack() {
+    let (_temp_dir, repo_path) = create_two_hunk_split_commit();
+    let describe = describe_split(&repo_path, "1");
+    let original_sha = describe["target"]["sha"].as_str().unwrap().to_string();
+    let original_head = run_git_full(&repo_path, &["rev-parse", "HEAD"]).1;
+    let selected = vec![describe["hunks"][0]["id"].clone()];
+    let plan_path = write_split_plan(&repo_path, &describe, selected);
+
+    let (success, stdout, stderr) = apply_split_plan(&repo_path, &plan_path);
+    assert!(success, "apply failed: {stderr}");
+    let result: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(result["version"], 1);
+    assert!(result["operation_id"].as_str().unwrap().starts_with("op_"));
+    assert_eq!(result["original_sha"], original_sha);
+    assert!(result["first"]["sha"].as_str().is_some());
+    assert!(result["first"]["gg_id"].as_str().is_some());
+    assert!(result["remainder"]["sha"].as_str().is_some());
+    assert_eq!(result["remainder"]["gg_id"], "c-abc1234");
+    assert_eq!(result["rewritten_descendants"], serde_json::json!([]));
+    let first_sha = result["first"]["sha"].as_str().unwrap();
+    let remainder_sha = result["remainder"]["sha"].as_str().unwrap();
+    assert!(
+        !run_git(
+            &repo_path,
+            &["cat-file", "-e", &format!("{first_sha}:binary.dat")]
+        )
+        .0
+    );
+    assert!(
+        run_git(
+            &repo_path,
+            &["cat-file", "-e", &format!("{remainder_sha}:binary.dat")],
+        )
+        .0
+    );
+    assert_eq!(
+        run_git_full(&repo_path, &["rev-list", "--count", "HEAD"])
+            .1
+            .trim(),
+        "3"
+    );
+
+    let operation_id = result["operation_id"].as_str().unwrap();
+    let (success, stdout, stderr) = run_gg(&repo_path, &["undo", operation_id, "--json"]);
+    assert!(success, "undo failed: stdout={stdout} stderr={stderr}");
+    assert_eq!(
+        run_git_full(&repo_path, &["rev-parse", "HEAD"]).1,
+        original_head
+    );
+    assert_eq!(
+        run_git_full(&repo_path, &["rev-list", "--count", "HEAD"])
+            .1
+            .trim(),
+        "2"
+    );
+}
+
+#[test]
+fn test_split_plan_rejects_stale_target_without_mutation() {
+    let (_temp_dir, repo_path) = create_two_hunk_split_commit();
+    let describe = describe_split(&repo_path, "1");
+    let plan_path = write_split_plan(
+        &repo_path,
+        &describe,
+        vec![describe["hunks"][0]["id"].clone()],
+    );
+    run_git(
+        &repo_path,
+        &[
+            "commit",
+            "--amend",
+            "-m",
+            "Changed after describe\n\nGG-ID: c-abc1234",
+        ],
+    );
+    let refs_before = run_git_full(&repo_path, &["show-ref"]).1;
+    let operations_before = operation_records(&repo_path);
+
+    let (success, stdout, stderr) = apply_split_plan(&repo_path, &plan_path);
+    assert!(!success, "stale plan unexpectedly applied: {stdout}");
+    let error: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert!(error["error"]
+        .as_str()
+        .unwrap()
+        .contains("stale split plan"));
+    assert!(
+        stderr.is_empty(),
+        "structured error should use stdout: {stderr}"
+    );
+    assert_eq!(run_git_full(&repo_path, &["show-ref"]).1, refs_before);
+    assert_eq!(operation_records(&repo_path), operations_before);
+}
+
+#[test]
+fn test_split_plan_rejects_stale_target_without_gg_id_as_stale_plan() {
+    let (_temp_dir, repo_path) = create_two_hunk_split_commit();
+    assert!(
+        run_git(
+            &repo_path,
+            &["commit", "--amend", "-m", "Two separated hunks"],
+        )
+        .0
+    );
+    let describe = describe_split(&repo_path, "1");
+    assert!(describe["target"]["gg_id"].is_null());
+    let plan_path = write_split_plan(
+        &repo_path,
+        &describe,
+        vec![describe["hunks"][0]["id"].clone()],
+    );
+    assert!(
+        run_git(
+            &repo_path,
+            &["commit", "--amend", "-m", "Changed after describe"],
+        )
+        .0
+    );
+    let refs_before = run_git_full(&repo_path, &["show-ref"]).1;
+    let operations_before = operation_records(&repo_path);
+
+    let (success, stdout, stderr) = apply_split_plan(&repo_path, &plan_path);
+    assert!(!success, "stale plan unexpectedly applied: {stdout}");
+    let error: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert!(error["error"]
+        .as_str()
+        .unwrap()
+        .contains("stale split plan"));
+    assert!(
+        stderr.is_empty(),
+        "structured error should use stdout: {stderr}"
+    );
+    assert_eq!(run_git_full(&repo_path, &["show-ref"]).1, refs_before);
+    assert_eq!(operation_records(&repo_path), operations_before);
+}
+
+#[test]
+fn test_split_plan_rejects_stale_target_after_gg_id_is_removed() {
+    let (_temp_dir, repo_path) = create_two_hunk_split_commit();
+    let describe = describe_split(&repo_path, "1");
+    assert_eq!(describe["target"]["gg_id"], "c-abc1234");
+    let plan_path = write_split_plan(
+        &repo_path,
+        &describe,
+        vec![describe["hunks"][0]["id"].clone()],
+    );
+    assert!(
+        run_git(
+            &repo_path,
+            &["commit", "--amend", "-m", "Changed after describe"],
+        )
+        .0
+    );
+    let refs_before = run_git_full(&repo_path, &["show-ref"]).1;
+    let operations_before = operation_records(&repo_path);
+
+    let (success, stdout, stderr) = apply_split_plan(&repo_path, &plan_path);
+    assert!(!success, "stale plan unexpectedly applied: {stdout}");
+    let error: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert!(error["error"]
+        .as_str()
+        .unwrap()
+        .contains("stale split plan"));
+    assert!(
+        stderr.is_empty(),
+        "structured error should use stdout: {stderr}"
+    );
+    assert_eq!(run_git_full(&repo_path, &["show-ref"]).1, refs_before);
+    assert_eq!(operation_records(&repo_path), operations_before);
+}
+
+#[test]
+fn test_split_plan_rejects_invalid_inputs_before_mutation() {
+    let invalid_cases = [
+        ("zero selected hunks", serde_json::json!([])),
+        (
+            "all selected hunks",
+            serde_json::json!(["$first", "$second"]),
+        ),
+        ("unknown hunk", serde_json::json!(["h-unknown"])),
+        ("duplicate hunk", serde_json::json!(["$first", "$first"])),
+    ];
+
+    for (name, selected_template) in invalid_cases {
+        let (_temp_dir, repo_path) = create_two_hunk_split_commit();
+        let describe = describe_split(&repo_path, "1");
+        let first_id = describe["hunks"][0]["id"].clone();
+        let second_id = describe["hunks"][1]["id"].clone();
+        let selected = selected_template
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|id| match id.as_str().unwrap() {
+                "$first" => first_id.clone(),
+                "$second" => second_id.clone(),
+                _ => id.clone(),
+            })
+            .collect();
+        let plan_path = write_split_plan(&repo_path, &describe, selected);
+        let refs_before = run_git_full(&repo_path, &["show-ref"]).1;
+        let operations_before = operation_records(&repo_path);
+
+        let (success, stdout, _stderr) = apply_split_plan(&repo_path, &plan_path);
+        assert!(!success, "{name} unexpectedly applied: {stdout}");
+        serde_json::from_str::<serde_json::Value>(&stdout)
+            .unwrap_or_else(|_| panic!("{name} should return JSON: {stdout}"));
+        assert_eq!(
+            run_git_full(&repo_path, &["show-ref"]).1,
+            refs_before,
+            "{name}"
+        );
+        assert_eq!(operation_records(&repo_path), operations_before, "{name}");
+    }
+
+    for (name, field, value) in [
+        (
+            "empty first message",
+            "first_message",
+            serde_json::json!("  "),
+        ),
+        (
+            "empty remainder message",
+            "remainder_message",
+            serde_json::json!("\n"),
+        ),
+        ("unsupported version", "version", serde_json::json!(2)),
+    ] {
+        let (_temp_dir, repo_path) = create_two_hunk_split_commit();
+        let describe = describe_split(&repo_path, "1");
+        let plan_path = write_split_plan(
+            &repo_path,
+            &describe,
+            vec![describe["hunks"][0]["id"].clone()],
+        );
+        let mut plan: serde_json::Value =
+            serde_json::from_slice(&fs::read(&plan_path).unwrap()).unwrap();
+        plan[field] = value;
+        fs::write(&plan_path, serde_json::to_vec_pretty(&plan).unwrap()).unwrap();
+        let refs_before = run_git_full(&repo_path, &["show-ref"]).1;
+        let operations_before = operation_records(&repo_path);
+
+        let (success, stdout, _stderr) = apply_split_plan(&repo_path, &plan_path);
+        assert!(!success, "{name} unexpectedly applied: {stdout}");
+        serde_json::from_str::<serde_json::Value>(&stdout)
+            .unwrap_or_else(|_| panic!("{name} should return JSON: {stdout}"));
+        assert_eq!(
+            run_git_full(&repo_path, &["show-ref"]).1,
+            refs_before,
+            "{name}"
+        );
+        assert_eq!(operation_records(&repo_path), operations_before, "{name}");
+    }
+}
+
+#[test]
+fn test_split_plan_reports_rewritten_descendant_identity() {
+    let (_temp_dir, repo_path) = create_two_hunk_split_commit();
+    fs::write(repo_path.join("descendant.txt"), "descendant\n").unwrap();
+    run_git(&repo_path, &["add", "descendant.txt"]);
+    run_git(
+        &repo_path,
+        &["commit", "-m", "Descendant\n\nGG-ID: c-def5678"],
+    );
+    let describe = describe_split(&repo_path, "1");
+    let plan_path = write_split_plan(
+        &repo_path,
+        &describe,
+        vec![describe["hunks"][0]["id"].clone()],
+    );
+
+    let (success, stdout, stderr) = apply_split_plan(&repo_path, &plan_path);
+    assert!(success, "apply failed: {stderr}");
+    let result: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let descendants = result["rewritten_descendants"].as_array().unwrap();
+    assert_eq!(descendants.len(), 1);
+    assert_eq!(descendants[0]["gg_id"], "c-def5678");
+    assert!(descendants[0]["sha"].as_str().is_some());
+}
+
+#[test]
+fn test_split_plan_rejects_immutable_target_without_force_path() {
+    let (_temp_dir, repo_path) = create_two_hunk_split_commit();
+    let describe = describe_split(&repo_path, "1");
+    let plan_path = write_split_plan(
+        &repo_path,
+        &describe,
+        vec![describe["hunks"][0]["id"].clone()],
+    );
+    let config_path = repo_path.join(".git/gg/config.json");
+    let mut config: serde_json::Value =
+        serde_json::from_slice(&fs::read(&config_path).unwrap()).unwrap();
+    config["defaults"]["provider"] = serde_json::json!("github");
+    config["stacks"]["test-split-describe"]["mrs"]["c-abc1234"] = serde_json::json!(99);
+    fs::write(&config_path, serde_json::to_vec_pretty(&config).unwrap()).unwrap();
+
+    let fake_bin = repo_path.join("fake-bin");
+    fs::create_dir_all(&fake_bin).unwrap();
+    let fake_gh = fake_bin.join("gh");
+    fs::write(
+        &fake_gh,
+        "#!/bin/sh\nif [ \"$1\" = \"pr\" ] && [ \"$2\" = \"view\" ]; then\n  echo '{\"number\":99,\"title\":\"Two separated hunks\",\"state\":\"MERGED\",\"url\":\"https://github.com/test/repo/pull/99\",\"headRefName\":\"testuser/test-split-describe--c-abc1234\",\"isDraft\":false,\"mergeable\":\"MERGEABLE\",\"reviews\":[]}'\n  exit 0\nfi\nexit 1\n",
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        let mut permissions = fs::metadata(&fake_gh).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&fake_gh, permissions).unwrap();
+    }
+    let mut path = std::ffi::OsString::from(fake_bin.as_os_str());
+    path.push(":");
+    path.push(std::env::var_os("PATH").unwrap_or_default());
+    let refs_before = run_git_full(&repo_path, &["show-ref"]).1;
+    let operations_before = operation_records(&repo_path);
+
+    let (success, stdout, stderr) = run_gg_with_env(
+        &repo_path,
+        &[
+            "split",
+            "--plan-json",
+            plan_path.to_str().unwrap(),
+            "--json",
+        ],
+        &[("PATH", path.as_os_str())],
+    );
+    assert!(!success, "immutable target unexpectedly applied: {stdout}");
+    let error: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert!(error["error"]
+        .as_str()
+        .unwrap()
+        .contains("cannot rewrite immutable commits"));
+    assert!(
+        stderr.is_empty(),
+        "structured error should use stdout: {stderr}"
+    );
+    assert_eq!(run_git_full(&repo_path, &["show-ref"]).1, refs_before);
+    assert_eq!(operation_records(&repo_path), operations_before);
 }
 
 #[test]

--- a/crates/gg-cli/tests/integration_tests/split.rs
+++ b/crates/gg-cli/tests/integration_tests/split.rs
@@ -4,6 +4,119 @@ use std::fs;
 use std::io::Write;
 use std::process::{Command, Stdio};
 
+fn create_two_hunk_split_commit() -> (tempfile::TempDir, std::path::PathBuf) {
+    let (temp_dir, repo_path) = create_test_repo();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .expect("Failed to write config");
+
+    let initial_content = (1..=20)
+        .map(|line| format!("line {line}\n"))
+        .collect::<String>();
+    fs::write(repo_path.join("multi_hunk.txt"), initial_content)
+        .expect("Failed to write initial file");
+    run_git(&repo_path, &["add", "multi_hunk.txt"]);
+    run_git(&repo_path, &["commit", "-m", "Add multi-hunk fixture"]);
+
+    let (success, _, stderr) = run_gg(&repo_path, &["co", "test-split-describe"]);
+    assert!(success, "Failed to create stack: {stderr}");
+
+    let modified_content = (1..=20)
+        .map(|line| match line {
+            2 => "line 2 modified\n".to_string(),
+            18 => "line 18 modified\n".to_string(),
+            _ => format!("line {line}\n"),
+        })
+        .collect::<String>();
+    fs::write(repo_path.join("multi_hunk.txt"), modified_content)
+        .expect("Failed to write modified file");
+    run_git(&repo_path, &["add", "multi_hunk.txt"]);
+    run_git(
+        &repo_path,
+        &["commit", "-m", "Two separated hunks\n\nGG-ID: c-abc1234"],
+    );
+
+    (temp_dir, repo_path)
+}
+
+#[test]
+fn test_split_describe_json() {
+    let (_temp_dir, repo_path) = create_two_hunk_split_commit();
+    let refs_before = run_git_full(&repo_path, &["show-ref"]).1;
+    let operation_records = || {
+        let operations_dir = repo_path.join(".git/gg/operations");
+        if !operations_dir.exists() {
+            return Vec::new();
+        }
+        let mut records = fs::read_dir(operations_dir)
+            .expect("Failed to read operation records")
+            .map(|entry| entry.expect("Failed to read operation record").file_name())
+            .collect::<Vec<_>>();
+        records.sort();
+        records
+    };
+    let operations_before = operation_records();
+
+    let describe = || {
+        let (success, stdout, stderr) = run_gg(
+            &repo_path,
+            &["split", "--describe", "--commit", "1", "--json"],
+        );
+        assert!(success, "describe failed: {stderr}");
+        serde_json::from_str::<serde_json::Value>(&stdout).expect("describe should return JSON")
+    };
+
+    let first = describe();
+    assert_eq!(first["version"], 1);
+    assert_eq!(first["hunks"].as_array().unwrap().len(), 2);
+    assert!(first["plan_token"]
+        .as_str()
+        .unwrap()
+        .starts_with("split-v1-"));
+    assert_eq!(first["remainder_message"], "Two separated hunks");
+
+    let second = describe();
+    assert_eq!(second["target"], first["target"]);
+    assert_eq!(second["plan_token"], first["plan_token"]);
+    let hunk_ids = |value: &serde_json::Value| {
+        value["hunks"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|hunk| hunk["id"].as_str().unwrap().to_string())
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(hunk_ids(&second), hunk_ids(&first));
+    assert_eq!(run_git_full(&repo_path, &["status", "--porcelain"]).1, "");
+    assert_eq!(run_git_full(&repo_path, &["show-ref"]).1, refs_before);
+    assert_eq!(operation_records(), operations_before);
+}
+
+#[test]
+fn test_split_describe_json_allows_dirty_worktree() {
+    let (_temp_dir, repo_path) = create_two_hunk_split_commit();
+    fs::write(repo_path.join("README.md"), "dirty but preserved\n")
+        .expect("Failed to dirty worktree");
+    let status_before = run_git_full(&repo_path, &["status", "--porcelain"]).1;
+
+    let (success, stdout, stderr) = run_gg(
+        &repo_path,
+        &["split", "--describe", "--commit", "1", "--json"],
+    );
+
+    assert!(success, "describe failed for dirty worktree: {stderr}");
+    serde_json::from_str::<serde_json::Value>(&stdout).expect("describe should return JSON");
+    assert_eq!(
+        run_git_full(&repo_path, &["status", "--porcelain"]).1,
+        status_before
+    );
+}
+
 #[test]
 fn test_split_head_with_file_args() {
     let (_temp_dir, repo_path) = create_test_repo();
@@ -259,6 +372,14 @@ fn test_split_help_no_interactive_flag() {
         !stdout.contains("--interactive"),
         "split help should NOT mention --interactive flag (hunk mode is default): {}",
         stdout
+    );
+    assert!(
+        stdout.contains("--describe"),
+        "split help should mention --describe: {stdout}"
+    );
+    assert!(
+        stdout.contains("--json"),
+        "split help should mention --json: {stdout}"
     );
 }
 

--- a/crates/gg-cli/tests/integration_tests/split.rs
+++ b/crates/gg-cli/tests/integration_tests/split.rs
@@ -1461,6 +1461,23 @@ fn test_split_help_no_interactive_flag() {
     );
 }
 
+#[test]
+fn test_split_json_requires_structured_mode() {
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["split", "--json"]);
+
+    assert!(!success, "bare split --json should be rejected");
+    assert!(
+        stdout.is_empty(),
+        "stdout should stay machine-readable: {stdout}"
+    );
+    assert!(
+        stderr.contains("--describe") && stderr.contains("--plan-json"),
+        "error should name the supported JSON modes: {stderr}"
+    );
+}
+
 /// Helper to run gg with stdin input
 fn run_gg_with_stdin(
     repo_path: &std::path::Path,

--- a/crates/gg-cli/tests/integration_tests/squash.rs
+++ b/crates/gg-cli/tests/integration_tests/squash.rs
@@ -8,6 +8,236 @@ fn head_sha(repo_path: &std::path::Path) -> String {
     stdout.trim().to_string()
 }
 
+fn assert_staged_only_ignores_unstaged_action(unstaged_action: &str) {
+    let (_temp_dir, repo_path) = create_test_repo();
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        format!(
+            r#"{{"defaults":{{"branch_username":"testuser","unstaged_action":"{unstaged_action}"}}}}"#
+        ),
+    )
+    .expect("Failed to write config");
+
+    run_gg(
+        &repo_path,
+        &["co", &format!("squash-staged-only-{unstaged_action}")],
+    );
+    fs::write(repo_path.join("staged.txt"), "original staged\n").unwrap();
+    fs::write(repo_path.join("unstaged.txt"), "original unstaged\n").unwrap();
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "Initial files"]);
+
+    fs::write(repo_path.join("staged.txt"), "amended staged\n").unwrap();
+    run_git(&repo_path, &["add", "staged.txt"]);
+    fs::write(repo_path.join("unstaged.txt"), "working unstaged\n").unwrap();
+    fs::write(repo_path.join("untracked.txt"), "working untracked\n").unwrap();
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["sc", "--staged-only"]);
+    assert!(
+        success,
+        "--staged-only must ignore unstaged_action={unstaged_action}: stdout={stdout} stderr={stderr}"
+    );
+
+    let (success, committed_staged) = run_git(&repo_path, &["show", "HEAD:staged.txt"]);
+    assert!(success);
+    assert_eq!(committed_staged, "amended staged\n");
+    let (success, committed_unstaged) = run_git(&repo_path, &["show", "HEAD:unstaged.txt"]);
+    assert!(success);
+    assert_eq!(committed_unstaged, "original unstaged\n");
+    let (success, _) = run_git(&repo_path, &["cat-file", "-e", "HEAD:untracked.txt"]);
+    assert!(!success, "untracked content must not be amended");
+
+    let (success, status) = run_git(&repo_path, &["status", "--porcelain"]);
+    assert!(success);
+    assert!(status.contains(" M unstaged.txt"), "status={status}");
+    assert!(status.contains("?? untracked.txt"), "status={status}");
+    assert!(
+        !status
+            .lines()
+            .any(|line| line.get(3..) == Some("staged.txt")),
+        "staged change should be clean: {status}"
+    );
+
+    let (success, stash_list) = run_git(&repo_path, &["stash", "list"]);
+    assert!(success);
+    assert!(
+        stash_list.trim().is_empty(),
+        "--staged-only must not auto-stash: {stash_list}"
+    );
+}
+
+#[test]
+fn test_gg_squash_staged_only_ignores_add_default_at_stack_head() {
+    assert_staged_only_ignores_unstaged_action("add");
+}
+
+#[test]
+fn test_gg_squash_staged_only_ignores_stash_default_at_stack_head() {
+    assert_staged_only_ignores_unstaged_action("stash");
+}
+
+#[test]
+fn test_gg_squash_staged_only_fails_before_mid_stack_rebase_with_unstaged_changes() {
+    let (_temp_dir, repo_path) = create_test_repo();
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser","unstaged_action":"add"}}"#,
+    )
+    .expect("Failed to write config");
+
+    run_gg(&repo_path, &["co", "squash-staged-only-mid-stack"]);
+    fs::write(repo_path.join("first.txt"), "first\n").unwrap();
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "First"]);
+    fs::write(repo_path.join("second.txt"), "second\n").unwrap();
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "Second"]);
+    let (success, _, stderr) = run_gg(&repo_path, &["mv", "1"]);
+    assert!(success, "move failed: {stderr}");
+
+    fs::write(repo_path.join("first.txt"), "unstaged first\n").unwrap();
+    fs::write(repo_path.join("staged.txt"), "staged\n").unwrap();
+    run_git(&repo_path, &["add", "staged.txt"]);
+    let head_before = head_sha(&repo_path);
+    let (_, status_before) = run_git(&repo_path, &["status", "--porcelain"]);
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["sc", "--staged-only"]);
+    assert!(
+        !success,
+        "mid-stack staged-only must refuse unstaged changes: stdout={stdout} stderr={stderr}"
+    );
+    assert!(
+        stderr.contains("Unstaged changes detected"),
+        "stderr={stderr}"
+    );
+    assert_eq!(
+        head_sha(&repo_path),
+        head_before,
+        "HEAD must not be amended"
+    );
+    let (_, status_after) = run_git(&repo_path, &["status", "--porcelain"]);
+    assert_eq!(
+        status_after, status_before,
+        "index/worktree must be untouched"
+    );
+    let (_, stash_list) = run_git(&repo_path, &["stash", "list"]);
+    assert!(
+        stash_list.trim().is_empty(),
+        "must not auto-stash: {stash_list}"
+    );
+}
+
+#[test]
+fn test_gg_squash_staged_only_rejects_untracked_descendant_collision_before_amend() {
+    let (_temp_dir, repo_path) = create_test_repo();
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).unwrap();
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser","unstaged_action":"add"}}"#,
+    )
+    .unwrap();
+    run_gg(&repo_path, &["co", "squash-staged-only-untracked"]);
+
+    fs::write(repo_path.join("first.txt"), "first\n").unwrap();
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "First"]);
+    fs::write(repo_path.join("descendant.txt"), "descendant\n").unwrap();
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "Second"]);
+    let (success, _, stderr) = run_gg(&repo_path, &["mv", "1"]);
+    assert!(success, "move failed: {stderr}");
+
+    fs::write(repo_path.join("prepared.txt"), "prepared\n").unwrap();
+    run_git(&repo_path, &["add", "prepared.txt"]);
+    fs::write(repo_path.join("descendant.txt"), "untracked collision\n").unwrap();
+    let head_before = head_sha(&repo_path);
+    let (_, status_before) = run_git(&repo_path, &["status", "--porcelain"]);
+    let operations_before = fs::read_dir(gg_dir.join("operations"))
+        .unwrap()
+        .filter_map(|entry| entry.ok())
+        .filter_map(|entry| fs::read(entry.path()).ok())
+        .filter_map(|bytes| serde_json::from_slice::<serde_json::Value>(&bytes).ok())
+        .filter(|record| record["kind"] == "squash")
+        .count();
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["sc", "--staged-only"]);
+    assert!(
+        !success,
+        "untracked collision must be refused before amend: stdout={stdout} stderr={stderr}"
+    );
+    assert!(
+        stderr.contains("Untracked files detected"),
+        "stderr={stderr}"
+    );
+    assert_eq!(
+        head_sha(&repo_path),
+        head_before,
+        "HEAD must not be amended"
+    );
+    let (_, status_after) = run_git(&repo_path, &["status", "--porcelain"]);
+    assert_eq!(
+        status_after, status_before,
+        "index/worktree must be untouched"
+    );
+    let operations_after = fs::read_dir(gg_dir.join("operations"))
+        .unwrap()
+        .filter_map(|entry| entry.ok())
+        .filter_map(|entry| fs::read(entry.path()).ok())
+        .filter_map(|bytes| serde_json::from_slice::<serde_json::Value>(&bytes).ok())
+        .filter(|record| record["kind"] == "squash")
+        .count();
+    assert_eq!(
+        operations_after, operations_before,
+        "preflight refusal must not create a Pending squash operation"
+    );
+}
+
+#[test]
+fn test_gg_squash_staged_only_help_and_all_conflict() {
+    let (_temp_dir, repo_path) = create_test_repo();
+    let (success, stdout, stderr) = run_gg(&repo_path, &["sc", "--help"]);
+    assert!(success, "sc help failed: {stderr}");
+    assert!(stdout.contains("--staged-only"), "stdout={stdout}");
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["sc", "--all", "--staged-only"]);
+    assert!(
+        !success && stderr.contains("cannot be used with"),
+        "--all and --staged-only must conflict: stdout={stdout} stderr={stderr}"
+    );
+}
+
+#[test]
+fn test_gg_squash_staged_only_without_staged_changes_does_not_amend() {
+    let (_temp_dir, repo_path) = create_test_repo();
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).unwrap();
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser","unstaged_action":"add"}}"#,
+    )
+    .unwrap();
+    run_gg(&repo_path, &["co", "squash-staged-only-empty"]);
+    fs::write(repo_path.join("tracked.txt"), "original\n").unwrap();
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "Tracked"]);
+    let head_before = head_sha(&repo_path);
+
+    fs::write(repo_path.join("tracked.txt"), "unstaged\n").unwrap();
+    let (success, stdout, stderr) = run_gg(&repo_path, &["sc", "--staged-only"]);
+    assert!(success, "staged-only no-op failed: {stderr}");
+    assert!(stdout.contains("No staged changes"), "stdout={stdout}");
+    assert_eq!(head_sha(&repo_path), head_before);
+    assert_eq!(
+        fs::read_to_string(repo_path.join("tracked.txt")).unwrap(),
+        "unstaged\n"
+    );
+}
+
 #[test]
 fn test_gg_squash_with_staged_changes() {
     let (_temp_dir, repo_path) = create_test_repo();

--- a/crates/gg-cli/tests/integration_tests/undo.rs
+++ b/crates/gg-cli/tests/integration_tests/undo.rs
@@ -219,6 +219,46 @@ fn test_undo_is_itself_recorded_and_double_undo_redoes() {
 }
 
 #[test]
+fn test_undo_operation_preserves_client_operation_id_in_raw_args() {
+    let (_temp_dir, repo_path) = setup_undo_test_repo("undo-client-correlation");
+
+    fs::write(repo_path.join("a.txt"), "v1").unwrap();
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "Commit A"]);
+    fs::write(repo_path.join("b.txt"), "v1").unwrap();
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "Commit B"]);
+    let (success, _, stderr) = run_gg(&repo_path, &["drop", "2", "--force"]);
+    assert!(success, "drop failed: {stderr}");
+
+    let client_id = "alas:018f84c0-3a14-7b45-a397-93c87266391d";
+    let (success, stdout, stderr) = run_gg(
+        &repo_path,
+        &["undo", "--client-operation-id", client_id, "--json"],
+    );
+    assert!(
+        success,
+        "correlated undo failed: stdout={stdout} stderr={stderr}"
+    );
+
+    let (_, stdout, stderr) = run_gg(&repo_path, &["undo", "--list", "--json"]);
+    assert!(stderr.is_empty(), "undo list failed: {stderr}");
+    let parsed: Value = serde_json::from_str(&stdout).expect("stdout must be valid JSON");
+    let undo_record = parsed["operations"]
+        .as_array()
+        .expect("operations must be array")
+        .iter()
+        .find(|record| record["kind"] == "undo")
+        .expect("undo mutation must create an operation record");
+
+    assert_eq!(
+        undo_record["args"],
+        serde_json::json!(["undo", "--client-operation-id", client_id, "--json"]),
+        "undo must preserve the same raw argv as every other recorded mutation"
+    );
+}
+
+#[test]
 fn test_undo_unknown_operation_id_errors() {
     let (_temp_dir, repo_path) = setup_undo_test_repo("undo-unknown");
 

--- a/crates/gg-cli/tests/integration_tests/unstack.rs
+++ b/crates/gg-cli/tests/integration_tests/unstack.rs
@@ -38,7 +38,15 @@ fn test_gg_unstack_worktree_creates_new_stack_worktree_and_preserves_current_bra
 
     let (success, stdout, stderr) = run_gg(
         &repo_path,
-        &["unstack", "-t", "3", "--name", "upper", "--worktree"],
+        &[
+            "unstack",
+            "-t",
+            "3",
+            "--name",
+            "upper",
+            "--worktree",
+            "--json",
+        ],
     );
     assert!(
         success,
@@ -48,6 +56,8 @@ fn test_gg_unstack_worktree_creates_new_stack_worktree_and_preserves_current_bra
 
     let (_, current_branch) = run_git(&repo_path, &["branch", "--show-current"]);
     assert_eq!(current_branch.trim(), "testuser/lower");
+    let value: Value = serde_json::from_str(&stdout).expect("stdout must be valid JSON");
+    assert_eq!(value["unstack"]["current_stack"], "lower");
 
     let (_, lower_log) = run_git(&repo_path, &["log", "--format=%s", "main..HEAD"]);
     assert!(lower_log.contains("commit 1"), "lower log: {lower_log}");
@@ -289,8 +299,10 @@ fn test_gg_unstack_without_worktree_switches_current_repo_to_new_stack() {
         assert!(success, "commit {i} should succeed");
     }
 
-    let (success, stdout, stderr) =
-        run_gg(&repo_path, &["unstack", "-t", "2", "--name", "plain-upper"]);
+    let (success, stdout, stderr) = run_gg(
+        &repo_path,
+        &["unstack", "-t", "2", "--name", "plain-upper", "--json"],
+    );
     assert!(
         success,
         "unstack should succeed: stdout={}, stderr={}",
@@ -299,6 +311,8 @@ fn test_gg_unstack_without_worktree_switches_current_repo_to_new_stack() {
 
     let (_, current_branch) = run_git(&repo_path, &["branch", "--show-current"]);
     assert_eq!(current_branch.trim(), "testuser/plain-upper");
+    let value: Value = serde_json::from_str(&stdout).expect("stdout must be valid JSON");
+    assert_eq!(value["unstack"]["current_stack"], "plain-upper");
 
     let (_, upper_log) = run_git(&repo_path, &["log", "--format=%s", "main..HEAD"]);
     assert!(
@@ -355,6 +369,110 @@ fn setup_unstack_repo(stack_name: &str, num_commits: usize) -> (TempDir, PathBuf
     }
 
     (temp_dir, repo_path)
+}
+
+#[test]
+fn test_gg_unstack_keep_current_leaves_invoking_worktree_on_lower_stack() {
+    let (_temp_dir, repo_path) = create_test_repo_with_worktree_support();
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser","base":"main"}}"#,
+    )
+    .expect("Failed to write config");
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["co", "original", "--worktree"]);
+    assert!(
+        success,
+        "checkout should succeed: stdout={stdout}, stderr={stderr}"
+    );
+    let original_worktree_path = repo_path.parent().expect("repo parent").join(format!(
+        "{}.{}",
+        repo_path.file_name().unwrap().to_string_lossy(),
+        "original"
+    ));
+
+    for i in 1..=4 {
+        fs::write(
+            original_worktree_path.join(format!("keep-current-{i}.txt")),
+            format!("commit {i}\n"),
+        )
+        .expect("Failed to write test file");
+        run_git(&original_worktree_path, &["add", "."]);
+        let (success, _) = run_git(
+            &original_worktree_path,
+            &["commit", "-m", &format!("keep-current commit {i}")],
+        );
+        assert!(success, "commit {i} should succeed");
+    }
+
+    let (success, stdout, stderr) = run_gg(
+        &original_worktree_path,
+        &[
+            "unstack",
+            "--target",
+            "3",
+            "--name",
+            "upper",
+            "--no-tui",
+            "--keep-current",
+            "--json",
+        ],
+    );
+    assert!(success, "keep-current unstack failed: {stderr}");
+
+    let value: Value = serde_json::from_str(&stdout).expect("stdout must be valid JSON");
+    let (_, current_branch) = run_git(&original_worktree_path, &["branch", "--show-current"]);
+    assert_eq!(current_branch.trim(), "testuser/original");
+    assert_eq!(value["unstack"]["current_stack"], "original");
+    assert!(value["unstack"]["worktree_path"].is_null());
+
+    let config: Value =
+        serde_json::from_str(&fs::read_to_string(gg_dir.join("config.json")).unwrap()).unwrap();
+    assert!(config["stacks"]["original"]["worktree_path"].is_string());
+    assert!(config["stacks"]["upper"]["worktree_path"].is_null());
+}
+
+#[test]
+fn test_gg_unstack_rejects_keep_current_with_worktree_before_mutation() {
+    let (_temp_dir, repo_path) = setup_unstack_repo("conflict-original", 4);
+    let config_path = repo_path.join(".git/gg/config.json");
+    let branch_before = rev_list(&repo_path, "main..testuser/conflict-original");
+    let config_before = fs::read_to_string(&config_path).unwrap();
+
+    let (success, stdout, stderr) = run_gg(
+        &repo_path,
+        &[
+            "unstack",
+            "--target",
+            "3",
+            "--name",
+            "conflict-upper",
+            "--no-tui",
+            "--keep-current",
+            "--worktree",
+            "--json",
+        ],
+    );
+    assert!(
+        !success,
+        "conflicting placement flags should fail: {stdout}"
+    );
+    assert!(
+        stderr.contains("cannot be used with"),
+        "Clap should reject conflicting placement flags: {stderr}"
+    );
+
+    let (_, current_branch) = run_git(&repo_path, &["branch", "--show-current"]);
+    assert_eq!(current_branch.trim(), "testuser/conflict-original");
+    assert_eq!(
+        rev_list(&repo_path, "main..testuser/conflict-original"),
+        branch_before
+    );
+    assert_eq!(fs::read_to_string(&config_path).unwrap(), config_before);
+    let (branch_exists, _) = run_git(&repo_path, &["rev-parse", "testuser/conflict-upper"]);
+    assert!(!branch_exists, "conflicting flags must not create a stack");
 }
 
 fn rev_list(repo_path: &std::path::Path, range: &str) -> Vec<String> {

--- a/crates/gg-core/src/commands/clean.rs
+++ b/crates/gg-core/src/commands/clean.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use crate::config::Config;
 use crate::error::{GgError, Result};
 use crate::git;
-use crate::operations::{OperationKind, SnapshotScope};
+use crate::operations::{OperationKind, RemoteEffect, SnapshotScope};
 use crate::output::{print_json, CleanResponse, CleanResultJson, OUTPUT_VERSION};
 use crate::provider::{PrState, Provider};
 use crate::stack;
@@ -20,7 +20,7 @@ pub fn run_for_stack(stack_name: &str, force: bool) -> Result<()> {
     let config = Config::load_with_global(repo.commondir())?;
 
     // Acquire operation lock + record a Pending op for the undo log.
-    let (_lock, guard) = git::acquire_operation_lock_and_record(
+    let (_lock, mut guard) = git::acquire_operation_lock_and_record(
         &repo,
         &config,
         OperationKind::Clean,
@@ -29,20 +29,25 @@ pub fn run_for_stack(stack_name: &str, force: bool) -> Result<()> {
         SnapshotScope::AllUserBranches,
     )?;
 
-    run_for_stack_with_repo(&repo, stack_name, force)?;
+    let mut remote_effects = Vec::new();
+    run_for_stack_with_repo_options(&repo, stack_name, force, false, &mut |effect| {
+        guard.record_remote_effect(effect.clone());
+        remote_effects.push(effect);
+    })?;
+    let touched_remote = !remote_effects.is_empty();
 
     guard.finalize_with_scope(
         &repo,
         &config,
         SnapshotScope::AllUserBranches,
-        vec![],
-        false,
+        remote_effects,
+        touched_remote,
     )
 }
 
 /// Run clean for a stack with an already-open repository (no lock acquisition)
 pub fn run_for_stack_with_repo(repo: &Repository, stack_name: &str, force: bool) -> Result<()> {
-    run_for_stack_with_repo_options(repo, stack_name, force, false)
+    run_for_stack_with_repo_options(repo, stack_name, force, false, &mut |_| {})
 }
 
 /// Run clean after `gg land` has already verified that every PR/MR in the stack
@@ -56,8 +61,9 @@ pub(crate) fn run_for_stack_with_repo_after_verified_land(
     repo: &Repository,
     stack_name: &str,
     force: bool,
+    record_remote_effect: &mut dyn FnMut(RemoteEffect),
 ) -> Result<()> {
-    run_for_stack_with_repo_options(repo, stack_name, force, true)
+    run_for_stack_with_repo_options(repo, stack_name, force, true, record_remote_effect)
 }
 
 fn run_for_stack_with_repo_options(
@@ -65,6 +71,7 @@ fn run_for_stack_with_repo_options(
     stack_name: &str,
     force: bool,
     merge_verified_by_land: bool,
+    record_remote_effect: &mut dyn FnMut(RemoteEffect),
 ) -> Result<()> {
     let git_dir = repo.commondir();
     let mut config = Config::load_with_global(git_dir)?;
@@ -178,6 +185,7 @@ fn run_for_stack_with_repo_options(
         &username,
         /*delete_remote=*/ allow_remote_delete,
         /*silent=*/ false,
+        record_remote_effect,
     );
 
     // Remove from config
@@ -204,7 +212,7 @@ pub fn run(clean_all: bool, json: bool) -> Result<()> {
     let mut config = Config::load_with_global(git_dir)?;
 
     // Acquire operation lock + record a Pending op for the undo log.
-    let (_lock, guard) = git::acquire_operation_lock_and_record(
+    let (_lock, mut guard) = git::acquire_operation_lock_and_record(
         &repo,
         &config,
         OperationKind::Clean,
@@ -232,6 +240,7 @@ pub fn run(clean_all: bool, json: bool) -> Result<()> {
 
     let mut cleaned: Vec<String> = Vec::new();
     let mut skipped: Vec<String> = Vec::new();
+    let mut remote_effects = Vec::new();
 
     if stacks.is_empty() {
         if json {
@@ -262,8 +271,13 @@ pub fn run(clean_all: bool, json: bool) -> Result<()> {
             // Be conservative: do NOT delete remote branches here because we can't
             // reliably verify merge status without the main stack branch.
             delete_entry_branches(
-                &repo, &config, stack_name, &username, /*delete_remote=*/ false,
+                &repo,
+                &config,
+                stack_name,
+                &username,
+                /*delete_remote=*/ false,
                 /*silent=*/ json,
+                &mut |_| {},
             );
             config.remove_stack(stack_name);
             cleaned.push(stack_name.clone());
@@ -382,6 +396,10 @@ pub fn run(clean_all: bool, json: bool) -> Result<()> {
                 &username,
                 /*delete_remote=*/ allow_remote_delete,
                 /*silent=*/ json,
+                &mut |effect| {
+                    guard.record_remote_effect(effect.clone());
+                    remote_effects.push(effect);
+                },
             );
 
             // Remove from config
@@ -426,12 +444,13 @@ pub fn run(clean_all: bool, json: bool) -> Result<()> {
         println!("{}", style("No stacks to clean.").dim());
     }
 
+    let touched_remote = !remote_effects.is_empty();
     guard.finalize_with_scope(
         &repo,
         &config,
         SnapshotScope::AllUserBranches,
-        vec![],
-        false,
+        remote_effects,
+        touched_remote,
     )?;
 
     Ok(())
@@ -901,6 +920,7 @@ fn delete_entry_branches(
     username: &str,
     delete_remote: bool,
     silent: bool,
+    record_remote_effect: &mut dyn FnMut(RemoteEffect),
 ) {
     // First, delete entry branches from config (if any)
     if let Some(stack_config) = config.get_stack(stack_name) {
@@ -934,7 +954,9 @@ fn delete_entry_branches(
             }
             // Delete remote entry branch
             if delete_remote {
-                let _ = git::delete_remote_branch(&entry_branch);
+                if let Some(effect) = delete_remote_branch(repo, &entry_branch) {
+                    record_remote_effect(effect);
+                }
             }
         }
     }
@@ -975,9 +997,22 @@ fn delete_entry_branches(
         }
         // Also try to delete from remote
         if delete_remote {
-            let _ = git::delete_remote_branch(&branch_name);
+            if let Some(effect) = delete_remote_branch(repo, &branch_name) {
+                record_remote_effect(effect);
+            }
         }
     }
+}
+
+fn delete_remote_branch(repo: &Repository, branch: &str) -> Option<RemoteEffect> {
+    git::delete_remote_branch(repo, branch)
+        .ok()
+        .flatten()
+        .map(|prior_oid| RemoteEffect::BranchDeleted {
+            remote: "origin".to_string(),
+            branch: branch.to_string(),
+            prior_oid: Some(prior_oid.to_string()),
+        })
 }
 
 #[cfg(test)]

--- a/crates/gg-core/src/commands/completions.rs
+++ b/crates/gg-core/src/commands/completions.rs
@@ -13,6 +13,10 @@ use crate::error::Result;
 #[derive(clap::Parser)]
 #[command(name = "gg")]
 struct Cli {
+    /// Add a native-client token to an operation record, if this command creates one
+    #[arg(long, global = true, value_name = "ID")]
+    _client_operation_id: Option<String>,
+
     #[clap(subcommand)]
     command: Option<Commands>,
 }

--- a/crates/gg-core/src/commands/completions.rs
+++ b/crates/gg-core/src/commands/completions.rs
@@ -59,6 +59,8 @@ enum Commands {
     Squash {
         #[arg(short, long)]
         all: bool,
+        #[arg(long, conflicts_with = "all")]
+        staged_only: bool,
     },
     #[command(name = "reorder")]
     Reorder,

--- a/crates/gg-core/src/commands/land.rs
+++ b/crates/gg-core/src/commands/land.rs
@@ -980,6 +980,11 @@ pub fn run(opts: LandOptions) -> Result<()> {
                 &repo,
                 &stack.name,
                 true,
+                &mut |effect| {
+                    guard.record_remote_effect(effect.clone());
+                    remote_effects.push(effect);
+                    touched_remote = true;
+                },
             )
             .is_ok()
             {

--- a/crates/gg-core/src/commands/ls.rs
+++ b/crates/gg-core/src/commands/ls.rs
@@ -134,6 +134,7 @@ fn list_all_stacks(repo: &git2::Repository, config: &Config, json: bool) -> Resu
 
         print_json(&AllStacksResponse {
             version: OUTPUT_VERSION,
+            operation_id: operations::interrupted_rebase_operation(repo)?.map(|record| record.id),
             current_stack,
             stacks: summaries,
         });

--- a/crates/gg-core/src/commands/ls.rs
+++ b/crates/gg-core/src/commands/ls.rs
@@ -5,6 +5,7 @@ use console::style;
 use crate::config::Config;
 use crate::error::Result;
 use crate::git;
+use crate::operations;
 use crate::output::{
     print_json, AllStacksResponse, RemoteStackJson, RemoteStacksResponse, SingleStackResponse,
     StackCommitJson, StackEntryJson, StackJson, StackSummaryJson, OUTPUT_VERSION,
@@ -563,6 +564,7 @@ fn show_stack(stack: &Stack, json: bool) -> Result<()> {
 
         print_json(&SingleStackResponse {
             version: OUTPUT_VERSION,
+            operation_id: operations::interrupted_rebase_operation(&repo)?.map(|record| record.id),
             stack: StackJson {
                 name: stack.name.clone(),
                 base: stack.base.clone(),

--- a/crates/gg-core/src/commands/mod.rs
+++ b/crates/gg-core/src/commands/mod.rs
@@ -20,6 +20,7 @@ pub mod restack;
 pub mod run;
 pub mod setup;
 pub mod split;
+pub mod split_protocol;
 pub mod split_tui;
 pub mod squash;
 pub mod sync;

--- a/crates/gg-core/src/commands/split.rs
+++ b/crates/gg-core/src/commands/split.rs
@@ -1399,7 +1399,7 @@ fn build_tree_from_hunks<'a>(
     }
 
     // For each file, determine what to do:
-    // - All hunks selected: use target tree entry
+    // - All hunks selected: use target tree entry unless metadata must remain
     // - No hunks selected: use parent tree entry
     // - Partial: apply selected hunks to parent content
     let mut accumulated_tree = repo.find_tree(parent_tree.id())?;
@@ -1423,7 +1423,31 @@ fn build_tree_from_hunks<'a>(
                 let target_file = target_diff_files.get(file_path).ok_or_else(|| {
                     GgError::Other(format!("Missing diff identity for '{file_path}'"))
                 })?;
-                if let Some(target_file) = target_file {
+                let parent_mode = accumulated_tree
+                    .get_path(Path::new(file_path))
+                    .ok()
+                    .map(|entry| entry.filemode());
+                let has_mode_change = target_file.as_ref().is_some_and(|target_file| {
+                    matches!(target_file.mode, 0o100644 | 0o100755)
+                        && match parent_mode {
+                            Some(mode @ (0o100644 | 0o100755)) => mode != target_file.mode,
+                            None => target_file.mode == 0o100755,
+                            _ => false,
+                        }
+                });
+                if has_mode_change {
+                    let selected_hunks = file_hunk_list
+                        .iter()
+                        .map(|(_, hunk)| *hunk)
+                        .collect::<Vec<_>>();
+                    apply_hunks_to_tree(
+                        repo,
+                        &mut builder,
+                        &accumulated_tree,
+                        file_path,
+                        &selected_hunks,
+                    )?;
+                } else if let Some(target_file) = target_file {
                     update_tree_entry(
                         repo,
                         &mut builder,

--- a/crates/gg-core/src/commands/split.rs
+++ b/crates/gg-core/src/commands/split.rs
@@ -1,6 +1,6 @@
 //! `gg split` - Split a commit into two
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::{self, Write};
 use std::process::Command;
 
@@ -13,8 +13,12 @@ use crate::error::{GgError, Result};
 use crate::git;
 use crate::immutability::{self, ImmutabilityPolicy};
 use crate::operations::{self, OperationKind, SnapshotScope};
+use crate::output;
 use crate::stack::{self, Stack};
 
+use super::split_protocol::{
+    describe_hunk, plan_token, SplitDescribeResponse, SplitTargetIdentity, SPLIT_PROTOCOL_VERSION,
+};
 pub use super::split_protocol::{DiffHunk, DiffLine};
 
 /// Options for the split command
@@ -32,6 +36,18 @@ pub struct SplitOptions {
     pub no_tui: bool,
     /// If true, override the immutability check.
     pub force: bool,
+    /// If true, describe the target commit's hunks without changing the repository.
+    pub describe: bool,
+    /// If true, emit machine-readable JSON output.
+    pub json: bool,
+}
+
+struct ResolvedSplitTarget<'repo> {
+    stack: Stack,
+    target_pos: usize,
+    target_commit: git2::Commit<'repo>,
+    parent_commit: git2::Commit<'repo>,
+    original_gg_id: Option<String>,
 }
 
 /// Information about a file changed in a commit
@@ -57,6 +73,12 @@ impl std::fmt::Display for ChangedFile {
 
 /// Run the split command
 pub fn run(options: SplitOptions) -> Result<()> {
+    if options.describe {
+        let response = describe(&options)?;
+        output::print_json(&response);
+        return Ok(());
+    }
+
     let repo = git::open_repo()?;
     let config = Config::load_with_global(repo.commondir())?;
     // Acquire the operation lock up-front but defer writing the op-log
@@ -66,30 +88,13 @@ pub fn run(options: SplitOptions) -> Result<()> {
 
     git::require_clean_working_directory(&repo)?;
 
-    let mut stack = Stack::load(&repo, &config)?;
-    // Best-effort refresh of mr_state for the immutability guard (catches
-    // squash-merged PRs that base-ancestor would otherwise miss).
-    immutability::refresh_mr_state_for_guard(&repo, &mut stack);
-
-    // Resolve target commit position (1-indexed)
-    let target_pos = match &options.target {
-        Some(target) => stack::resolve_target(&stack, target)?,
-        None => {
-            // Default to current position or stack head
-            stack.current_position.map(|p| p + 1).unwrap_or(stack.len())
-        }
-    };
-
-    let entry = stack.get_entry_by_position(target_pos).ok_or_else(|| {
-        GgError::Other(format!(
-            "Commit at position {} not found in stack",
-            target_pos
-        ))
-    })?;
-
-    let target_oid = entry.oid;
-    let target_commit = repo.find_commit(target_oid)?;
-    let original_gg_id = entry.gg_id.clone();
+    let ResolvedSplitTarget {
+        stack,
+        target_pos,
+        target_commit,
+        parent_commit,
+        original_gg_id,
+    } = resolve_target(&repo, &config, options.target.as_deref(), false)?;
 
     // Immutability pre-flight: splitting rewrites the target commit and every
     // commit above it (they get a new parent). Guard against splitting a
@@ -107,11 +112,6 @@ pub fn run(options: SplitOptions) -> Result<()> {
         style(git::get_commit_title(&target_commit)).bold(),
         style(git::short_sha(&target_commit)).yellow()
     );
-
-    // Get parent commit
-    let parent_commit = target_commit
-        .parent(0)
-        .map_err(|_| GgError::Other("Cannot split the root commit (no parent)".to_string()))?;
 
     // Get list of changed files with stats
     let changed_files = get_changed_files(&repo, &parent_commit, &target_commit)?;
@@ -337,6 +337,96 @@ pub fn run(options: SplitOptions) -> Result<()> {
     )?;
 
     Ok(())
+}
+
+fn resolve_target<'repo>(
+    repo: &'repo git2::Repository,
+    config: &Config,
+    target: Option<&str>,
+    check_immutability: bool,
+) -> Result<ResolvedSplitTarget<'repo>> {
+    let mut stack = Stack::load(repo, config)?;
+    // Best-effort refresh of mr_state for the immutability guard (catches
+    // squash-merged PRs that base-ancestor would otherwise miss).
+    immutability::refresh_mr_state_for_guard(repo, &mut stack);
+
+    let target_pos = match target {
+        Some(target) => stack::resolve_target(&stack, target)?,
+        None => stack
+            .current_position
+            .map(|position| position + 1)
+            .unwrap_or(stack.len()),
+    };
+
+    let entry = stack.get_entry_by_position(target_pos).ok_or_else(|| {
+        GgError::Other(format!(
+            "Commit at position {} not found in stack",
+            target_pos
+        ))
+    })?;
+    let target_commit = repo.find_commit(entry.oid)?;
+    let parent_commit = target_commit
+        .parent(0)
+        .map_err(|_| GgError::Other("Cannot split the root commit (no parent)".to_string()))?;
+    let original_gg_id = entry.gg_id.clone();
+
+    if check_immutability {
+        let targets: Vec<usize> = (target_pos..=stack.len()).collect();
+        let policy = ImmutabilityPolicy::for_stack(repo, &stack)?;
+        let report = policy.check_positions(&stack, &targets);
+        immutability::guard(report, false)?;
+    }
+
+    Ok(ResolvedSplitTarget {
+        stack,
+        target_pos,
+        target_commit,
+        parent_commit,
+        original_gg_id,
+    })
+}
+
+/// Describe a split target without changing repository state.
+pub fn describe(options: &SplitOptions) -> Result<SplitDescribeResponse> {
+    let repo = git::open_repo()?;
+    let config = Config::load_with_global(repo.commondir())?;
+    let resolved = resolve_target(&repo, &config, options.target.as_deref(), true)?;
+    let hunks = get_hunks(&repo, &resolved.parent_commit, &resolved.target_commit)?;
+    let described_hunks = hunks
+        .iter()
+        .enumerate()
+        .map(|(index, hunk)| describe_hunk(index, hunk))
+        .collect::<Vec<_>>();
+    let hunk_files = hunks
+        .iter()
+        .map(|hunk| hunk.file_path.as_str())
+        .collect::<HashSet<_>>();
+    let non_textual_files =
+        get_changed_files(&repo, &resolved.parent_commit, &resolved.target_commit)?
+            .into_iter()
+            .filter(|file| !hunk_files.contains(file.path.as_str()))
+            .map(|file| file.path)
+            .collect();
+    let target = SplitTargetIdentity {
+        gg_id: resolved.original_gg_id,
+        sha: resolved.target_commit.id().to_string(),
+        tree: resolved.target_commit.tree_id().to_string(),
+    };
+    let remainder_message =
+        git::strip_gg_id_from_message(resolved.target_commit.message().unwrap_or(""));
+
+    Ok(SplitDescribeResponse {
+        version: SPLIT_PROTOCOL_VERSION,
+        plan_token: plan_token(&target, &described_hunks),
+        target,
+        hunks: described_hunks,
+        non_textual_files,
+        first_message: format!(
+            "Split from: {}",
+            git::get_commit_title(&resolved.target_commit)
+        ),
+        remainder_message,
+    })
 }
 
 /// Get the list of files changed between two commits

--- a/crates/gg-core/src/commands/split.rs
+++ b/crates/gg-core/src/commands/split.rs
@@ -15,6 +15,8 @@ use crate::immutability::{self, ImmutabilityPolicy};
 use crate::operations::{self, OperationKind, SnapshotScope};
 use crate::stack::{self, Stack};
 
+pub use super::split_protocol::{DiffHunk, DiffLine};
+
 /// Options for the split command
 #[derive(Debug, Default)]
 pub struct SplitOptions {
@@ -30,36 +32,6 @@ pub struct SplitOptions {
     pub no_tui: bool,
     /// If true, override the immutability check.
     pub force: bool,
-}
-
-/// A single line in a diff hunk
-#[derive(Debug, Clone)]
-pub struct DiffLine {
-    /// Origin character: '+' (added), '-' (deleted), ' ' (context)
-    pub origin: char,
-    /// The line content (without the origin character)
-    pub content: String,
-}
-
-/// A diff hunk representing a contiguous change in a file
-#[derive(Debug, Clone)]
-pub struct DiffHunk {
-    /// File path relative to repo root
-    pub file_path: String,
-    /// Hunk header (e.g., "@@ -10,6 +10,12 @@ fn authenticate...")
-    pub header: String,
-    /// Lines in the hunk
-    pub lines: Vec<DiffLine>,
-    /// Starting line number in the old file
-    pub old_start: u32,
-    /// Number of lines in the old file (used in split/display)
-    #[allow(dead_code)]
-    pub old_lines: u32,
-    /// Starting line number in the new file
-    pub new_start: u32,
-    /// Number of lines in the new file (used in split/display)
-    #[allow(dead_code)]
-    pub new_lines: u32,
 }
 
 /// Information about a file changed in a commit

--- a/crates/gg-core/src/commands/split.rs
+++ b/crates/gg-core/src/commands/split.rs
@@ -363,7 +363,15 @@ pub fn apply_plan(_options: &SplitOptions, path: &Path) -> Result<SplitApplyResp
             "Split plan must select at least one hunk".into(),
         ));
     }
-    if selected_indices.len() == described_hunks.len() {
+    let changed_files = get_changed_files(&repo, &resolved.parent_commit, &resolved.target_commit)?;
+    let hunk_files = hunks
+        .iter()
+        .map(|hunk| hunk.file_path.as_str())
+        .collect::<HashSet<_>>();
+    let has_non_textual_changes = changed_files
+        .iter()
+        .any(|file| !hunk_files.contains(file.path.as_str()));
+    if selected_indices.len() == described_hunks.len() && !has_non_textual_changes {
         return Err(GgError::Other(
             "No changes would remain in the remainder commit".into(),
         ));
@@ -377,7 +385,6 @@ pub fn apply_plan(_options: &SplitOptions, path: &Path) -> Result<SplitApplyResp
         ));
     }
 
-    let changed_files = get_changed_files(&repo, &resolved.parent_commit, &resolved.target_commit)?;
     let selected_paths = selected_indices
         .iter()
         .map(|index| hunks[*index].file_path.as_str())

--- a/crates/gg-core/src/commands/split.rs
+++ b/crates/gg-core/src/commands/split.rs
@@ -1,6 +1,6 @@
 //! `gg split` - Split a commit into two
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -70,6 +70,12 @@ struct ChangedFile {
     additions: usize,
     /// Lines deleted
     deletions: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct TargetDiffFile {
+    oid: git2::Oid,
+    mode: i32,
 }
 
 impl std::fmt::Display for ChangedFile {
@@ -371,6 +377,14 @@ pub fn apply_plan(_options: &SplitOptions, path: &Path) -> Result<SplitApplyResp
         ));
     }
 
+    let changed_files = get_changed_files(&repo, &resolved.parent_commit, &resolved.target_commit)?;
+    let selected_paths = selected_indices
+        .iter()
+        .map(|index| hunks[*index].file_path.as_str())
+        .collect::<HashSet<_>>();
+    let target_tree = resolved.target_commit.tree()?;
+    validate_path_dependent_selection(&target_tree, &changed_files, &selected_paths)?;
+
     let result = execute_split(
         &repo,
         &config,
@@ -395,6 +409,51 @@ pub fn apply_plan(_options: &SplitOptions, path: &Path) -> Result<SplitApplyResp
 
 fn stale_split_plan(reason: &str) -> GgError {
     GgError::Other(format!("stale split plan: {reason}"))
+}
+
+fn validate_path_dependent_selection(
+    target_tree: &git2::Tree,
+    changed_files: &[ChangedFile],
+    selected_paths: &HashSet<&str>,
+) -> Result<()> {
+    for (index, first) in changed_files.iter().enumerate() {
+        for second in &changed_files[index + 1..] {
+            if !paths_have_prefix_dependency(&first.path, &second.path) {
+                continue;
+            }
+
+            let first_selected = selected_paths.contains(first.path.as_str());
+            let second_selected = selected_paths.contains(second.path.as_str());
+            if first_selected == second_selected {
+                continue;
+            }
+
+            let (selected, dependent) = if first_selected {
+                (&first.path, &second.path)
+            } else {
+                (&second.path, &first.path)
+            };
+            let selected_is_target_leaf = target_tree
+                .get_path(Path::new(selected))
+                .ok()
+                .is_some_and(|entry| entry.kind() != Some(git2::ObjectType::Tree));
+            if selected_is_target_leaf {
+                return Err(GgError::Other(format!(
+                    "path-dependent split selection: selecting '{selected}' would also apply the unselected change '{dependent}'; select both sides together or leave '{selected}' in the remainder"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn paths_have_prefix_dependency(first: &str, second: &str) -> bool {
+    second
+        .strip_prefix(first)
+        .is_some_and(|suffix| suffix.starts_with('/'))
+        || first
+            .strip_prefix(second)
+            .is_some_and(|suffix| suffix.starts_with('/'))
 }
 
 fn execute_split(
@@ -582,6 +641,8 @@ pub fn describe(options: &SplitOptions) -> Result<SplitDescribeResponse> {
             .into_iter()
             .filter(|file| !hunk_files.contains(file.path.as_str()))
             .map(|file| file.path)
+            .collect::<BTreeSet<_>>()
+            .into_iter()
             .collect();
     let target = SplitTargetIdentity {
         gg_id: resolved.original_gg_id,
@@ -681,16 +742,13 @@ fn insert_nested_entry(
     repo: &git2::Repository,
     root_builder: &mut git2::TreeBuilder,
     parent_tree: &git2::Tree,
-    target_tree: &git2::Tree,
     file_path: &str,
+    target_file: TargetDiffFile,
 ) -> Result<()> {
     let parts: Vec<&str> = file_path.split('/').collect();
 
-    // Get the target entry (or None if deleted)
-    let target_entry = target_tree.get_path(std::path::Path::new(file_path)).ok();
-
     // Recursively rebuild the tree hierarchy from the top directory down
-    let new_subtree_oid = rebuild_subtree(repo, parent_tree, &parts, 0, target_entry.as_ref())?;
+    let new_subtree_oid = rebuild_subtree(repo, parent_tree, &parts, 0, target_file)?;
 
     // Update the root builder with the new subtree
     root_builder
@@ -706,7 +764,7 @@ fn rebuild_subtree(
     parent_tree: &git2::Tree,
     parts: &[&str],
     depth: usize,
-    target_entry: Option<&git2::TreeEntry>,
+    target_file: TargetDiffFile,
 ) -> std::result::Result<git2::Oid, GgError> {
     // Get the current subtree from parent at this depth
     let subpath = parts[..=depth].join("/");
@@ -732,17 +790,12 @@ fn rebuild_subtree(
     if depth == parts.len() - 2 {
         // This is the parent directory of the file
         let filename = parts[parts.len() - 1];
-        if let Some(entry) = target_entry {
-            builder
-                .insert(filename, entry.id(), entry.filemode())
-                .map_err(|e| GgError::Other(format!("Failed to insert entry: {}", e)))?;
-        } else {
-            // File was deleted
-            let _ = builder.remove(filename);
-        }
+        builder
+            .insert(filename, target_file.oid, target_file.mode)
+            .map_err(|e| GgError::Other(format!("Failed to insert entry: {}", e)))?;
     } else {
         // Intermediate directory - recurse
-        let child_oid = rebuild_subtree(repo, parent_tree, parts, depth + 1, target_entry)?;
+        let child_oid = rebuild_subtree(repo, parent_tree, parts, depth + 1, target_file)?;
         builder
             .insert(parts[depth + 1], child_oid, 0o040000)
             .map_err(|e| GgError::Other(format!("Failed to insert subtree: {}", e)))?;
@@ -910,6 +963,22 @@ fn get_hunks(
     let mut current_file_path;
     let mut current_hunk: Option<DiffHunk> = None;
 
+    let mut non_reconstructable_paths = HashSet::new();
+    for delta in diff.deltas() {
+        let old_file = delta.old_file();
+        let new_file = delta.new_file();
+        if !diff_file_supports_hunk_reconstruction(repo, &old_file)?
+            || !diff_file_supports_hunk_reconstruction(repo, &new_file)?
+        {
+            let path = new_file
+                .path()
+                .or_else(|| old_file.path())
+                .map(|path| path.to_string_lossy().to_string())
+                .unwrap_or_default();
+            non_reconstructable_paths.insert(path);
+        }
+    }
+
     // We need to iterate patch-by-patch to avoid borrow checker issues with foreach
     let num_deltas = diff.deltas().len();
 
@@ -918,12 +987,20 @@ fn get_hunks(
             .get_delta(delta_idx)
             .ok_or_else(|| GgError::Other(format!("Failed to get delta {}", delta_idx)))?;
 
-        current_file_path = delta
-            .new_file()
-            .path()
-            .or_else(|| delta.old_file().path())
+        let old_file = delta.old_file();
+        let new_file = delta.new_file();
+        let old_path = old_file.path().map(Path::to_path_buf);
+        let new_path = new_file.path().map(Path::to_path_buf);
+
+        current_file_path = new_path
+            .as_deref()
+            .or(old_path.as_deref())
             .map(|p| p.to_string_lossy().to_string())
             .unwrap_or_default();
+
+        if non_reconstructable_paths.contains(&current_file_path) {
+            continue;
+        }
 
         // Get the patch for this delta
         let patch = git2::Patch::from_diff(&diff, delta_idx)?;
@@ -978,6 +1055,27 @@ fn get_hunks(
     }
 
     Ok(hunks)
+}
+
+fn diff_file_supports_hunk_reconstruction(
+    repo: &git2::Repository,
+    file: &git2::DiffFile<'_>,
+) -> Result<bool> {
+    if !file.exists() {
+        return Ok(true);
+    }
+    if !matches!(
+        file.mode(),
+        git2::FileMode::Blob | git2::FileMode::BlobGroupWritable | git2::FileMode::BlobExecutable
+    ) {
+        return Ok(false);
+    }
+    let Ok(blob) = repo.find_blob(file.id()) else {
+        return Ok(false);
+    };
+
+    let content = blob.content();
+    Ok(std::str::from_utf8(content).is_ok() && !content.contains(&b'\r'))
 }
 
 /// Print help for interactive hunk selection
@@ -1282,8 +1380,10 @@ fn build_tree_from_hunks<'a>(
     selected_indices: &[usize],
     non_hunk_files: &[String],
 ) -> Result<git2::Tree<'a>> {
+    let target_diff_files = target_diff_files(repo, parent_tree, target_tree)?;
+
     // Group hunks by file
-    let mut file_hunks: HashMap<String, Vec<(usize, &DiffHunk)>> = HashMap::new();
+    let mut file_hunks: BTreeMap<String, Vec<(usize, &DiffHunk)>> = BTreeMap::new();
     for (idx, hunk) in hunks.iter().enumerate() {
         file_hunks
             .entry(hunk.file_path.clone())
@@ -1295,7 +1395,7 @@ fn build_tree_from_hunks<'a>(
     // - All hunks selected: use target tree entry
     // - No hunks selected: use parent tree entry
     // - Partial: apply selected hunks to parent content
-    let mut builder = repo.treebuilder(Some(parent_tree))?;
+    let mut accumulated_tree = repo.find_tree(parent_tree.id())?;
 
     for (file_path, file_hunk_list) in &file_hunks {
         let file_indices: Vec<usize> = file_hunk_list.iter().map(|(idx, _)| *idx).collect();
@@ -1305,46 +1405,107 @@ fn build_tree_from_hunks<'a>(
             .copied()
             .collect();
 
-        let path = std::path::Path::new(file_path);
-
         if selected_in_file.is_empty() {
             // No hunks selected for this file - keep parent version (no change to builder)
             continue;
-        } else if selected_in_file.len() == file_hunk_list.len() {
-            // All hunks selected - use target tree entry
-            if target_tree.get_path(path).is_ok() {
-                // Update the tree with target entry
-                update_tree_entry(repo, &mut builder, parent_tree, target_tree, file_path)?;
-            } else {
-                // File was deleted in target - apply deletion
-                remove_tree_entry(repo, &mut builder, parent_tree, file_path)?;
-            }
-        } else {
-            // Partial selection - apply hunks
-            let selected_hunks: Vec<&DiffHunk> = file_hunk_list
-                .iter()
-                .filter(|(idx, _)| selected_indices.contains(idx))
-                .map(|(_, h)| *h)
-                .collect();
-
-            apply_hunks_to_tree(repo, &mut builder, parent_tree, file_path, &selected_hunks)?;
         }
+
+        let tree_oid = {
+            let mut builder = repo.treebuilder(Some(&accumulated_tree))?;
+            if selected_in_file.len() == file_hunk_list.len() {
+                let target_file = target_diff_files.get(file_path).ok_or_else(|| {
+                    GgError::Other(format!("Missing diff identity for '{file_path}'"))
+                })?;
+                if let Some(target_file) = target_file {
+                    update_tree_entry(
+                        repo,
+                        &mut builder,
+                        &accumulated_tree,
+                        file_path,
+                        *target_file,
+                    )?;
+                } else {
+                    remove_tree_entry(repo, &mut builder, &accumulated_tree, file_path)?;
+                }
+            } else {
+                // Partial selection - apply hunks
+                let selected_hunks: Vec<&DiffHunk> = file_hunk_list
+                    .iter()
+                    .filter(|(idx, _)| selected_indices.contains(idx))
+                    .map(|(_, h)| *h)
+                    .collect();
+
+                apply_hunks_to_tree(
+                    repo,
+                    &mut builder,
+                    &accumulated_tree,
+                    file_path,
+                    &selected_hunks,
+                )?;
+            }
+            builder.write()?
+        };
+        accumulated_tree = repo.find_tree(tree_oid)?;
     }
 
     // Include non-hunk files (binary, rename-only, mode-only) wholesale from target tree
-    for file_path in non_hunk_files {
-        let path = std::path::Path::new(file_path.as_str());
-        if target_tree.get_path(path).is_ok() {
-            update_tree_entry(repo, &mut builder, parent_tree, target_tree, file_path)?;
-        } else {
-            // File was deleted in target - apply deletion
-            remove_tree_entry(repo, &mut builder, parent_tree, file_path)?;
-        }
+    let mut sorted_non_hunk_files = non_hunk_files.to_vec();
+    sorted_non_hunk_files.sort();
+    sorted_non_hunk_files.dedup();
+    for file_path in &sorted_non_hunk_files {
+        let tree_oid = {
+            let mut builder = repo.treebuilder(Some(&accumulated_tree))?;
+            let target_file = target_diff_files.get(file_path).ok_or_else(|| {
+                GgError::Other(format!("Missing diff identity for '{file_path}'"))
+            })?;
+            if let Some(target_file) = target_file {
+                update_tree_entry(
+                    repo,
+                    &mut builder,
+                    &accumulated_tree,
+                    file_path,
+                    *target_file,
+                )?;
+            } else {
+                remove_tree_entry(repo, &mut builder, &accumulated_tree, file_path)?;
+            }
+            builder.write()?
+        };
+        accumulated_tree = repo.find_tree(tree_oid)?;
     }
 
-    let tree_oid = builder.write()?;
-    let tree = repo.find_tree(tree_oid)?;
-    Ok(tree)
+    Ok(accumulated_tree)
+}
+
+fn target_diff_files(
+    repo: &git2::Repository,
+    parent_tree: &git2::Tree,
+    target_tree: &git2::Tree,
+) -> Result<HashMap<String, Option<TargetDiffFile>>> {
+    let diff = repo.diff_tree_to_tree(Some(parent_tree), Some(target_tree), None)?;
+    let mut files: HashMap<String, Option<TargetDiffFile>> = HashMap::new();
+    for delta in diff.deltas() {
+        let old_file = delta.old_file();
+        let new_file = delta.new_file();
+        let path = new_file
+            .path()
+            .or_else(|| old_file.path())
+            .map(|path| path.to_string_lossy().to_string())
+            .unwrap_or_default();
+        let target_file = new_file.exists().then(|| TargetDiffFile {
+            oid: new_file.id(),
+            mode: new_file.mode().into(),
+        });
+        files
+            .entry(path)
+            .and_modify(|existing| {
+                if target_file.is_some() {
+                    *existing = target_file;
+                }
+            })
+            .or_insert(target_file);
+    }
+    Ok(files)
 }
 
 /// Update a tree entry to use the target version
@@ -1352,20 +1513,18 @@ fn update_tree_entry(
     repo: &git2::Repository,
     builder: &mut git2::TreeBuilder,
     parent_tree: &git2::Tree,
-    target_tree: &git2::Tree,
     file_path: &str,
+    target_file: TargetDiffFile,
 ) -> Result<()> {
     let path = std::path::Path::new(file_path);
 
-    if let Ok(entry) = target_tree.get_path(path) {
-        if path.parent().is_some() && path.parent() != Some(std::path::Path::new("")) {
-            // Nested path
-            insert_nested_entry(repo, builder, parent_tree, target_tree, file_path)?;
-        } else {
-            // Top-level file
-            let name = path.file_name().unwrap().to_string_lossy();
-            builder.insert(&*name, entry.id(), entry.filemode())?;
-        }
+    if path.parent().is_some() && path.parent() != Some(std::path::Path::new("")) {
+        // Nested path
+        insert_nested_entry(repo, builder, parent_tree, file_path, target_file)?;
+    } else {
+        // Top-level file
+        let name = path.file_name().unwrap().to_string_lossy();
+        builder.insert(&*name, target_file.oid, target_file.mode)?;
     }
     Ok(())
 }
@@ -1397,12 +1556,61 @@ fn insert_nested_entry_for_deletion(
     parent_tree: &git2::Tree,
     file_path: &str,
 ) -> Result<()> {
+    if parent_tree.get_path(Path::new(file_path)).is_err() {
+        return Ok(());
+    }
+
     let parts: Vec<&str> = file_path.split('/').collect();
-    let new_subtree_oid = rebuild_subtree(repo, parent_tree, &parts, 0, None)?;
-    root_builder
-        .insert(parts[0], new_subtree_oid, 0o040000)
-        .map_err(|e| GgError::Other(format!("Failed to update root tree: {}", e)))?;
+    match rebuild_subtree_for_deletion(repo, parent_tree, &parts, 0)? {
+        Some(new_subtree_oid) => {
+            root_builder
+                .insert(parts[0], new_subtree_oid, 0o040000)
+                .map_err(|e| GgError::Other(format!("Failed to update root tree: {}", e)))?;
+        }
+        None => {
+            let _ = root_builder.remove(parts[0]);
+        }
+    }
     Ok(())
+}
+
+fn rebuild_subtree_for_deletion(
+    repo: &git2::Repository,
+    parent_tree: &git2::Tree,
+    parts: &[&str],
+    depth: usize,
+) -> Result<Option<git2::Oid>> {
+    let subpath = parts[..=depth].join("/");
+    let current_subtree = if depth == 0 {
+        parent_tree
+            .get_name(parts[0])
+            .and_then(|entry| repo.find_tree(entry.id()).ok())
+    } else {
+        parent_tree
+            .get_path(Path::new(&subpath))
+            .ok()
+            .and_then(|entry| repo.find_tree(entry.id()).ok())
+    };
+    let mut builder = repo.treebuilder(current_subtree.as_ref())?;
+
+    if depth == parts.len() - 2 {
+        let _ = builder.remove(parts[parts.len() - 1]);
+    } else {
+        match rebuild_subtree_for_deletion(repo, parent_tree, parts, depth + 1)? {
+            Some(child_oid) => {
+                builder.insert(parts[depth + 1], child_oid, 0o040000)?;
+            }
+            None => {
+                let _ = builder.remove(parts[depth + 1]);
+            }
+        }
+    }
+
+    if builder.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(builder.write()?))
+    }
 }
 
 /// Apply selected hunks to a file and update the tree
@@ -1456,8 +1664,8 @@ fn apply_hunks_to_content(parent_content: &str, hunks: &[&DiffHunk]) -> Result<S
     let mut sorted_hunks: Vec<&DiffHunk> = hunks.to_vec();
     sorted_hunks.sort_by_key(|h| h.old_start);
 
-    let parent_lines: Vec<&str> = parent_content.lines().collect();
-    let mut result_lines: Vec<String> = Vec::new();
+    let parent_lines: Vec<&str> = parent_content.split_inclusive('\n').collect();
+    let mut result = String::new();
     let mut parent_idx = 0usize; // 0-indexed position in parent
 
     for hunk in sorted_hunks {
@@ -1466,7 +1674,7 @@ fn apply_hunks_to_content(parent_content: &str, hunks: &[&DiffHunk]) -> Result<S
 
         // Copy lines from parent before this hunk
         while parent_idx < hunk_start && parent_idx < parent_lines.len() {
-            result_lines.push(parent_lines[parent_idx].to_string());
+            result.push_str(parent_lines[parent_idx]);
             parent_idx += 1;
         }
 
@@ -1474,8 +1682,7 @@ fn apply_hunks_to_content(parent_content: &str, hunks: &[&DiffHunk]) -> Result<S
         for line in &hunk.lines {
             match line.origin {
                 '+' => {
-                    // Add new line
-                    result_lines.push(line.content.trim_end_matches('\n').to_string());
+                    result.push_str(&line.content);
                 }
                 '-' => {
                     // Skip (delete) line from parent
@@ -1483,7 +1690,7 @@ fn apply_hunks_to_content(parent_content: &str, hunks: &[&DiffHunk]) -> Result<S
                 }
                 ' ' if parent_idx < parent_lines.len() => {
                     // Context - should match, advance parent
-                    result_lines.push(parent_lines[parent_idx].to_string());
+                    result.push_str(parent_lines[parent_idx]);
                     parent_idx += 1;
                 }
                 _ => {}
@@ -1493,15 +1700,8 @@ fn apply_hunks_to_content(parent_content: &str, hunks: &[&DiffHunk]) -> Result<S
 
     // Copy remaining lines from parent
     while parent_idx < parent_lines.len() {
-        result_lines.push(parent_lines[parent_idx].to_string());
+        result.push_str(parent_lines[parent_idx]);
         parent_idx += 1;
-    }
-
-    // Join with newlines, preserve trailing newline if original had one
-    // For new files (empty parent), add trailing newline if there's content
-    let mut result = result_lines.join("\n");
-    if !result_lines.is_empty() && (parent_content.is_empty() || parent_content.ends_with('\n')) {
-        result.push('\n');
     }
 
     Ok(result)

--- a/crates/gg-core/src/commands/split.rs
+++ b/crates/gg-core/src/commands/split.rs
@@ -2,6 +2,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::io::{self, Write};
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use console::{style, Term};
@@ -17,7 +18,8 @@ use crate::output;
 use crate::stack::{self, Stack};
 
 use super::split_protocol::{
-    describe_hunk, plan_token, SplitDescribeResponse, SplitTargetIdentity, SPLIT_PROTOCOL_VERSION,
+    describe_hunk, plan_token, read_plan, SplitApplyResponse, SplitApplyResult,
+    SplitCommitIdentity, SplitDescribeResponse, SplitTargetIdentity, SPLIT_PROTOCOL_VERSION,
 };
 pub use super::split_protocol::{DiffHunk, DiffLine};
 
@@ -38,6 +40,8 @@ pub struct SplitOptions {
     pub force: bool,
     /// If true, describe the target commit's hunks without changing the repository.
     pub describe: bool,
+    /// Apply a previously described structured split plan.
+    pub plan_json: Option<PathBuf>,
     /// If true, emit machine-readable JSON output.
     pub json: bool,
 }
@@ -48,6 +52,13 @@ struct ResolvedSplitTarget<'repo> {
     target_commit: git2::Commit<'repo>,
     parent_commit: git2::Commit<'repo>,
     original_gg_id: Option<String>,
+}
+
+struct SplitSelection {
+    selected_indices: Vec<usize>,
+    non_hunk_files: Vec<String>,
+    first_message: String,
+    remainder_message: String,
 }
 
 /// Information about a file changed in a commit
@@ -75,6 +86,11 @@ impl std::fmt::Display for ChangedFile {
 pub fn run(options: SplitOptions) -> Result<()> {
     if options.describe {
         let response = describe(&options)?;
+        output::print_json(&response);
+        return Ok(());
+    }
+    if let Some(path) = options.plan_json.as_deref() {
+        let response = apply_plan(&options, path)?;
         output::print_json(&response);
         return Ok(());
     }
@@ -121,10 +137,6 @@ pub fn run(options: SplitOptions) -> Result<()> {
             "Commit has no file changes to split".to_string(),
         ));
     }
-
-    // Get trees for building the split
-    let parent_tree = parent_commit.tree()?;
-    let target_tree = target_commit.tree()?;
 
     // If the TUI provides commit messages inline, they're stored here to skip the editor
     let mut tui_commit_message: Option<String> = None;
@@ -212,15 +224,6 @@ pub fn run(options: SplitOptions) -> Result<()> {
         );
     }
 
-    let first_tree = build_tree_from_hunks(
-        &repo,
-        &parent_tree,
-        &target_tree,
-        &hunks,
-        &selected_indices,
-        &non_hunk_files,
-    )?;
-
     // Get commit messages
     // Priority: -m flag > TUI inline message > editor prompt
     let new_commit_message = if options.message.is_some() {
@@ -237,74 +240,29 @@ pub fn run(options: SplitOptions) -> Result<()> {
         get_remainder_message(&options, &target_commit)?
     };
 
-    // All validation passed — write the Pending op-log record now, right
-    // before the first actual repo mutation. A failure beyond this point
-    // leaves a Pending record the sweep promotes to Interrupted, which
-    // `gg undo` refuses (avoiding an unsafe partial-state rewind).
-    let mut guard = git::begin_recorded_op(
+    let result = execute_split(
         &repo,
         &config,
-        OperationKind::Split,
+        ResolvedSplitTarget {
+            stack,
+            target_pos,
+            target_commit,
+            parent_commit,
+            original_gg_id,
+        },
+        &hunks,
+        SplitSelection {
+            selected_indices,
+            non_hunk_files,
+            first_message: new_commit_message,
+            remainder_message,
+        },
         std::env::args().skip(1).collect(),
-        None,
-        SnapshotScope::AllUserBranches,
     )?;
-    guard.set_pending_plan(json!({
-        "split": {
-            "branch_name": stack.branch_name(),
-            "remainder_position": target_pos + 1,
-            "remainder_gg_id": original_gg_id.clone(),
-        }
-    }));
 
-    // 2. Create the first (new, lower) commit
-    let sig = git::get_signature(&repo)?;
-    let new_gg_id = git::generate_gg_id();
-    let first_message = git::set_gg_id_in_message(&new_commit_message, &new_gg_id);
-    let first_oid = repo.commit(
-        None, // don't update any ref
-        &sig,
-        &sig,
-        &first_message,
-        &first_tree,
-        &[&parent_commit],
-    )?;
-    let first_commit = repo.find_commit(first_oid)?;
-
-    // 3. Create the second (remainder, upper) commit
-    //    Tree = original target tree (all changes). Parent = first commit.
-    //    This means the diff of second commit = only the non-selected files.
-    let remainder_msg = if let Some(gg_id) = &original_gg_id {
-        git::set_gg_id_in_message(&remainder_message, gg_id)
-    } else {
-        remainder_message.clone()
-    };
-    let second_oid = repo.commit(
-        None,
-        &sig,
-        &sig,
-        &remainder_msg,
-        &target_tree,
-        &[&first_commit],
-    )?;
-    let second_commit = repo.find_commit(second_oid)?;
-
-    // 4. Rebase descendants onto second commit
-    let num_rebased = match rebase_descendants(
-        &repo,
-        &stack,
-        &config,
-        target_pos,
-        &target_commit,
-        &second_commit,
-    ) {
-        Ok(num_rebased) => num_rebased,
-        Err(GgError::RebaseConflict) => {
-            let _ = operations::remember_interrupted_rebase_operation(&repo, guard.id());
-            return Err(GgError::RebaseConflict);
-        }
-        Err(e) => return Err(e),
-    };
+    let first_commit = repo.find_commit(git2::Oid::from_str(&result.first.sha)?)?;
+    let second_commit = repo.find_commit(git2::Oid::from_str(&result.remainder.sha)?)?;
+    let num_rebased = result.rewritten_descendants.len();
 
     // Print results
     println!("{} Split complete!", style("✔").green().bold());
@@ -328,15 +286,233 @@ pub fn run(options: SplitOptions) -> Result<()> {
         );
     }
 
-    guard.finalize_with_scope(
+    Ok(())
+}
+
+/// Apply a versioned split plan after validating it against current repository state.
+pub fn apply_plan(_options: &SplitOptions, path: &Path) -> Result<SplitApplyResponse> {
+    let plan = read_plan(path)?;
+    let repo = git::open_repo()?;
+    let config = Config::load_with_global(repo.commondir())?;
+    let _lock = git::acquire_operation_lock(&repo, "split")?;
+
+    git::require_clean_working_directory(&repo)?;
+
+    let target_selector = plan.target.gg_id.as_deref().unwrap_or(&plan.target.sha);
+    let resolved = match resolve_target(&repo, &config, Some(target_selector), true) {
+        Ok(resolved) => resolved,
+        Err(GgError::Other(message))
+            if message
+                == format!(
+                    "Could not find commit matching '{}' in stack",
+                    target_selector
+                ) =>
+        {
+            return Err(stale_split_plan("target identity changed"));
+        }
+        Err(error) => return Err(error),
+    };
+    let current_target = SplitTargetIdentity {
+        gg_id: resolved.original_gg_id.clone(),
+        sha: resolved.target_commit.id().to_string(),
+        tree: resolved.target_commit.tree_id().to_string(),
+    };
+    if current_target != plan.target {
+        return Err(stale_split_plan("target identity changed"));
+    }
+
+    let hunks = get_hunks(&repo, &resolved.parent_commit, &resolved.target_commit)?;
+    let described_hunks = hunks
+        .iter()
+        .enumerate()
+        .map(|(index, hunk)| describe_hunk(index, hunk))
+        .collect::<Vec<_>>();
+    if plan_token(&current_target, &described_hunks) != plan.plan_token {
+        return Err(stale_split_plan("hunks changed"));
+    }
+
+    let mut indices_by_id: HashMap<&str, Vec<usize>> = HashMap::new();
+    for (index, hunk) in described_hunks.iter().enumerate() {
+        indices_by_id.entry(&hunk.id).or_default().push(index);
+    }
+    let mut selected_indices = Vec::with_capacity(plan.selected_hunk_ids.len());
+    for id in &plan.selected_hunk_ids {
+        match indices_by_id.get(id.as_str()).map(Vec::as_slice) {
+            Some([index]) => selected_indices.push(*index),
+            Some(_) => {
+                return Err(GgError::Other(format!(
+                    "Split plan hunk ID '{id}' is not unique"
+                )))
+            }
+            None => {
+                return Err(GgError::Other(format!(
+                    "Split plan contains unknown hunk ID '{id}'"
+                )))
+            }
+        }
+    }
+
+    if selected_indices.is_empty() {
+        return Err(GgError::Other(
+            "Split plan must select at least one hunk".into(),
+        ));
+    }
+    if selected_indices.len() == described_hunks.len() {
+        return Err(GgError::Other(
+            "No changes would remain in the remainder commit".into(),
+        ));
+    }
+
+    let first_message = plan.first_message.trim().to_string();
+    let remainder_message = plan.remainder_message.trim().to_string();
+    if first_message.is_empty() || remainder_message.is_empty() {
+        return Err(GgError::Other(
+            "Split plan commit messages must not be empty".into(),
+        ));
+    }
+
+    let result = execute_split(
         &repo,
         &config,
-        SnapshotScope::AllUserBranches,
-        vec![],
-        false,
+        resolved,
+        &hunks,
+        SplitSelection {
+            selected_indices,
+            // Structured plans select textual hunks only. All non-textual files
+            // therefore remain in the upper commit.
+            non_hunk_files: vec![],
+            first_message,
+            remainder_message,
+        },
+        std::env::args().skip(1).collect(),
     )?;
 
-    Ok(())
+    Ok(SplitApplyResponse {
+        version: SPLIT_PROTOCOL_VERSION,
+        result,
+    })
+}
+
+fn stale_split_plan(reason: &str) -> GgError {
+    GgError::Other(format!("stale split plan: {reason}"))
+}
+
+fn execute_split(
+    repo: &git2::Repository,
+    config: &Config,
+    resolved: ResolvedSplitTarget<'_>,
+    hunks: &[DiffHunk],
+    selection: SplitSelection,
+    command_args: Vec<String>,
+) -> Result<SplitApplyResult> {
+    let ResolvedSplitTarget {
+        stack,
+        target_pos,
+        target_commit,
+        parent_commit,
+        original_gg_id,
+    } = resolved;
+    let original_sha = target_commit.id().to_string();
+    let parent_tree = parent_commit.tree()?;
+    let target_tree = target_commit.tree()?;
+    let first_tree = build_tree_from_hunks(
+        repo,
+        &parent_tree,
+        &target_tree,
+        hunks,
+        &selection.selected_indices,
+        &selection.non_hunk_files,
+    )?;
+
+    // All validation passed. From here on, failures retain an interrupted
+    // operation marker so partial mutations are never offered as undoable.
+    let mut guard = git::begin_recorded_op(
+        repo,
+        config,
+        OperationKind::Split,
+        command_args,
+        None,
+        SnapshotScope::AllUserBranches,
+    )?;
+    guard.set_pending_plan(json!({
+        "split": {
+            "branch_name": stack.branch_name(),
+            "remainder_position": target_pos + 1,
+            "remainder_gg_id": original_gg_id.clone(),
+        }
+    }));
+    let operation_id = guard.id().to_owned();
+
+    let sig = git::get_signature(repo)?;
+    let new_gg_id = git::generate_gg_id();
+    let first_message = git::set_gg_id_in_message(&selection.first_message, &new_gg_id);
+    let first_oid = repo.commit(
+        None,
+        &sig,
+        &sig,
+        &first_message,
+        &first_tree,
+        &[&parent_commit],
+    )?;
+    let first_commit = repo.find_commit(first_oid)?;
+
+    let remainder_message = if let Some(gg_id) = &original_gg_id {
+        git::set_gg_id_in_message(&selection.remainder_message, gg_id)
+    } else {
+        selection.remainder_message
+    };
+    let second_oid = repo.commit(
+        None,
+        &sig,
+        &sig,
+        &remainder_message,
+        &target_tree,
+        &[&first_commit],
+    )?;
+    let second_commit = repo.find_commit(second_oid)?;
+
+    if let Err(error) = rebase_descendants(
+        repo,
+        &stack,
+        config,
+        target_pos,
+        &target_commit,
+        &second_commit,
+    ) {
+        if matches!(error, GgError::RebaseConflict) {
+            let _ = operations::remember_interrupted_rebase_operation(repo, guard.id());
+        }
+        return Err(error);
+    }
+
+    let rewritten_stack = Stack::load(repo, config)?;
+    let first = split_identity_at(&rewritten_stack, target_pos)?;
+    let remainder = split_identity_at(&rewritten_stack, target_pos + 1)?;
+    let rewritten_descendants = ((target_pos + 2)..=rewritten_stack.len())
+        .map(|position| split_identity_at(&rewritten_stack, position))
+        .collect::<Result<Vec<_>>>()?;
+
+    guard.finalize_with_scope(repo, config, SnapshotScope::AllUserBranches, vec![], false)?;
+
+    Ok(SplitApplyResult {
+        operation_id,
+        original_sha,
+        first,
+        remainder,
+        rewritten_descendants,
+    })
+}
+
+fn split_identity_at(stack: &Stack, position: usize) -> Result<SplitCommitIdentity> {
+    let entry = stack.get_entry_by_position(position).ok_or_else(|| {
+        GgError::Other(format!(
+            "Split result commit at position {position} was not found"
+        ))
+    })?;
+    Ok(SplitCommitIdentity {
+        sha: entry.oid.to_string(),
+        gg_id: entry.gg_id.clone(),
+    })
 }
 
 fn resolve_target<'repo>(

--- a/crates/gg-core/src/commands/split.rs
+++ b/crates/gg-core/src/commands/split.rs
@@ -368,10 +368,15 @@ pub fn apply_plan(_options: &SplitOptions, path: &Path) -> Result<SplitApplyResp
         .iter()
         .map(|hunk| hunk.file_path.as_str())
         .collect::<HashSet<_>>();
-    let has_non_textual_changes = changed_files
+    let parent_tree = resolved.parent_commit.tree()?;
+    let target_tree = resolved.target_commit.tree()?;
+    let has_remainder_changes = changed_files
         .iter()
-        .any(|file| !hunk_files.contains(file.path.as_str()));
-    if selected_indices.len() == described_hunks.len() && !has_non_textual_changes {
+        .any(|file| !hunk_files.contains(file.path.as_str()))
+        || hunk_files
+            .iter()
+            .any(|path| has_regular_file_mode_change(&parent_tree, &target_tree, path));
+    if selected_indices.len() == described_hunks.len() && !has_remainder_changes {
         return Err(GgError::Other(
             "No changes would remain in the remainder commit".into(),
         ));
@@ -389,7 +394,6 @@ pub fn apply_plan(_options: &SplitOptions, path: &Path) -> Result<SplitApplyResp
         .iter()
         .map(|index| hunks[*index].file_path.as_str())
         .collect::<HashSet<_>>();
-    let target_tree = resolved.target_commit.tree()?;
     validate_path_dependent_selection(&target_tree, &changed_files, &selected_paths)?;
 
     let result = execute_split(
@@ -1423,18 +1427,8 @@ fn build_tree_from_hunks<'a>(
                 let target_file = target_diff_files.get(file_path).ok_or_else(|| {
                     GgError::Other(format!("Missing diff identity for '{file_path}'"))
                 })?;
-                let parent_mode = accumulated_tree
-                    .get_path(Path::new(file_path))
-                    .ok()
-                    .map(|entry| entry.filemode());
-                let has_mode_change = target_file.as_ref().is_some_and(|target_file| {
-                    matches!(target_file.mode, 0o100644 | 0o100755)
-                        && match parent_mode {
-                            Some(mode @ (0o100644 | 0o100755)) => mode != target_file.mode,
-                            None => target_file.mode == 0o100755,
-                            _ => false,
-                        }
-                });
+                let has_mode_change =
+                    has_regular_file_mode_change(&accumulated_tree, target_tree, file_path);
                 if has_mode_change {
                     let selected_hunks = file_hunk_list
                         .iter()
@@ -1506,6 +1500,29 @@ fn build_tree_from_hunks<'a>(
     }
 
     Ok(accumulated_tree)
+}
+
+fn has_regular_file_mode_change(
+    parent_tree: &git2::Tree,
+    target_tree: &git2::Tree,
+    file_path: &str,
+) -> bool {
+    let parent_mode = parent_tree
+        .get_path(Path::new(file_path))
+        .ok()
+        .map(|entry| entry.filemode());
+    let target_mode = target_tree
+        .get_path(Path::new(file_path))
+        .ok()
+        .map(|entry| entry.filemode());
+    target_mode.is_some_and(|target_mode| {
+        matches!(target_mode, 0o100644 | 0o100755)
+            && match parent_mode {
+                Some(mode @ (0o100644 | 0o100755)) => mode != target_mode,
+                None => target_mode == 0o100755,
+                _ => false,
+            }
+    })
 }
 
 fn target_diff_files(

--- a/crates/gg-core/src/commands/split_protocol.rs
+++ b/crates/gg-core/src/commands/split_protocol.rs
@@ -1,0 +1,376 @@
+//! Versioned DTOs and stable identities for structured split operations.
+
+use std::collections::HashSet;
+use std::fs;
+use std::path::Path;
+
+use git2::{ObjectType, Oid};
+use serde::{Deserialize, Serialize};
+
+use crate::error::{GgError, Result};
+
+pub const SPLIT_PROTOCOL_VERSION: u32 = 1;
+
+/// A single line in a diff hunk.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DiffLine {
+    /// Origin character: '+' (added), '-' (deleted), ' ' (context).
+    pub origin: char,
+    /// The line content without the origin character.
+    pub content: String,
+}
+
+/// A contiguous change in a file.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DiffHunk {
+    /// File path relative to the repository root.
+    pub file_path: String,
+    /// Hunk header (for example, "@@ -10,6 +10,12 @@").
+    pub header: String,
+    /// Lines in the hunk.
+    pub lines: Vec<DiffLine>,
+    /// Starting line number in the old file.
+    pub old_start: u32,
+    /// Number of lines in the old file.
+    pub old_lines: u32,
+    /// Starting line number in the new file.
+    pub new_start: u32,
+    /// Number of lines in the new file.
+    pub new_lines: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub struct SplitTargetIdentity {
+    pub gg_id: Option<String>,
+    pub sha: String,
+    pub tree: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub struct SplitHunkDescription {
+    pub id: String,
+    pub path: String,
+    pub header: String,
+    pub patch: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub struct SplitDescribeResponse {
+    pub version: u32,
+    pub plan_token: String,
+    pub target: SplitTargetIdentity,
+    pub hunks: Vec<SplitHunkDescription>,
+    pub non_textual_files: Vec<String>,
+    pub first_message: String,
+    pub remainder_message: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub struct SplitPlanV1 {
+    pub version: u32,
+    pub plan_token: String,
+    pub target: SplitTargetIdentity,
+    pub selected_hunk_ids: Vec<String>,
+    pub first_message: String,
+    pub remainder_message: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub struct SplitCommitIdentity {
+    pub sha: String,
+    pub gg_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub struct SplitApplyResult {
+    pub operation_id: String,
+    pub original_sha: String,
+    pub first: SplitCommitIdentity,
+    pub remainder: SplitCommitIdentity,
+    pub rewritten_descendants: Vec<SplitCommitIdentity>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub struct SplitApplyResponse {
+    pub version: u32,
+    #[serde(flatten)]
+    pub result: SplitApplyResult,
+}
+
+/// Convert an internal hunk into its public protocol representation.
+pub fn describe_hunk(index: usize, hunk: &DiffHunk) -> SplitHunkDescription {
+    let patch = canonical_patch(hunk);
+    let canonical = format!("{index}\0{}\0{patch}", hunk.file_path);
+    let oid = hash_blob(&canonical);
+
+    SplitHunkDescription {
+        id: format!("h-{}", &oid.to_string()[..12]),
+        path: hunk.file_path.clone(),
+        header: hunk.header.clone(),
+        patch,
+    }
+}
+
+/// Build a token binding a Describe response to its target and ordered hunks.
+pub fn plan_token(target: &SplitTargetIdentity, hunks: &[SplitHunkDescription]) -> String {
+    let gg_id = match &target.gg_id {
+        Some(gg_id) => format!("some:{}:{gg_id}", gg_id.len()),
+        None => "none".into(),
+    };
+    let mut canonical = format!(
+        "{}\0{}\0{}\0{}",
+        SPLIT_PROTOCOL_VERSION, gg_id, target.sha, target.tree
+    );
+    for hunk in hunks {
+        canonical.push('\0');
+        canonical.push_str(&hunk.id);
+    }
+    let oid = hash_blob(&canonical);
+    format!("split-v1-{}", &oid.to_string()[..12])
+}
+
+/// Read and validate a version 1 structured split plan.
+pub fn read_plan(path: &Path) -> Result<SplitPlanV1> {
+    let contents = fs::read_to_string(path).map_err(|error| {
+        GgError::Other(format!(
+            "Failed to read split plan '{}': {error}",
+            path.display()
+        ))
+    })?;
+    let plan: SplitPlanV1 = serde_json::from_str(&contents).map_err(|error| {
+        GgError::Other(format!(
+            "Failed to parse split plan JSON '{}': {error}",
+            path.display()
+        ))
+    })?;
+
+    if plan.version != SPLIT_PROTOCOL_VERSION {
+        return Err(GgError::Other(format!(
+            "Unsupported split plan version {}; expected {}",
+            plan.version, SPLIT_PROTOCOL_VERSION
+        )));
+    }
+    if plan.first_message.trim().is_empty() {
+        return Err(GgError::Other(
+            "Split plan first_message must not be empty".into(),
+        ));
+    }
+    if plan.remainder_message.trim().is_empty() {
+        return Err(GgError::Other(
+            "Split plan remainder_message must not be empty".into(),
+        ));
+    }
+
+    let mut unique_ids = HashSet::new();
+    if let Some(duplicate) = plan
+        .selected_hunk_ids
+        .iter()
+        .find(|id| !unique_ids.insert(id.as_str()))
+    {
+        return Err(GgError::Other(format!(
+            "Split plan contains duplicate hunk ID '{duplicate}'"
+        )));
+    }
+
+    Ok(plan)
+}
+
+fn canonical_patch(hunk: &DiffHunk) -> String {
+    let mut patch = String::with_capacity(
+        hunk.header.len()
+            + 1
+            + hunk
+                .lines
+                .iter()
+                .map(|line| line.content.len() + 1)
+                .sum::<usize>(),
+    );
+    patch.push_str(&hunk.header);
+    patch.push('\n');
+    for line in &hunk.lines {
+        patch.push(line.origin);
+        patch.push_str(&line.content);
+    }
+    patch
+}
+
+fn hash_blob(value: &str) -> Oid {
+    Oid::hash_object(ObjectType::Blob, value.as_bytes())
+        .expect("hashing in-memory split protocol data cannot fail")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    fn test_target(sha: &str) -> SplitTargetIdentity {
+        SplitTargetIdentity {
+            gg_id: Some("c-abc1234".into()),
+            sha: sha.into(),
+            tree: "cccccccccccccccccccccccccccccccccccccccc".into(),
+        }
+    }
+
+    fn test_hunk(file_path: &str, header: &str, patch: &str) -> DiffHunk {
+        DiffHunk {
+            file_path: file_path.into(),
+            header: header.into(),
+            lines: patch
+                .split_inclusive('\n')
+                .map(|line| DiffLine {
+                    origin: line.chars().next().unwrap(),
+                    content: line[1..].into(),
+                })
+                .collect(),
+            old_start: 1,
+            old_lines: 1,
+            new_start: 1,
+            new_lines: 1,
+        }
+    }
+
+    #[test]
+    fn hunk_ids_are_stable_and_content_sensitive() {
+        let a = test_hunk("src/lib.rs", "@@ -1,1 +1,1 @@", "-old\n+new\n");
+        let b = test_hunk("src/lib.rs", "@@ -1,1 +1,1 @@", "-old\n+new\n");
+        let changed = test_hunk("src/lib.rs", "@@ -1,1 +1,1 @@", "-old\n+other\n");
+        assert_eq!(describe_hunk(0, &a).id, describe_hunk(0, &b).id);
+        assert_ne!(describe_hunk(0, &a).id, describe_hunk(0, &changed).id);
+    }
+
+    #[test]
+    fn duplicate_hunks_have_distinct_ids() {
+        let hunk = test_hunk("src/lib.rs", "@@ -1,1 +1,1 @@", "-old\n+new\n");
+        assert_ne!(describe_hunk(0, &hunk).id, describe_hunk(1, &hunk).id);
+    }
+
+    #[test]
+    fn plan_token_changes_with_target_or_hunks() {
+        let target = test_target("aaaaaaaa");
+        let hunk = describe_hunk(0, &test_hunk("a", "@@ -1 +1 @@", "-a\n+b\n"));
+        let cloned_hunks = vec![hunk.clone()];
+        assert_eq!(
+            plan_token(&target, std::slice::from_ref(&hunk)),
+            plan_token(&target, &cloned_hunks)
+        );
+        assert_ne!(
+            plan_token(&target, &cloned_hunks),
+            plan_token(&test_target("bbbbbbbb"), std::slice::from_ref(&hunk))
+        );
+
+        let other_hunk = describe_hunk(1, &test_hunk("b", "@@ -1 +1 @@", "-c\n+d\n"));
+        assert_ne!(
+            plan_token(&target, std::slice::from_ref(&hunk)),
+            plan_token(&target, std::slice::from_ref(&other_hunk))
+        );
+        assert_ne!(
+            plan_token(&target, &[hunk.clone(), other_hunk.clone()]),
+            plan_token(&target, &[other_hunk, hunk])
+        );
+    }
+
+    #[test]
+    fn plan_token_distinguishes_missing_and_empty_gg_ids() {
+        let mut without_gg_id = test_target("aaaaaaaa");
+        without_gg_id.gg_id = None;
+        let mut empty_gg_id = without_gg_id.clone();
+        empty_gg_id.gg_id = Some(String::new());
+
+        assert_ne!(
+            plan_token(&without_gg_id, &[]),
+            plan_token(&empty_gg_id, &[])
+        );
+    }
+
+    #[test]
+    fn plan_v1_round_trips() {
+        let plan = SplitPlanV1 {
+            version: 1,
+            plan_token: "token".into(),
+            target: test_target("aaaaaaaa"),
+            selected_hunk_ids: vec!["h-abc".into()],
+            first_message: "first".into(),
+            remainder_message: "remainder".into(),
+        };
+        let json = serde_json::to_string(&plan).unwrap();
+        assert_eq!(serde_json::from_str::<SplitPlanV1>(&json).unwrap(), plan);
+    }
+
+    #[test]
+    fn read_plan_rejects_unsupported_versions() {
+        let mut plan = test_plan();
+        plan.version = 2;
+        let error = write_and_read_plan(&plan).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("Unsupported split plan version 2"));
+    }
+
+    #[test]
+    fn read_plan_rejects_empty_messages() {
+        let mut plan = test_plan();
+        plan.first_message = "  \n".into();
+        let error = write_and_read_plan(&plan).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("first_message must not be empty"));
+
+        let mut plan = test_plan();
+        plan.remainder_message = "\t".into();
+        let error = write_and_read_plan(&plan).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("remainder_message must not be empty"));
+    }
+
+    #[test]
+    fn read_plan_rejects_duplicate_hunk_ids() {
+        let mut plan = test_plan();
+        plan.selected_hunk_ids.push("h-abc".into());
+        let error = write_and_read_plan(&plan).unwrap_err();
+        assert!(error.to_string().contains("duplicate hunk ID 'h-abc'"));
+    }
+
+    #[test]
+    fn read_plan_reports_unreadable_json() {
+        let directory = tempdir().unwrap();
+        let missing = directory.path().join("missing.json");
+        let error = read_plan(&missing).unwrap_err();
+        assert!(error.to_string().contains("Failed to read split plan"));
+
+        let invalid = directory.path().join("invalid.json");
+        fs::write(&invalid, "not json").unwrap();
+        let error = read_plan(&invalid).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("Failed to parse split plan JSON"));
+    }
+
+    fn test_plan() -> SplitPlanV1 {
+        SplitPlanV1 {
+            version: SPLIT_PROTOCOL_VERSION,
+            plan_token: "token".into(),
+            target: test_target("aaaaaaaa"),
+            selected_hunk_ids: vec!["h-abc".into()],
+            first_message: "first".into(),
+            remainder_message: "remainder".into(),
+        }
+    }
+
+    fn write_and_read_plan(plan: &SplitPlanV1) -> Result<SplitPlanV1> {
+        let directory = tempdir().unwrap();
+        let path = directory.path().join("plan.json");
+        fs::write(&path, serde_json::to_vec(plan).unwrap()).unwrap();
+        read_plan(&path)
+    }
+}

--- a/crates/gg-core/src/commands/squash.rs
+++ b/crates/gg-core/src/commands/squash.rs
@@ -55,6 +55,13 @@ fn has_unstaged_changes() -> Result<bool> {
     Ok(!output.status.success())
 }
 
+fn has_staged_changes() -> Result<bool> {
+    let output = Command::new("git")
+        .args(["diff", "--cached", "--quiet"])
+        .output()?;
+    Ok(!output.status.success())
+}
+
 fn has_untracked_files() -> Result<bool> {
     let output = Command::new("git")
         .args(["ls-files", "--others", "--exclude-standard"])
@@ -73,7 +80,7 @@ fn has_untracked_files() -> Result<bool> {
 }
 
 /// Run the squash command
-pub fn run(all: bool, force: bool) -> Result<()> {
+pub fn run(all: bool, staged_only: bool, force: bool) -> Result<()> {
     let repo = git::open_repo()?;
     let config = Config::load_with_global(repo.commondir())?;
 
@@ -94,6 +101,10 @@ pub fn run(all: bool, force: bool) -> Result<()> {
     if statuses.is_empty() {
         println!("{}", style("No changes to squash.").dim());
         // No mutation — no record needed.
+        return Ok(());
+    }
+    if staged_only && !has_staged_changes()? {
+        println!("{}", style("No staged changes to squash.").dim());
         return Ok(());
     }
 
@@ -130,7 +141,7 @@ pub fn run(all: bool, force: bool) -> Result<()> {
 
     let mut auto_stashed = false;
 
-    if !all && (has_unstaged || has_untracked) && !needs_rebase {
+    if !all && !staged_only && (has_unstaged || has_untracked) && !needs_rebase {
         match config.get_unstaged_action() {
             UnstagedAction::Ask => {
                 println!(
@@ -217,6 +228,12 @@ pub fn run(all: bool, force: bool) -> Result<()> {
     // Staged changes are fine (they'll be committed), but unstaged changes
     // would be lost during the rebase
     if needs_rebase {
+        if staged_only && has_untracked {
+            return Err(GgError::Other(
+                "Untracked files detected. Move or remove them before a mid-stack --staged-only amend."
+                    .to_string(),
+            ));
+        }
         let has_unstaged = has_unstaged_changes()?;
 
         if has_unstaged {

--- a/crates/gg-core/src/commands/undo.rs
+++ b/crates/gg-core/src/commands/undo.rs
@@ -70,16 +70,11 @@ fn run_undo(repo: &git2::Repository, config: &Config, options: &UndoCliOptions) 
     // Undo itself takes a lock and records itself (D5). Use AllUserBranches
     // scope so the undo record's refs_before captures whatever user-owned
     // state existed before the replay.
-    let args: Vec<String> = if let Some(id) = &options.operation_id {
-        vec!["undo".into(), id.clone()]
-    } else {
-        vec!["undo".into()]
-    };
     let (_lock, guard) = git::acquire_operation_lock_and_record(
         repo,
         config,
         OperationKind::Undo,
-        args,
+        std::env::args().skip(1).collect(),
         None,
         SnapshotScope::AllUserBranches,
     )?;

--- a/crates/gg-core/src/commands/unstack.rs
+++ b/crates/gg-core/src/commands/unstack.rs
@@ -36,6 +36,8 @@ pub struct UnstackOptions {
     pub json: bool,
     /// Create or reuse a managed worktree for the new stack.
     pub worktree: bool,
+    /// Leave this worktree on the lower stack without creating an upper worktree.
+    pub keep_current: bool,
 }
 
 /// Run the unstack command.
@@ -154,12 +156,13 @@ pub fn run(options: UnstackOptions) -> Result<()> {
     )?;
 
     // Migrate config (MR mappings, base override)
+    let preserve_original_worktree = options.worktree || options.keep_current;
     let migrated_review_mappings = migrate_config(
         &mut config,
         &original_stack,
         &new_stack_name,
         &moved_entries,
-        options.worktree,
+        preserve_original_worktree,
     );
 
     if let Some(path) = &precreated_worktree_path {
@@ -182,6 +185,16 @@ pub fn run(options: UnstackOptions) -> Result<()> {
         let upper_stack = Stack::load(&upper_repo, &config)?;
         git::normalize_stack_metadata(&upper_repo, &upper_stack)?;
         Some(path.to_string_lossy().to_string())
+    } else if options.keep_current {
+        let upper_result = (|| -> Result<()> {
+            git::checkout_branch(&repo, &new_branch)?;
+            let upper_stack = Stack::load(&repo, &config)?;
+            git::normalize_stack_metadata(&repo, &upper_stack)?;
+            Ok(())
+        })();
+        git::checkout_branch(&repo, &original_branch)?;
+        upper_result?;
+        None
     } else {
         // Normalize metadata on the new (upper) stack and leave HEAD there.
         git::checkout_branch(&repo, &new_branch)?;
@@ -200,6 +213,11 @@ pub fn run(options: UnstackOptions) -> Result<()> {
     )?;
 
     let sync_required = migrated_review_mappings > 0;
+    let current_stack = if preserve_original_worktree {
+        original_stack.clone()
+    } else {
+        new_stack_name.clone()
+    };
 
     if options.json {
         print_json(&UnstackResponse {
@@ -207,6 +225,7 @@ pub fn run(options: UnstackOptions) -> Result<()> {
             unstack: UnstackResultJson {
                 original_stack,
                 new_stack: new_stack_name,
+                current_stack,
                 split_position,
                 remaining_entries,
                 moved_entries,
@@ -520,7 +539,7 @@ fn migrate_config(
     original_stack: &str,
     new_stack: &str,
     moved_entries: &[UnstackEntryJson],
-    worktree_mode: bool,
+    preserve_original_worktree: bool,
 ) -> usize {
     let original_base = config
         .get_stack(original_stack)
@@ -544,11 +563,11 @@ fn migrate_config(
         }
     }
 
-    // In worktree mode, the current worktree stays with the old (lower) stack,
-    // so preserve the old worktree_path on it. The new stack gets its worktree
-    // assigned later by ensure_stack_worktree.
+    // When the current worktree stays with the old (lower) stack, preserve its
+    // worktree_path. A managed new-stack worktree is assigned later by
+    // ensure_stack_worktree.
     // In normal mode, HEAD moves to the new stack, so migrate the worktree_path.
-    if !worktree_mode {
+    if !preserve_original_worktree {
         if let Some(wt_path) = original_worktree_path {
             new_config.worktree_path = Some(wt_path);
             if let Some(old_stack) = config.stacks.get_mut(original_stack) {
@@ -603,6 +622,7 @@ mod tests {
         assert!(!opts.force);
         assert!(!opts.json);
         assert!(!opts.worktree);
+        assert!(!opts.keep_current);
     }
 
     fn temp_repo() -> (tempfile::TempDir, Repository) {

--- a/crates/gg-core/src/git.rs
+++ b/crates/gg-core/src/git.rs
@@ -981,10 +981,52 @@ fn parse_push_error(stderr: &str) -> (Option<String>, Option<String>) {
     (hook_error, git_error)
 }
 
-/// Delete a remote branch
-pub fn delete_remote_branch(branch_name: &str) -> Result<()> {
-    run_git_command(&["push", "origin", "--delete", branch_name])?;
-    Ok(())
+/// Delete a remote branch only if its server tip still matches the tip resolved
+/// immediately before deletion. Returns the exact deleted OID, or `None` when
+/// the branch does not exist on the server.
+pub fn delete_remote_branch(repo: &Repository, branch_name: &str) -> Result<Option<Oid>> {
+    let workdir = repo
+        .workdir()
+        .ok_or_else(|| GgError::Other("Cannot delete a remote branch from a bare repo".into()))?;
+    let branch_ref = format!("refs/heads/{branch_name}");
+    let lookup = Command::new("git")
+        .args(["-C"])
+        .arg(workdir)
+        .args(["ls-remote", "--heads", "origin", &branch_ref])
+        .output()?;
+    if !lookup.status.success() {
+        return Err(GgError::Other(format!(
+            "git ls-remote failed: {}",
+            String::from_utf8_lossy(&lookup.stderr).trim()
+        )));
+    }
+
+    let stdout = String::from_utf8_lossy(&lookup.stdout);
+    let Some(oid_text) = stdout.lines().find_map(|line| {
+        let mut fields = line.split_whitespace();
+        let oid = fields.next()?;
+        let remote_ref = fields.next()?;
+        (remote_ref == branch_ref).then_some(oid)
+    }) else {
+        return Ok(None);
+    };
+    let oid = Oid::from_str(oid_text)?;
+
+    let lease = format!("--force-with-lease={branch_ref}:{oid}");
+    let delete_refspec = format!(":{branch_ref}");
+    let deletion = Command::new("git")
+        .args(["-C"])
+        .arg(workdir)
+        .args(["push", &lease, "origin", &delete_refspec])
+        .output()?;
+    if !deletion.status.success() {
+        return Err(GgError::Other(format!(
+            "Refusing to delete remote branch '{branch_name}' because its server tip changed: {}",
+            String::from_utf8_lossy(&deletion.stderr).trim()
+        )));
+    }
+
+    Ok(Some(oid))
 }
 
 /// Continue a rebase
@@ -2233,6 +2275,139 @@ mod tests {
                 no_verify
             );
         }
+    }
+
+    fn setup_remote_branch_for_delete() -> (
+        tempfile::TempDir,
+        std::path::PathBuf,
+        std::path::PathBuf,
+        Repository,
+        Oid,
+    ) {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let repo_path = temp_dir.path().join("repo");
+        let remote_path = temp_dir.path().join("remote.git");
+        std::fs::create_dir_all(&repo_path).unwrap();
+        std::fs::create_dir_all(&remote_path).unwrap();
+        run_git(&remote_path, &["init", "--bare", "--initial-branch=main"]);
+        run_git(&repo_path, &["init", "--initial-branch=main"]);
+        run_git(&repo_path, &["config", "user.email", "test@example.com"]);
+        run_git(&repo_path, &["config", "user.name", "Test User"]);
+        std::fs::write(repo_path.join("file.txt"), "one\n").unwrap();
+        run_git(&repo_path, &["add", "."]);
+        run_git(&repo_path, &["commit", "-m", "one"]);
+        run_git(
+            &repo_path,
+            &["remote", "add", "origin", remote_path.to_str().unwrap()],
+        );
+        run_git(&repo_path, &["push", "origin", "HEAD:refs/heads/feature"]);
+        let repo = Repository::open(&repo_path).unwrap();
+        let oid = repo.head().unwrap().target().unwrap();
+        (temp_dir, repo_path, remote_path, repo, oid)
+    }
+
+    #[test]
+    fn delete_remote_branch_resolves_tip_when_tracking_ref_is_absent() {
+        let (_temp_dir, repo_path, remote_path, repo, server_oid) =
+            setup_remote_branch_for_delete();
+        run_git(
+            &repo_path,
+            &["update-ref", "-d", "refs/remotes/origin/feature"],
+        );
+
+        let deleted = delete_remote_branch(&repo, "feature").unwrap();
+        assert_eq!(deleted, Some(server_oid));
+        let output = Command::new("git")
+            .args([
+                "--git-dir",
+                remote_path.to_str().unwrap(),
+                "show-ref",
+                "refs/heads/feature",
+            ])
+            .output()
+            .unwrap();
+        assert!(!output.status.success());
+    }
+
+    #[test]
+    fn delete_remote_branch_uses_server_tip_when_tracking_ref_is_stale() {
+        let (_temp_dir, repo_path, remote_path, repo, stale_oid) = setup_remote_branch_for_delete();
+        std::fs::write(repo_path.join("file.txt"), "two\n").unwrap();
+        run_git(&repo_path, &["add", "."]);
+        run_git(&repo_path, &["commit", "-m", "two"]);
+        let server_oid = repo.head().unwrap().target().unwrap();
+        run_git(&repo_path, &["push", "origin", "HEAD:refs/heads/feature"]);
+        run_git(
+            &repo_path,
+            &[
+                "update-ref",
+                "refs/remotes/origin/feature",
+                &stale_oid.to_string(),
+            ],
+        );
+
+        let deleted = delete_remote_branch(&repo, "feature").unwrap();
+        assert_eq!(deleted, Some(server_oid));
+        let output = Command::new("git")
+            .args([
+                "--git-dir",
+                remote_path.to_str().unwrap(),
+                "show-ref",
+                "refs/heads/feature",
+            ])
+            .output()
+            .unwrap();
+        assert!(!output.status.success());
+    }
+
+    #[test]
+    fn delete_remote_branch_refuses_when_server_tip_changes_after_lookup() {
+        let (_temp_dir, repo_path, remote_path, repo, original_oid) =
+            setup_remote_branch_for_delete();
+        std::fs::write(repo_path.join("file.txt"), "race winner\n").unwrap();
+        run_git(&repo_path, &["add", "."]);
+        run_git(&repo_path, &["commit", "-m", "race winner"]);
+        let changed_oid = repo.head().unwrap().target().unwrap();
+        run_git(
+            &repo_path,
+            &["push", "origin", "HEAD:refs/heads/race-source"],
+        );
+
+        let hook = repo_path.join(".git/hooks/pre-push");
+        std::fs::write(
+            &hook,
+            format!(
+                "#!/bin/sh\ngit --git-dir='{}' update-ref refs/heads/feature {}\n",
+                remote_path.display(),
+                changed_oid
+            ),
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut permissions = std::fs::metadata(&hook).unwrap().permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(&hook, permissions).unwrap();
+        }
+
+        let error = delete_remote_branch(&repo, "feature").unwrap_err();
+        assert!(error.to_string().contains("server tip changed"));
+        let output = Command::new("git")
+            .args([
+                "--git-dir",
+                remote_path.to_str().unwrap(),
+                "rev-parse",
+                "refs/heads/feature",
+            ])
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            changed_oid.to_string()
+        );
+        assert_ne!(changed_oid, original_oid);
     }
 }
 

--- a/crates/gg-core/src/operations.rs
+++ b/crates/gg-core/src/operations.rs
@@ -30,7 +30,7 @@ use crate::stack::Stack;
 
 /// Durable schema version for operation records. Bumping this is a
 /// backwards-incompatible change and must be accompanied by a migration.
-pub const SCHEMA_VERSION: u32 = 1;
+pub const SCHEMA_VERSION: u32 = 2;
 
 /// Ring buffer cap. Committed/Interrupted records beyond this count are
 /// pruned oldest-first. `Pending` records are never pruned — they may
@@ -112,6 +112,14 @@ pub enum RemoteEffect {
         remote: String,
         branch: String,
         force: bool,
+    },
+    /// A remote branch was deleted. `prior_oid` is captured from the live
+    /// server tip when available so the refusal hint can restore it.
+    BranchDeleted {
+        remote: String,
+        branch: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        prior_oid: Option<String>,
     },
     /// A pull/merge request was created.
     PrCreated { number: u64, url: String },
@@ -896,6 +904,22 @@ fn build_remote_hints(record: &OperationRecord) -> Vec<String> {
                  where <prior_sha> is the pre-op SHA (see refs_before via `gg undo --json {id}`).",
                 id = record.id
             ),
+            RemoteEffect::BranchDeleted {
+                remote,
+                branch,
+                prior_oid: Some(prior_oid),
+            } => format!(
+                "This operation deleted `{branch}` from `{remote}`. Restore it with: \
+                 `git push {remote} {prior_oid}:refs/heads/{branch}`."
+            ),
+            RemoteEffect::BranchDeleted {
+                remote,
+                branch,
+                prior_oid: None,
+            } => format!(
+                "This operation deleted `{branch}` from `{remote}`. Restore it manually by \
+                 pushing the intended commit to `refs/heads/{branch}`."
+            ),
             RemoteEffect::PrCreated { number, url } => format!(
                 "This operation opened {url}. Close it manually: `gh pr close {number}` / `glab mr close {number}`."
             ),
@@ -946,7 +970,7 @@ pub(crate) mod tests {
     // -- schema --------------------------------------------------------------
 
     #[test]
-    fn operation_record_serde_round_trip_v1() {
+    fn operation_record_current_schema_round_trip() {
         let record = OperationRecord {
             id: "op_0000000001700_abcd".into(),
             schema_version: SCHEMA_VERSION,
@@ -971,6 +995,49 @@ pub(crate) mod tests {
         let back: OperationRecord = serde_json::from_str(&json).unwrap();
         assert_eq!(record.id, back.id);
         assert_eq!(record.kind, OperationKind::Drop);
+    }
+
+    #[test]
+    fn operation_record_schema_v1_fixture_round_trips() {
+        let fixture = r#"{
+            "id": "op_0000000001700_abcd",
+            "schema_version": 1,
+            "kind": "sync",
+            "status": "committed",
+            "created_at_ms": 1700000000000,
+            "args": ["sync", "--json"],
+            "stack_name": "feat/login",
+            "refs_before": [],
+            "refs_after": [],
+            "remote_effects": [{
+                "kind": "pushed",
+                "remote": "origin",
+                "branch": "user/feat-login--c-a1b2c3d",
+                "force": false
+            }],
+            "touched_remote": true
+        }"#;
+
+        let record: OperationRecord = serde_json::from_str(fixture).unwrap();
+        assert_eq!(record.schema_version, 1);
+        assert_eq!(record.kind, OperationKind::Sync);
+        assert_eq!(record.remote_effects.len(), 1);
+        assert!(record.touched_remote);
+        assert!(record.undoes.is_none());
+        assert!(record.pending_plan.is_none());
+
+        let encoded = serde_json::to_string(&record).unwrap();
+        let round_tripped: OperationRecord = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(round_tripped.schema_version, 1);
+        assert_eq!(round_tripped.args, vec!["sync", "--json"]);
+        assert!(matches!(
+            round_tripped.remote_effects.as_slice(),
+            [RemoteEffect::Pushed {
+                remote,
+                branch,
+                force: false,
+            }] if remote == "origin" && branch == "user/feat-login--c-a1b2c3d"
+        ));
     }
 
     #[test]

--- a/crates/gg-core/src/operations.rs
+++ b/crates/gg-core/src/operations.rs
@@ -446,15 +446,41 @@ pub fn interrupted_rebase_operation(repo: &Repository) -> Result<Option<Operatio
     }
 
     let bytes = fs::read(&path)?;
-    let marker: InterruptedRebaseMarker = serde_json::from_slice(&bytes)?;
-    if let Some(expected) = &marker.rebase_state {
-        if current_rebase_state(repo).as_ref() != Some(expected) {
+    let marker: InterruptedRebaseMarker = match serde_json::from_slice(&bytes) {
+        Ok(marker) => marker,
+        Err(_) => {
             clear_interrupted_rebase_operation(repo)?;
             return Ok(None);
         }
+    };
+    let Some(expected) = &marker.rebase_state else {
+        clear_interrupted_rebase_operation(repo)?;
+        return Ok(None);
+    };
+    if current_rebase_state(repo).as_ref() != Some(expected) {
+        clear_interrupted_rebase_operation(repo)?;
+        return Ok(None);
     }
+
     let store = OperationStore::new(&crate::git::gg_dir(repo));
-    Ok(Some(store.load(&marker.operation_id)?))
+    let record = match store.load(&marker.operation_id) {
+        Ok(record) => record,
+        Err(_) => {
+            clear_interrupted_rebase_operation(repo)?;
+            return Ok(None);
+        }
+    };
+    if record.schema_version > SCHEMA_VERSION
+        || !matches!(
+            record.status,
+            OperationStatus::Pending | OperationStatus::Interrupted
+        )
+    {
+        clear_interrupted_rebase_operation(repo)?;
+        return Ok(None);
+    }
+
+    Ok(Some(record))
 }
 
 /// Remove the interrupted-rebase marker.

--- a/crates/gg-core/src/output.rs
+++ b/crates/gg-core/src/output.rs
@@ -769,6 +769,7 @@ pub struct UnstackResponse {
 pub struct UnstackResultJson {
     pub original_stack: String,
     pub new_stack: String,
+    pub current_stack: String,
     pub split_position: usize,
     pub remaining_entries: Vec<UnstackEntryJson>,
     pub moved_entries: Vec<UnstackEntryJson>,

--- a/crates/gg-core/src/output.rs
+++ b/crates/gg-core/src/output.rs
@@ -85,6 +85,8 @@ pub fn print_json_error(message: &str) {
 #[derive(Serialize)]
 pub struct SingleStackResponse {
     pub version: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub operation_id: Option<String>,
     pub stack: StackJson,
 }
 

--- a/crates/gg-core/src/output.rs
+++ b/crates/gg-core/src/output.rs
@@ -130,6 +130,8 @@ pub struct StackEntryJson {
 #[derive(Serialize)]
 pub struct AllStacksResponse {
     pub version: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub operation_id: Option<String>,
     pub current_stack: Option<String>,
     pub stacks: Vec<StackSummaryJson>,
 }

--- a/docs/src/commands/clean.md
+++ b/docs/src/commands/clean.md
@@ -23,3 +23,10 @@ gg clean --json
 - `version`: output schema version
 - `clean.cleaned`: stacks that were cleaned
 - `clean.skipped`: stacks skipped (unmerged or declined in interactive mode)
+
+When merge verification allows Clean to delete an entry branch from `origin`,
+the Clean operation records a `branch_deleted` remote effect with the branch's
+exact server-side OID. Deletion uses a matching force-with-lease so a concurrent
+server update is never deleted or misreported. `gg undo` refuses local replay
+for that operation and prints the exact
+`git push origin <prior_oid>:refs/heads/<branch>` recovery command.

--- a/docs/src/commands/ls.md
+++ b/docs/src/commands/ls.md
@@ -81,3 +81,23 @@ Field types for each entry in `unintegrated_commits`:
 - `subject`: `string` — first line of the commit message
 - `sits_on_position`: `number` — position of the stack entry that this commit sits directly on top of
 - `count`: `number` — total number of un-integrated commits at HEAD (useful when multiple commits were made before restacking)
+
+### Interrupted operation ID in JSON output
+
+While a GG mutation is paused on the current Git rebase, `gg ls --json`
+includes its opaque operation-log ID at the top level:
+
+```json
+{
+  "version": 1,
+  "operation_id": "op_...",
+  "stack": {
+    "name": "my-feature",
+    "entries": []
+  }
+}
+```
+
+Pass the value unchanged to `gg undo <operation_id> --json` after the operation
+has been completed or aborted. The field is omitted when no operation is paused
+and when a saved marker no longer matches the current Git rebase state.

--- a/docs/src/commands/ls.md
+++ b/docs/src/commands/ls.md
@@ -98,6 +98,11 @@ includes its opaque operation-log ID at the top level:
 }
 ```
 
+If the paused rebase leaves `HEAD` detached and no current-stack navigation
+state is available, the command returns the all-stacks envelope instead. Its
+top level still includes the same `operation_id` alongside `current_stack` and
+`stacks`.
+
 Pass the value unchanged to `gg undo <operation_id> --json` after the operation
 has been completed or aborted. The field is omitted when no operation is paused
 and when a saved marker no longer matches the current Git rebase state.

--- a/docs/src/commands/sc.md
+++ b/docs/src/commands/sc.md
@@ -9,6 +9,11 @@ gg sc [OPTIONS]
 ## Options
 
 - `-a, --all`: Include staged and unstaged changes
+- `--staged-only`: Include staged changes only and ignore
+  `defaults.unstaged_action`. Unstaged and untracked files are never staged or
+  stashed. Conflicts with `--all`. A mid-stack amend refuses before mutation
+  when tracked changes are unstaged or any untracked files are present, since
+  either can prevent rebasing descendants safely.
 - `-f, --force` (alias `--ignore-immutable`): Override the immutability guard.
   By default `gg sc` refuses to amend a commit whose PR is merged or which is
   already reachable from `origin/<base>`. See
@@ -31,4 +36,7 @@ gg sc
 
 # Include unstaged changes too
 gg sc --all
+
+# Native-client flow: amend only the prepared index
+gg sc --staged-only
 ```

--- a/docs/src/commands/split.md
+++ b/docs/src/commands/split.md
@@ -19,6 +19,8 @@ gg split [OPTIONS] [FILES...]
   `--json` and cannot be combined with `--describe`, interactive selection, or
   file arguments.
 - `--json`: Emit machine-readable output for structured Describe or Apply.
+  Requires either `--describe` or `--plan-json`; ordinary interactive and
+  file-based Split do not have a structured response.
 - `-f, --force` (alias `--ignore-immutable`): Override the immutability guard
   for interactive and file-based Split. Structured Describe/Apply always uses
   the guard without an override. Splitting a merged or base-ancestor commit is refused by default. See

--- a/docs/src/commands/split.md
+++ b/docs/src/commands/split.md
@@ -188,8 +188,9 @@ gg split --describe --commit c-abc1234 --json > split-description.json
 
 The response contains the exact `target`, an opaque `plan_token`, selectable
 textual `hunks`, `non_textual_files`, and default messages. Copy `target` and
-`plan_token` unchanged, choose a non-empty proper subset of the returned hunk
-IDs, and supply both non-empty messages:
+`plan_token` unchanged, choose at least one returned hunk ID while leaving
+some textual, non-textual, or metadata change for the remainder, and supply
+both non-empty messages:
 
 ```bash
 jq '{
@@ -204,10 +205,12 @@ jq '{
 gg split --plan-json split-plan.json --json > split-result.json
 ```
 
-At least one textual hunk must remain for the remainder. Files listed in
-`non_textual_files` are not selectable in protocol v1 and always remain in the
-remainder commit. Treat hunk IDs, plan tokens, GG-IDs, and operation IDs as
-opaque values; do not parse, construct, or remap them.
+The remainder must contain at least one change. It can be an unselected textual
+hunk, a file listed in `non_textual_files`, or a regular-file mode change such
+as an executable-bit update. Non-textual files and metadata are not selectable
+in protocol v1 and always remain in the remainder commit. Treat hunk IDs, plan
+tokens, GG-IDs, and operation IDs as opaque values; do not parse, construct, or
+remap them.
 
 Apply re-resolves the target, checks its GG-ID/SHA/tree and the current ordered
 hunks, and rejects stale plans before moving refs or adding an operation-log
@@ -238,8 +241,8 @@ gg undo "$operation_id" --json
 
 ## Edge Cases
 
-- **All textual hunks selected** — Structured Apply refuses the plan because it
-  requires a proper subset with at least one textual hunk left in the remainder.
+- **All textual hunks selected** — Structured Apply accepts the plan only when
+  a non-textual file or regular-file mode change remains for the remainder.
 - **No changes selected** — Error in every mode.
 - **Dirty working directory** — Interactive Split and structured Apply error.
   Describe remains read-only and is allowed.

--- a/docs/src/commands/split.md
+++ b/docs/src/commands/split.md
@@ -12,8 +12,16 @@ gg split [OPTIONS] [FILES...]
 - `-m, --message <MESSAGE>`: Commit message for the new (first) commit. Skips the editor prompt.
 - `--no-edit`: Keep the original message for the remainder commit without prompting.
 - `--no-tui`: Disable TUI, use sequential prompt instead (legacy `git add -p` style).
-- `-f, --force` (alias `--ignore-immutable`): Override the immutability guard.
-  Splitting a merged or base-ancestor commit is refused by default. See
+- `--describe`: Describe the target and its textual hunks as protocol v1 JSON.
+  Requires `--json` and cannot be combined with interactive selection or file
+  arguments.
+- `--plan-json <PATH>`: Apply a protocol v1 plan read from `PATH`. Requires
+  `--json` and cannot be combined with `--describe`, interactive selection, or
+  file arguments.
+- `--json`: Emit machine-readable output for structured Describe or Apply.
+- `-f, --force` (alias `--ignore-immutable`): Override the immutability guard
+  for interactive and file-based Split. Structured Describe/Apply always uses
+  the guard without an override. Splitting a merged or base-ancestor commit is refused by default. See
   [Core concepts · Immutable commits](../core-concepts.md#immutable-commits).
 - `FILES...`: Files to include in the new commit. When provided, all hunks from those files are auto-selected (skips the interactive picker).
 
@@ -164,9 +172,74 @@ gg split -c c-abc1234 src/config.rs
 
 If a hunk contains multiple logical changes separated by unchanged lines, pressing `s` will break it into smaller hunks. You can then select each sub-hunk individually. If the hunk is already atomic (contiguous changes), you'll see "This hunk cannot be split further."
 
+## Structured Clients
+
+Native clients that provide their own hunk-selection UI can use a versioned,
+two-step protocol. Ordinary terminal use should keep the default TUI.
+
+First, describe the current target without changing refs, requiring a clean
+worktree, or creating an operation record:
+
+```bash
+gg split --describe --commit c-abc1234 --json > split-description.json
+```
+
+The response contains the exact `target`, an opaque `plan_token`, selectable
+textual `hunks`, `non_textual_files`, and default messages. Copy `target` and
+`plan_token` unchanged, choose a non-empty proper subset of the returned hunk
+IDs, and supply both non-empty messages:
+
+```bash
+jq '{
+  version,
+  plan_token,
+  target,
+  selected_hunk_ids: [.hunks[0].id],
+  first_message: "Extract validation",
+  remainder_message: "Finish authentication"
+}' split-description.json > split-plan.json
+
+gg split --plan-json split-plan.json --json > split-result.json
+```
+
+At least one textual hunk must remain for the remainder. Files listed in
+`non_textual_files` are not selectable in protocol v1 and always remain in the
+remainder commit. Treat hunk IDs, plan tokens, GG-IDs, and operation IDs as
+opaque values; do not parse, construct, or remap them.
+
+Apply re-resolves the target, checks its GG-ID/SHA/tree and the current ordered
+hunks, and rejects stale plans before moving refs or adding an operation-log
+record. After any stale-plan error, run Describe again and ask the user to
+review a new selection. Describe and Apply both refuse immutable targets, and
+structured Apply has no force field or force override.
+
+Structured failures are written to stdout as JSON:
+
+```json
+{
+  "version": 1,
+  "error": "stale split plan: target identity changed"
+}
+```
+
+Once rewriting starts, a descendant rebase conflict returns the same JSON
+error envelope but leaves the operation paused. Resolve and stage the conflict,
+then run `gg continue`, or run `gg abort` to cancel it.
+
+A successful Apply returns an `operation_id`. Use that exact ID to undo this
+split rather than assuming it is still the most recent operation:
+
+```bash
+operation_id=$(jq -r '.operation_id' split-result.json)
+gg undo "$operation_id" --json
+```
+
 ## Edge Cases
 
-- **All changes selected** — Warning: the original commit will be empty.
-- **No changes selected** — Error.
-- **Dirty working directory** — Error. Commit or stash changes first.
-- **Merge conflicts during rebase** — Split is aborted, original state restored.
+- **All textual hunks selected** — Structured Apply refuses the plan because it
+  requires a proper subset with at least one textual hunk left in the remainder.
+- **No changes selected** — Error in every mode.
+- **Dirty working directory** — Interactive Split and structured Apply error.
+  Describe remains read-only and is allowed.
+- **Merge conflicts during rebase** — Resolve and stage the conflict, then run
+  `gg continue`; use `gg abort` to cancel the paused operation.

--- a/docs/src/commands/undo.md
+++ b/docs/src/commands/undo.md
@@ -42,6 +42,28 @@ recorded as an operation, running it twice reverses the reversal.
 Entries created by `gg undo` appear in `--list` with a `↶` marker and
 an `undoes` field pointing at the original operation id.
 
+## Native-client correlation
+
+All `gg` commands accept the global `--client-operation-id <ID>` option. A
+native client can assign a unique token to a mutation and then identify the
+operation record created by that invocation without relying on timestamps or
+newest-record ordering:
+
+```bash
+gg drop 3 --yes --client-operation-id alas:018f84c0-3a14-7b45-a397-93c87266391d
+gg undo --list --json
+```
+
+The operation record's `args` array preserves the exact adjacent
+`"--client-operation-id", "alas:..."` pair. Match that pair, then pass the
+record's opaque `op_...` `id` to `gg undo <OPERATION_ID> --json`. The client
+token is correlation metadata only: it never replaces or influences GG's
+operation ID.
+
+Client operation IDs must be 1–128 characters of ASCII letters, digits, `-`,
+`_`, `.`, or `:`. Generate a unique token for every attempted mutation and do
+not reuse one across concurrent requests.
+
 ## Refusal modes
 
 `gg undo` refuses (exit 1, no refs touched) when:

--- a/docs/src/commands/undo.md
+++ b/docs/src/commands/undo.md
@@ -70,7 +70,7 @@ not reuse one across concurrent requests.
 
 | Reason | Condition | What to do |
 |---|---|---|
-| `remote` | The target op pushed/merged/closed/created a PR or MR. | Use the printed provider hint (`gh pr close <n>`, `glab mr close <n>`, `git push --delete …`). Local state is unchanged. |
+| `remote` | The target op pushed, deleted a remote branch, or created/merged/closed a PR or MR. | Use the printed recovery hint. Deleted branches include an exact `git push origin <prior_oid>:refs/heads/<branch>` command when GG captured the prior OID. Local state is unchanged. |
 | `interrupted` | The op crashed, was Ctrl-C'd, or was aborted before completion and has `status: Interrupted`. | Fix the underlying state manually; the stale Pending record is swept into Interrupted on the next lock-acquiring op. |
 | `stale` | Refs have moved since the target op finalised. | Run `gg undo --list` and target a more recent record instead. The error names the ref, the expected OID, and the actual OID. |
 | `unsupported_schema` | The record was written by a newer `gg` with a schema version this binary does not understand. | Upgrade `gg` or delete the offending record. |
@@ -176,8 +176,8 @@ UI/agent actions; use `is_undo` + `undoes` to render redo markers.
 - It does **not** restore working-tree files or the index. If you amended
   a commit and want the old source back, use `git reflog` or
   `git stash`.
-- It does **not** touch remotes. Operations that pushed, merged, closed,
-  or created PRs/MRs are recorded (so you can see them in `--list`) but
+- It does **not** touch remotes. Operations that pushed, deleted a remote
+  branch, or created/merged/closed PRs/MRs are recorded (so you can see them in `--list`) but
   refused for local replay.
 - It does **not** guarantee atomicity of the replay. If the process
   dies mid-replay, a second `gg undo` will finish the job — the

--- a/docs/src/commands/unstack.md
+++ b/docs/src/commands/unstack.md
@@ -3,7 +3,7 @@
 Split the current stack into two independent stacks.
 
 ```bash
-gg unstack [--target <TARGET>] [--name <STACK_NAME>] [--no-tui] [-f] [--json] [-w]
+gg unstack [--target <TARGET>] [--name <STACK_NAME>] [--no-tui] [-f] [--json] [-w | --keep-current]
 ```
 
 The selected entry becomes the root of a new stack, and all entries above it
@@ -29,6 +29,9 @@ gg unstack --target 3 --json --no-tui
 
 # Put the new upper stack in a managed worktree
 gg unstack --target 3 --name upper-auth --wt
+
+# Keep this worktree on the lower stack without creating another worktree
+gg unstack --target 3 --name upper-auth --keep-current --json
 ```
 
 ## Behavior
@@ -58,9 +61,21 @@ local entry branches under the old stack name are removed for moved entries.
 If moved entries had review mappings, run `gg sync` afterwards to recreate or
 update review branches for the new stack.
 
-Without `--worktree`, the current directory switches to the new upper stack.
-With `--worktree`, the current directory stays on the lower stack and the new
-upper stack is checked out in its managed worktree.
+Placement depends on the selected mode:
+
+| Mode | Invoking worktree after success | Additional upper worktree | JSON `current_stack` |
+|------|---------------------------------|---------------------------|----------------------|
+| default | upper stack | not created | new upper stack name |
+| `--worktree` / `--wt` | lower stack | created or reused | original lower stack name |
+| `--keep-current` | lower stack | not created | original lower stack name |
+
+`--keep-current` is intended for native clients that must keep using the
+invoking worktree but do not want another worktree. It conflicts with
+`--worktree`/`--wt`.
+
+With `--json`, `unstack.current_stack` always reports the stack left in the
+invoking worktree. `unstack.worktree_path` is present only when `--worktree`
+created or reused the upper managed worktree.
 
 ## Options
 
@@ -74,6 +89,8 @@ upper stack is checked out in its managed worktree.
 - `--json`: emit structured JSON.
 - `-w, --worktree`: create or reuse a managed worktree for the new stack
   (`--wt` also works).
+- `--keep-current`: leave the invoking worktree on the lower stack without
+  creating an upper worktree. Conflicts with `--worktree`/`--wt`.
 
 Position `1` is rejected because it would leave the original stack empty. The
 last position is allowed and creates a one-entry new stack.

--- a/skills/gg/SKILL.md
+++ b/skills/gg/SKILL.md
@@ -96,6 +96,13 @@ worktree for the new upper stack:
 gg unstack --target 3 --name feature-auth-followup --wt
 ```
 
+When a native client must leave its current worktree on the lower stack and
+must not create another worktree, use the explicit keep-current placement:
+
+```bash
+gg unstack --target 3 --name feature-auth-followup --keep-current --json
+```
+
 2. Commit logical changes:
 
 ```bash
@@ -143,14 +150,18 @@ gg land -a -c --json
 6. Prefer `gg absorb -s` for multi-commit edits.
 7. **Never use `git add -A` blindly.** Review `git status` first and only stage intended files. Use `git add <specific-files>` to avoid leaking secrets, env files, or unrelated changes.
 8. **Respect the immutability guard.** Rewrite-style commands (`gg sc`, `gg absorb`, `gg reorder`/`gg arrange`, `gg split`, `gg unstack`, `gg drop`, `gg rebase`, `gg restack`) refuse to rewrite merged PRs/MRs or commits already on the base branch, except that `gg rebase` silently skips base-ancestor commits that naturally drop out when rebasing onto the refreshed base. If a command exits with `ImmutableTargets`, surface the listed commits and reasons to the user and get explicit confirmation before retrying with `-f` / `--force` (alias `--ignore-immutable`). If the error comes from `gg sync`'s auto-rebase, the override is `gg rebase --force` / `gg rebase --ignore-immutable`, not `gg sync --force`.
+9. **Keep terminal Split interactive.** For ordinary terminal use, run `gg split`
+   and use its TUI. Use `gg split --describe --json` followed by
+   `gg split --plan-json <path> --json` only when a native client is collecting
+   hunk choices in its own UI. Structured Apply has no force override.
 
 ## Common operations
 
 - Navigate: `gg mv`, `gg first`, `gg last`, `gg prev`, `gg next`
 - Amend current commit: `gg sc` / `gg sc -a`
 - Auto-distribute staged hunks: `gg absorb -s`
-- Split a commit into two: `gg split` — opens a two-panel TUI for hunk selection (files on the left, colored diff on the right), followed by inline commit message inputs for both the new and remainder commits. Use `--no-tui` to fall back to sequential `git add -p` style prompts. The `-m` flag bypasses the TUI message input for the new commit. The `--no-edit` flag skips the remainder message input. Pass `FILES...` to auto-select all hunks from those files (e.g., `gg split -c 3 file1.rs file2.rs`).
-- Split a stack into two stacks: `gg unstack` — opens a picker by default. The selected entry and descendants become a new independent stack; lower entries remain in the original stack. Use `--target <position|gg-id|sha> --no-tui` for scripts, and `--name <stack>` to choose the new stack name.
+- Split a commit into two: `gg split` — opens a two-panel TUI for hunk selection (files on the left, colored diff on the right), followed by inline commit message inputs for both the new and remainder commits. Use `--no-tui` to fall back to sequential `git add -p` style prompts. The `-m` flag bypasses the TUI message input for the new commit. The `--no-edit` flag skips the remainder message input. Pass `FILES...` to auto-select all hunks from those files (e.g., `gg split -c 3 file1.rs file2.rs`). Native clients with their own hunk picker use the structured Describe/Apply protocol documented in `reference.md`.
+- Split a stack into two stacks: `gg unstack` — opens a picker by default. The selected entry and descendants become a new independent stack; lower entries remain in the original stack. Use `--target <position|gg-id|sha> --no-tui` for scripts, and `--name <stack>` to choose the new stack name. Use `--keep-current` when a native client must leave the invoking worktree on the lower stack without creating an upper worktree; it conflicts with `--worktree`.
 - Drop commits from stack: `gg drop <position|sha|gg-id>... -y` (alias: `gg abandon`). Use `-y` / `--yes` to skip confirmation; add `-f` / `--force` only to bypass the immutability guard for merged/base-ancestor commits.
 - Reorder/drop stack (TUI): `gg reorder` (or `gg arrange`) — opens interactive TUI for visual reordering and dropping commits. Press `d` to mark a commit for dropping. Use `--no-tui` to fall back to text editor (delete lines to drop).
 - Reorder stack (direct): `gg reorder -o "3,1,2"`

--- a/skills/gg/SKILL.md
+++ b/skills/gg/SKILL.md
@@ -195,6 +195,13 @@ and `run --amend`) snapshots the refs it will touch before mutating and
 records the operation on success. The log keeps the last 100 records;
 interrupted/pending records are never pruned.
 
+Native clients should pass a fresh `--client-operation-id <ID>` on every
+mutation. This global flag accepts a 1–128 character safe ASCII token and is
+preserved as an exact flag/value pair in the operation record's raw `args`.
+Match that pair in `gg undo --list --json`, then use the record's own opaque
+`op_...` `id` for targeted undo. Never infer the record from timestamps or
+newest-first ordering, and never treat the client token as GG's operation ID.
+
 If a recorded operation pauses on a rebase conflict, resolve the conflict,
 stage the files, and run `gg continue`; completion finalizes the original
 operation record so it remains available to `gg undo`.

--- a/skills/gg/SKILL.md
+++ b/skills/gg/SKILL.md
@@ -158,7 +158,9 @@ gg land -a -c --json
 ## Common operations
 
 - Navigate: `gg mv`, `gg first`, `gg last`, `gg prev`, `gg next`
-- Amend current commit: `gg sc` / `gg sc -a`
+- Amend current commit: `gg sc` / `gg sc -a`. Native clients that already
+  prepared the index should use `gg sc --staged-only` so repository
+  `defaults.unstaged_action` cannot stage or stash unrelated changes.
 - Auto-distribute staged hunks: `gg absorb -s`
 - Split a commit into two: `gg split` — opens a two-panel TUI for hunk selection (files on the left, colored diff on the right), followed by inline commit message inputs for both the new and remainder commits. Use `--no-tui` to fall back to sequential `git add -p` style prompts. The `-m` flag bypasses the TUI message input for the new commit. The `--no-edit` flag skips the remainder message input. Pass `FILES...` to auto-select all hunks from those files (e.g., `gg split -c 3 file1.rs file2.rs`). Native clients with their own hunk picker use the structured Describe/Apply protocol documented in `reference.md`.
 - Split a stack into two stacks: `gg unstack` — opens a picker by default. The selected entry and descendants become a new independent stack; lower entries remain in the original stack. Use `--target <position|gg-id|sha> --no-tui` for scripts, and `--name <stack>` to choose the new stack name. Use `--keep-current` when a native client must leave the invoking worktree on the lower stack without creating an upper worktree; it conflicts with `--worktree`.
@@ -208,7 +210,8 @@ operation record so it remains available to `gg undo`.
 
 **Refusal modes** (exit 1, no refs touched, JSON includes `refusal.reason`):
 
-- `remote` — target operation pushed/merged/closed/created a PR/MR.
+- `remote` — target operation pushed, deleted a remote branch, or
+  created/merged/closed a PR/MR.
   gg prints a provider-specific revert hint (`gh pr close <n>`,
   `glab mr close <n>`, `git push --delete …`). Agents must surface the
   hint to the user rather than attempt silent remote rollback.

--- a/skills/gg/reference.md
+++ b/skills/gg/reference.md
@@ -184,8 +184,16 @@ Split a commit into two. Selected files/hunks become a new commit inserted befor
 - `-m, --message <MSG>` — message for the new commit
 - `--no-edit` — keep original message for remainder, don't prompt
 - `--no-tui` — disable TUI, use sequential prompt instead (legacy `git add -p` style)
-- `-f, --force` (alias: `--ignore-immutable`) — bypass the [immutability guard](#immutable-commits)
+- `--describe` — emit protocol v1 target and hunk JSON; requires `--json`
+- `--plan-json <PATH>` — apply a protocol v1 plan; requires `--json`
+- `--json` — machine-readable structured Describe/Apply output
+- `-f, --force` (alias: `--ignore-immutable`) — bypass the [immutability guard](#immutable-commits) for interactive or file-based Split; structured Describe/Apply does not honor it
 - `FILES...` — auto-select all hunks from these files (opens interactive hunk picker if omitted)
+
+`--describe` and `--plan-json` conflict with each other and with interactive
+selection/message flags and `FILES...`. Structured Describe and Apply always
+use the immutability guard without a force override; the v1 plan has no force
+field.
 
 #### `gg unstack [OPTIONS]`
 Split the current stack into two independent stacks. The selected entry and its descendants become a new stack; lower entries remain in the original stack. This is named `unstack` because `gg split` already splits commits.
@@ -193,6 +201,8 @@ Split the current stack into two independent stacks. The selected entry and its 
 - `-t, --target <TARGET>` — first entry for the new stack (position, SHA, or GG-ID)
 - `-n, --name <STACK_NAME>` — explicit new stack name (default: `<old-stack>-2`, incrementing)
 - `-w, --worktree` / `--wt` — create the new upper stack in a managed worktree; current directory stays on the lower stack
+- `--keep-current` — leave the invoking worktree on the lower stack without
+  creating an upper worktree; conflicts with `--worktree` / `--wt`
 - `--no-tui` — disable the interactive picker; requires `--target`
 - `-f, --force` (alias: `--ignore-immutable`) — bypass the [immutability guard](#immutable-commits)
 - `--json`
@@ -333,6 +343,139 @@ All JSON payloads include `version` (`u32`, current value: `1`).
   "error": "string"
 }
 ```
+
+Structured Split writes this envelope to stdout and exits non-zero for parse,
+validation, stale-plan, immutability, and rewrite failures. Clients must use the
+exit status to distinguish it from a success response.
+
+### `gg split --describe --json`
+
+```json
+{
+  "version": 1,
+  "plan_token": "split-v1-a1b2c3d4e5f6",
+  "target": {
+    "gg_id": "c-abc1234",
+    "sha": "0123456789abcdef0123456789abcdef01234567",
+    "tree": "89abcdef0123456789abcdef0123456789abcdef"
+  },
+  "hunks": [
+    {
+      "id": "h-0123456789ab",
+      "path": "src/auth.rs",
+      "header": "@@ -10,3 +10,4 @@",
+      "patch": "@@ -10,3 +10,4 @@\n context\n+added\n"
+    }
+  ],
+  "non_textual_files": ["assets/icon.png"],
+  "first_message": "Split from: Add authentication",
+  "remainder_message": "Add authentication"
+}
+```
+
+Fields:
+
+- `version` (`number`): schema version; currently exactly `1`.
+- `plan_token` (`string`): opaque token binding the version, complete target
+  identity, and ordered hunk IDs. Copy it unchanged into Apply.
+- `target.gg_id` (`string | null`): target GG-ID when present.
+- `target.sha` (`string`): full target commit SHA at Describe time.
+- `target.tree` (`string`): full target tree SHA at Describe time.
+- `hunks` (`array`): selectable textual hunks in canonical order.
+- `hunks[].id` (`string`): opaque, stable ID for this described hunk. Copy it
+  unchanged; do not construct or parse it.
+- `hunks[].path` (`string`): repository-relative file path.
+- `hunks[].header` (`string`): unified-diff hunk header.
+- `hunks[].patch` (`string`): canonical hunk patch including its header.
+- `non_textual_files` (`string[]`): changed files without selectable textual
+  hunks. Protocol v1 always leaves them in the remainder commit.
+- `first_message` (`string`): suggested message for the new first commit.
+- `remainder_message` (`string`): original message with its GG-ID trailer
+  removed; the remainder keeps the original GG-ID during Apply.
+
+Describe is read-only: it does not require a clean worktree, move refs, acquire
+the operation lock, or add an operation-log record. Repeated Describe calls over
+unchanged state return the same `target`, `plan_token`, and ordered hunk IDs.
+
+### `gg split --plan-json <PATH> --json` input
+
+```json
+{
+  "version": 1,
+  "plan_token": "split-v1-a1b2c3d4e5f6",
+  "target": {
+    "gg_id": "c-abc1234",
+    "sha": "0123456789abcdef0123456789abcdef01234567",
+    "tree": "89abcdef0123456789abcdef0123456789abcdef"
+  },
+  "selected_hunk_ids": ["h-0123456789ab"],
+  "first_message": "Extract validation",
+  "remainder_message": "Add authentication"
+}
+```
+
+Fields:
+
+- `version` (`number`): must be exactly `1`.
+- `plan_token` (`string`): copy unchanged from the Describe response.
+- `target.gg_id` (`string | null`), `target.sha` (`string`), and `target.tree`
+  (`string`): copy the complete target object unchanged from Describe.
+- `selected_hunk_ids` (`string[]`): unique IDs copied from `hunks[].id`. The
+  selection must contain at least one hunk and must be a proper subset of all
+  returned hunks so changes remain in both commits.
+- `first_message` (`string`): non-empty message for the new first commit;
+  surrounding whitespace is trimmed.
+- `remainder_message` (`string`): non-empty message for the remainder commit;
+  surrounding whitespace is trimmed.
+
+There is no force field in protocol v1, and structured Apply does not honor a
+force override. It refuses immutable targets. It also rejects changed target
+identity or hunks as a `stale split plan`; clients must Describe again and have
+the user review a new selection rather than remapping old hunk IDs. Decode and
+validation refusals occur before refs move or an operation record is created.
+
+### `gg split --plan-json <PATH> --json` success
+
+```json
+{
+  "version": 1,
+  "operation_id": "op_0000001750000000_018f...",
+  "original_sha": "0123456789abcdef0123456789abcdef01234567",
+  "first": {
+    "sha": "1111111111111111111111111111111111111111",
+    "gg_id": "c-new1234"
+  },
+  "remainder": {
+    "sha": "2222222222222222222222222222222222222222",
+    "gg_id": "c-abc1234"
+  },
+  "rewritten_descendants": [
+    {
+      "sha": "3333333333333333333333333333333333333333",
+      "gg_id": "c-def5678"
+    }
+  ]
+}
+```
+
+Fields:
+
+- `version` (`number`): schema version; currently exactly `1`.
+- `operation_id` (`string`): opaque operation-log ID. Pass it unchanged to
+  `gg undo <operation_id> --json` for a targeted undo.
+- `original_sha` (`string`): full SHA of the commit that was split.
+- `first.sha` (`string`) and `first.gg_id` (`string | null`): identity of the
+  newly inserted first commit.
+- `remainder.sha` (`string`) and `remainder.gg_id` (`string | null`): identity
+  of the remainder, which retains the original GG-ID when one existed.
+- `rewritten_descendants` (`array`): ordered identities of descendants rebased
+  above the remainder; each has `sha` (`string`) and `gg_id`
+  (`string | null`). It is empty when no descendants were rewritten.
+
+Treat `plan_token`, hunk IDs, GG-IDs, and operation IDs as opaque strings.
+After mutation begins, a descendant rebase conflict returns the common JSON
+error envelope and leaves a paused operation. Resolve and stage the conflict,
+then run `gg continue`, or run `gg abort` to cancel it.
 
 ### `gg ls --json` (single stack)
 
@@ -595,6 +738,7 @@ Field types for `entries`:
   "unstack": {
     "original_stack": "my-feature",
     "new_stack": "my-feature-2",
+    "current_stack": "my-feature",
     "split_position": 3,
     "remaining_entries": [
       { "position": 1, "sha": "abc1234", "title": "First commit", "gg_id": "c-abc1234" }
@@ -611,8 +755,19 @@ Field types for `entries`:
 ```
 
 Field types:
-- `worktree_path`: `string | null` — present only when `--worktree` was used
+- `current_stack`: `string` — stack left in the invoking worktree after success
+- `worktree_path`: `string` — omitted unless `--worktree` was used
 - `gg_id`: `string | null`
+
+Placement modes:
+
+| Mode | Invoking worktree | Additional upper worktree | `current_stack` | `worktree_path` |
+|------|-------------------|---------------------------|-----------------|-----------------|
+| default | upper stack | not created | `new_stack` | omitted |
+| `--worktree` / `--wt` | lower stack | created or reused | `original_stack` | string path |
+| `--keep-current` | lower stack | not created | `original_stack` | omitted |
+
+`--keep-current` and `--worktree` / `--wt` are mutually exclusive.
 
 ### `gg restack --json`
 

--- a/skills/gg/reference.md
+++ b/skills/gg/reference.md
@@ -157,6 +157,9 @@ Move around stack entries.
 Squash changes into current stack commit.
 
 - `-a, --all`
+- `--staged-only` — use only the prepared index and ignore
+  `defaults.unstaged_action`; never stages or stashes other changes. Conflicts
+  with `--all`.
 - `-f, --force` (alias: `--ignore-immutable`) — bypass the [immutability guard](#immutable-commits)
 
 #### `gg absorb [OPTIONS]`
@@ -285,7 +288,7 @@ completed operation is still undoable.
 
 | `refusal.reason` | Condition | Handling |
 |---|---|---|
-| `remote` | Op pushed/merged/closed/created a PR or MR | Use the printed provider hint (`gh pr close <n>`, `glab mr close <n>`, `git push --delete …`). |
+| `remote` | Op pushed, deleted a remote branch, or created/merged/closed a PR or MR | Use the printed recovery hint. Branch deletions include an exact restore push when the prior OID was captured. |
 | `interrupted` | Op was Ctrl-C'd, crashed, or aborted before completion | Fix state manually; stale Pending records are swept on the next lock-acquiring op. |
 | `stale` | Refs moved since the target op finalised | Run `gg undo --list` and pick a more recent record. Error names the ref, expected OID, actual OID. |
 | `unsupported_schema` | Record was written by a newer `gg` binary | Upgrade `gg` or delete the record. |
@@ -491,6 +494,7 @@ then run `gg continue`, or run `gg abort` to cancel it.
 ```json
 {
   "version": 1,
+  "operation_id": "op_...",
   "stack": {
     "name": "string",
     "base": "string",
@@ -527,6 +531,7 @@ then run `gg continue`, or run `gg abort` to cancel it.
 ```
 
 Field types:
+- `operation_id`: `string`, **omitted when no GG operation is paused on the current Git rebase or when its saved marker is stale**. Treat it as opaque and pass it unchanged to `gg undo <operation_id> --json` after the operation has been completed or aborted.
 - `current_position`: `number | null`
 - `behind_base`: `number | null`
 - `gg_id`: `string | null`

--- a/skills/gg/reference.md
+++ b/skills/gg/reference.md
@@ -51,6 +51,15 @@ Example local config:
 
 ## Commands and flags
 
+### Global native-client correlation
+
+Every command accepts `--client-operation-id <ID>`. Native clients should pass
+a unique 1–128 character token made from ASCII letters, digits, `-`, `_`, `.`,
+or `:` on each mutation. GG preserves the exact flag/value pair in the
+operation record's raw `args`; find that pair in `gg undo --list --json` and
+use the record's own opaque `op_...` `id` for targeted undo. The client token
+does not replace or influence GG's operation ID.
+
 ### Stack lifecycle
 
 #### `gg co [OPTIONS] [STACK_NAME]`

--- a/skills/gg/reference.md
+++ b/skills/gg/reference.md
@@ -433,8 +433,10 @@ Fields:
 - `target.gg_id` (`string | null`), `target.sha` (`string`), and `target.tree`
   (`string`): copy the complete target object unchanged from Describe.
 - `selected_hunk_ids` (`string[]`): unique IDs copied from `hunks[].id`. The
-  selection must contain at least one hunk and must be a proper subset of all
-  returned hunks so changes remain in both commits.
+  selection must contain at least one hunk and leave a change for the remainder.
+  The selection may include every returned textual hunk when a non-textual file
+  or regular-file mode change remains; otherwise at least one textual hunk must
+  remain unselected.
 - `first_message` (`string`): non-empty message for the new first commit;
   surrounding whitespace is trimmed.
 - `remainder_message` (`string`): non-empty message for the remainder commit;


### PR DESCRIPTION
## Summary

- add structured split description and apply protocols with byte-accurate hunk preservation
- keep unstack operations anchored to the invoking worktree
- add native client operation correlation, staged-only amend support, and interrupted operation identity
- record remote branch deletion effects with exact server OIDs and leased deletion safety

## Verification

- `cargo test --all-features` (912 tests)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `mdbook build docs`
- `git diff --check`

## Consumer

- Alas integration stack: https://github.com/mrmans0n/alas/pull/868
