### PR TITLE
feat(inbox): stream progressive refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ gg clean
 | `gg log` | Smartlog tree view of the current stack, with PR/MR status, CI badges, and `<- HEAD` marker |
 | `gg log --json` | Machine-readable stack snapshot (same shape as `gg ls --json`, always refreshes PR/MR state) |
 | `gg log --refresh` | Refresh PR/MR state from the provider before rendering the tree |
-| `gg inbox` | Cross-stack triage view that groups PRs/MRs by action needed (ready, blocked, review, behind base, draft) |
+| `gg inbox` | Cross-stack triage view with progressive refresh and streaming output that groups PRs/MRs by action needed (ready, blocked, review, behind base, draft) |
 | `gg clean` | Remove merged stacks and their remote branches |
 
 ### Syncing

--- a/crates/gg-cli/src/main.rs
+++ b/crates/gg-cli/src/main.rs
@@ -522,6 +522,10 @@ enum Commands {
         /// Output structured JSON
         #[arg(long)]
         json: bool,
+
+        /// Output streaming NDJSON (one event per line; flushed after each)
+        #[arg(long = "jsonl", conflicts_with = "json")]
+        jsonl: bool,
     },
 
     /// Repair stack ancestry after manual history changes (amend, cherry-pick, rebase)
@@ -562,6 +566,7 @@ enum Commands {
 
 fn main() {
     let cli = Cli::parse();
+    let mut streaming_command: Option<&'static str> = None;
 
     let (result, json_mode, jsonl) = match cli.command {
         // No command = show stacks (like `gg ls`)
@@ -606,6 +611,10 @@ fn main() {
             until,
             no_verify,
         }) => {
+            if jsonl {
+                streaming_command = Some("sync");
+            }
+
             // Determine run_lint based on flags and config
             let run_lint = if lint {
                 // --lint explicitly passed
@@ -868,8 +877,19 @@ fn main() {
             false,
             false,
         ),
-        Some(Commands::Inbox { all, json }) => {
-            (gg_core::commands::inbox::run(all, json), json, false)
+        Some(Commands::Inbox { all, json, jsonl }) => {
+            if jsonl {
+                streaming_command = Some("inbox");
+            }
+            (
+                gg_core::commands::inbox::run(gg_core::commands::inbox::InboxOptions {
+                    all,
+                    json,
+                    jsonl,
+                }),
+                json || jsonl,
+                jsonl,
+            )
         }
         Some(Commands::Restack {
             dry_run,
@@ -910,13 +930,15 @@ fn main() {
         }
         if json_mode {
             if jsonl {
+                let command =
+                    streaming_command.expect("streaming command must be tracked in JSONL mode");
                 gg_core::output::StreamingJson::emit_and_exit(
-                    &gg_core::output::SyncStreamingResponse {
+                    &gg_core::output::StreamingErrorResponse {
                         version: gg_core::output::OUTPUT_VERSION,
-                        command: "sync".to_string(),
-                        event: gg_core::output::SyncStreamingEvent::Error {
-                            message: e.to_string(),
-                        },
+                        command,
+                        status: "error",
+                        event: "error",
+                        message: e.to_string(),
                     },
                     1,
                 );

--- a/crates/gg-cli/tests/integration_tests/inbox.rs
+++ b/crates/gg-cli/tests/integration_tests/inbox.rs
@@ -1,4 +1,4 @@
-use crate::helpers::{create_test_repo, run_gg, run_git};
+use crate::helpers::{create_test_repo, run_gg, run_gg_with_env, run_git};
 
 use serde_json::Value;
 use std::fs;
@@ -33,6 +33,7 @@ fn test_gg_inbox_json_no_stacks() {
         .as_object()
         .expect("buckets must be an object");
     for key in [
+        "refresh_failed",
         "ready_to_land",
         "changes_requested",
         "blocked_on_ci",
@@ -202,6 +203,102 @@ fn create_repo_with_inbox_item(provider: &str, mr_number: u64) -> (TempDir, Path
     .expect("Failed to write config");
 
     (temp_dir, repo_path)
+}
+
+fn write_fake_gh(temp_dir: &TempDir, fails_pr_view: bool) -> (PathBuf, PathBuf) {
+    let fake_bin = temp_dir.path().join("fake-bin");
+    fs::create_dir_all(&fake_bin).expect("create fake gh directory");
+    let log_path = temp_dir.path().join("gh-requests.log");
+    let pr_view_response = if fails_pr_view {
+        "echo 'simulated provider failure' >&2\n  exit 1"
+    } else {
+        r#"printf '%s\n' '{"number":42,"title":"Inbox item","state":"OPEN","url":"https://github.com/acme/app/pull/42","headRefName":"testuser/inbox-copy/c-abc1234","isDraft":false,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS"}]}'
+  exit 0"#
+    };
+    fs::write(
+        fake_bin.join("gh"),
+        format!(
+            r#"#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "gh version test"
+  exit 0
+fi
+printf '%s\n' "$*" >> "$GG_FAKE_LOG"
+if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  {pr_view_response}
+fi
+exit 1
+"#
+        ),
+    )
+    .expect("write fake gh");
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(fake_bin.join("gh"), fs::Permissions::from_mode(0o755))
+            .expect("make fake gh executable");
+    }
+
+    (fake_bin, log_path)
+}
+
+#[test]
+fn test_gg_inbox_uses_one_snapshot_request_per_github_candidate() {
+    let (temp_dir, repo_path) = create_repo_with_inbox_item("github", 42);
+    let (fake_bin, log_path) = write_fake_gh(&temp_dir, false);
+
+    let (success, stdout, stderr) = run_gg_with_env(
+        &repo_path,
+        &["inbox", "--json"],
+        &[
+            ("PATH", fake_bin.as_os_str()),
+            ("GG_FAKE_LOG", log_path.as_os_str()),
+        ],
+    );
+    assert!(success, "gg inbox --json failed: {stderr}");
+
+    let parsed: Value = serde_json::from_str(&stdout).expect("stdout must be valid JSON");
+    assert_eq!(
+        parsed["buckets"]["ready_to_land"].as_array().unwrap().len(),
+        1
+    );
+    assert_eq!(
+        fs::read_to_string(log_path)
+            .expect("read fake gh log")
+            .lines()
+            .filter(|line| line.starts_with("pr view "))
+            .count(),
+        1,
+        "one candidate should issue exactly one snapshot request"
+    );
+}
+
+#[test]
+fn test_gg_inbox_reports_snapshot_refresh_failures_without_failing() {
+    let (temp_dir, repo_path) = create_repo_with_inbox_item("github", 42);
+    let (fake_bin, log_path) = write_fake_gh(&temp_dir, true);
+
+    let (success, stdout, stderr) = run_gg_with_env(
+        &repo_path,
+        &["inbox", "--json"],
+        &[
+            ("PATH", fake_bin.as_os_str()),
+            ("GG_FAKE_LOG", log_path.as_os_str()),
+        ],
+    );
+    assert!(success, "refresh failures should not fail inbox: {stderr}");
+
+    let parsed: Value = serde_json::from_str(&stdout).expect("stdout must be valid JSON");
+    let refresh_failed = parsed["buckets"]["refresh_failed"]
+        .as_array()
+        .expect("refresh_failed must be an array");
+    assert_eq!(refresh_failed.len(), 1);
+    assert!(refresh_failed[0].get("refresh_error").is_some());
+    assert!(parsed["buckets"]["awaiting_review"]
+        .as_array()
+        .expect("awaiting_review must be an array")
+        .is_empty());
 }
 
 #[test]

--- a/crates/gg-cli/tests/integration_tests/inbox.rs
+++ b/crates/gg-cli/tests/integration_tests/inbox.rs
@@ -611,9 +611,17 @@ fn test_gg_inbox_jsonl_refresh_failure_emits_entry_error_and_summary() {
 
 #[test]
 fn test_gg_inbox_human_uses_gitlab_mr_label() {
-    let (_temp_dir, repo_path) = create_repo_with_inbox_item("gitlab", 42);
+    let (temp_dir, repo_path) = create_repo_with_inbox_item("gitlab", 42);
+    let (fake_bin, log_path) = write_fake_glab(&temp_dir, false);
 
-    let (success, stdout, stderr) = run_gg(&repo_path, &["inbox"]);
+    let (success, stdout, stderr) = run_gg_with_env(
+        &repo_path,
+        &["inbox"],
+        &[
+            ("PATH", fake_bin.as_os_str()),
+            ("GG_FAKE_LOG", log_path.as_os_str()),
+        ],
+    );
     assert!(success, "gg inbox failed: {}", stderr);
 
     assert!(

--- a/crates/gg-cli/tests/integration_tests/inbox.rs
+++ b/crates/gg-cli/tests/integration_tests/inbox.rs
@@ -325,6 +325,47 @@ exit 1
     (fake_bin, log_path)
 }
 
+fn write_fake_glab(temp_dir: &TempDir, fails_approvals: bool) -> (PathBuf, PathBuf) {
+    let fake_bin = temp_dir.path().join("fake-bin");
+    fs::create_dir_all(&fake_bin).expect("create fake glab directory");
+    let log_path = temp_dir.path().join("glab-requests.log");
+    let approvals_response = if fails_approvals {
+        "echo 'simulated approvals failure' >&2\n  exit 1"
+    } else {
+        "printf '%s\\n' '{\"approved\":true}'\n  exit 0"
+    };
+    fs::write(
+        fake_bin.join("glab"),
+        format!(
+            r#"#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "glab version test"
+  exit 0
+fi
+printf '%s\n' "$*" >> "$GG_FAKE_LOG"
+if [ "$1" = "mr" ] && [ "$2" = "view" ]; then
+  printf '%s\n' '{{"iid":42,"title":"Inbox item","state":"opened","web_url":"https://gitlab.com/acme/app/-/merge_requests/42","source_branch":"testuser/inbox-copy/c-abc1234","draft":false,"work_in_progress":false,"detailed_merge_status":"mergeable","head_pipeline":{{"status":"success"}}}}'
+  exit 0
+fi
+if [ "$1" = "api" ] && [ "$2" = "projects/:id/merge_requests/42/approvals" ]; then
+  {approvals_response}
+fi
+exit 1
+"#
+        ),
+    )
+    .expect("write fake glab");
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(fake_bin.join("glab"), fs::Permissions::from_mode(0o755))
+            .expect("make fake glab executable");
+    }
+
+    (fake_bin, log_path)
+}
+
 #[test]
 fn test_gg_inbox_uses_one_snapshot_request_per_github_candidate() {
     let (temp_dir, repo_path) = create_repo_with_inbox_item("github", 42);
@@ -357,6 +398,75 @@ fn test_gg_inbox_uses_one_snapshot_request_per_github_candidate() {
 }
 
 #[test]
+fn test_gg_inbox_uses_one_details_and_approvals_request_per_gitlab_candidate() {
+    let (temp_dir, repo_path) = create_repo_with_inbox_item("gitlab", 42);
+    let (fake_bin, log_path) = write_fake_glab(&temp_dir, false);
+
+    let (success, stdout, stderr) = run_gg_with_env(
+        &repo_path,
+        &["inbox", "--json"],
+        &[
+            ("PATH", fake_bin.as_os_str()),
+            ("GG_FAKE_LOG", log_path.as_os_str()),
+        ],
+    );
+    assert!(success, "gg inbox --json failed: {stderr}");
+
+    let parsed: Value = serde_json::from_str(&stdout).expect("stdout must be valid JSON");
+    assert_eq!(
+        parsed["buckets"]["ready_to_land"]
+            .as_array()
+            .expect("ready_to_land must be an array")
+            .len(),
+        1
+    );
+    assert_eq!(
+        fs::read_to_string(log_path)
+            .expect("read fake glab log")
+            .lines()
+            .collect::<Vec<_>>(),
+        vec![
+            "mr view 42 --output json",
+            "api projects/:id/merge_requests/42/approvals"
+        ],
+        "one GitLab candidate should issue one details and one approvals request"
+    );
+}
+
+#[test]
+fn test_gg_inbox_contains_gitlab_approvals_failures_per_item() {
+    let (temp_dir, repo_path) = create_repo_with_inbox_item("gitlab", 42);
+    let (fake_bin, log_path) = write_fake_glab(&temp_dir, true);
+
+    let (success, stdout, stderr) = run_gg_with_env(
+        &repo_path,
+        &["inbox", "--json"],
+        &[
+            ("PATH", fake_bin.as_os_str()),
+            ("GG_FAKE_LOG", log_path.as_os_str()),
+        ],
+    );
+    assert!(success, "refresh failures should not fail inbox: {stderr}");
+
+    let parsed: Value = serde_json::from_str(&stdout).expect("stdout must be valid JSON");
+    let refresh_failed = parsed["buckets"]["refresh_failed"]
+        .as_array()
+        .expect("refresh_failed must be an array");
+    assert_eq!(refresh_failed.len(), 1);
+    assert!(refresh_failed[0]["refresh_error"]
+        .as_str()
+        .expect("refresh error")
+        .contains("simulated approvals failure"));
+    assert!(
+        parsed["buckets"]["ready_to_land"]
+            .as_array()
+            .expect("ready_to_land must be an array")
+            .is_empty(),
+        "a failed approvals refresh must not retain a partially refreshed ready item"
+    );
+}
+
+#[test]
 fn test_gg_inbox_reports_snapshot_refresh_failures_without_failing() {
     let (temp_dir, repo_path) = create_repo_with_inbox_item("github", 42);
     let (fake_bin, log_path) = write_fake_gh(&temp_dir, true);
@@ -381,6 +491,27 @@ fn test_gg_inbox_reports_snapshot_refresh_failures_without_failing() {
         .as_array()
         .expect("awaiting_review must be an array")
         .is_empty());
+}
+
+#[test]
+fn test_gg_inbox_human_refresh_failure_includes_provider_diagnostic() {
+    let (temp_dir, repo_path) = create_repo_with_inbox_item("github", 42);
+    let (fake_bin, log_path) = write_fake_gh(&temp_dir, true);
+
+    let (success, stdout, stderr) = run_gg_with_env(
+        &repo_path,
+        &["inbox"],
+        &[
+            ("PATH", fake_bin.as_os_str()),
+            ("GG_FAKE_LOG", log_path.as_os_str()),
+        ],
+    );
+
+    assert!(success, "refresh failures should not fail inbox: {stderr}");
+    assert!(
+        stdout.contains("simulated provider failure"),
+        "final human output should explain the refresh failure: {stdout}"
+    );
 }
 
 #[test]

--- a/crates/gg-cli/tests/integration_tests/inbox.rs
+++ b/crates/gg-cli/tests/integration_tests/inbox.rs
@@ -640,9 +640,17 @@ fn test_gg_inbox_human_uses_gitlab_mr_label() {
 
 #[test]
 fn test_gg_inbox_human_uses_github_pr_label() {
-    let (_temp_dir, repo_path) = create_repo_with_inbox_item("github", 43);
+    let (temp_dir, repo_path) = create_repo_with_inbox_item("github", 43);
+    let (fake_bin, log_path) = write_fake_gh(&temp_dir, false);
 
-    let (success, stdout, stderr) = run_gg(&repo_path, &["inbox"]);
+    let (success, stdout, stderr) = run_gg_with_env(
+        &repo_path,
+        &["inbox"],
+        &[
+            ("PATH", fake_bin.as_os_str()),
+            ("GG_FAKE_LOG", log_path.as_os_str()),
+        ],
+    );
     assert!(success, "gg inbox failed: {}", stderr);
 
     assert!(

--- a/crates/gg-cli/tests/integration_tests/inbox.rs
+++ b/crates/gg-cli/tests/integration_tests/inbox.rs
@@ -486,8 +486,8 @@ fn test_gg_inbox_human_uses_gitlab_mr_label() {
     assert!(success, "gg inbox failed: {}", stderr);
 
     assert!(
-        stderr.contains("Refreshing MR status"),
-        "stderr should use MR wording for GitLab, got: {stderr}"
+        !stderr.contains("Refreshing MR status"),
+        "redirected stderr should not contain static refresh progress, got: {stderr}"
     );
     assert!(
         stdout.contains("MR !42"),
@@ -507,8 +507,8 @@ fn test_gg_inbox_human_uses_github_pr_label() {
     assert!(success, "gg inbox failed: {}", stderr);
 
     assert!(
-        stderr.contains("Refreshing PR status"),
-        "stderr should use PR wording for GitHub, got: {stderr}"
+        !stderr.contains("Refreshing PR status"),
+        "redirected stderr should not contain static refresh progress, got: {stderr}"
     );
     assert!(
         stdout.contains("PR #43"),

--- a/crates/gg-cli/tests/integration_tests/inbox.rs
+++ b/crates/gg-cli/tests/integration_tests/inbox.rs
@@ -6,6 +6,88 @@ use std::path::PathBuf;
 
 use tempfile::TempDir;
 
+fn parse_jsonl(stdout: &str) -> Vec<Value> {
+    stdout
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("every JSONL line must parse"))
+        .collect()
+}
+
+#[test]
+fn test_gg_inbox_help_mentions_jsonl() {
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["inbox", "--help"]);
+
+    assert!(success, "gg inbox --help failed: {stderr}");
+    assert!(stdout.contains("--jsonl"), "help should mention --jsonl");
+}
+
+#[test]
+fn test_gg_inbox_rejects_json_and_jsonl_together() {
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    let (success, _stdout, stderr) = run_gg(&repo_path, &["inbox", "--json", "--jsonl"]);
+
+    assert!(!success, "--json and --jsonl should conflict");
+    assert!(
+        stderr.contains("cannot be used with"),
+        "Clap should report an explicit flag conflict: {stderr}"
+    );
+}
+
+#[test]
+fn test_gg_inbox_jsonl_fatal_error_uses_inbox_envelope() {
+    let temp_dir = TempDir::new().expect("create non-repository directory");
+
+    let (success, stdout, stderr) = run_gg(temp_dir.path(), &["inbox", "--jsonl"]);
+
+    assert!(!success, "fatal inbox error should exit nonzero");
+    assert!(
+        stderr.trim().is_empty(),
+        "stderr should be empty in JSONL mode: {stderr}"
+    );
+    let events = parse_jsonl(&stdout);
+    assert_eq!(events.len(), 1, "fatal error should emit one event");
+    assert_eq!(events[0]["version"], 1);
+    assert_eq!(events[0]["command"], "inbox");
+    assert_eq!(events[0]["status"], "error");
+    assert_eq!(events[0]["event"], "error");
+    assert!(events[0]["message"].is_string());
+}
+
+#[test]
+fn test_gg_inbox_jsonl_empty_inbox_emits_start_then_summary() {
+    let (_temp_dir, repo_path) = create_test_repo();
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"},"stacks":{}}"#,
+    )
+    .expect("Failed to write config");
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["inbox", "--jsonl"]);
+
+    assert!(success, "gg inbox --jsonl failed: {stderr}");
+    assert!(
+        stderr.trim().is_empty(),
+        "stderr should be empty in JSONL mode: {stderr}"
+    );
+    let events = parse_jsonl(&stdout);
+    assert_eq!(
+        events.len(),
+        2,
+        "empty inbox should emit exactly two events"
+    );
+    assert_eq!(events[0]["version"], 1);
+    assert_eq!(events[0]["command"], "inbox");
+    assert_eq!(events[0]["event"], "start");
+    assert_eq!(events[0]["total_candidates"], 0);
+    assert_eq!(events[1]["event"], "summary");
+    assert_eq!(events[1]["total_items"], 0);
+}
+
 #[test]
 fn test_gg_inbox_json_no_stacks() {
     let (_temp_dir, repo_path) = create_test_repo();
@@ -299,6 +381,101 @@ fn test_gg_inbox_reports_snapshot_refresh_failures_without_failing() {
         .as_array()
         .expect("awaiting_review must be an array")
         .is_empty());
+}
+
+#[test]
+fn test_gg_inbox_jsonl_success_emits_entry_and_atomic_summary() {
+    let (temp_dir, repo_path) = create_repo_with_inbox_item("github", 42);
+    let (fake_bin, log_path) = write_fake_gh(&temp_dir, false);
+    let env = [
+        ("PATH", fake_bin.as_os_str()),
+        ("GG_FAKE_LOG", log_path.as_os_str()),
+    ];
+
+    let (atomic_success, atomic_stdout, atomic_stderr) =
+        run_gg_with_env(&repo_path, &["inbox", "--json"], &env);
+    assert!(atomic_success, "gg inbox --json failed: {atomic_stderr}");
+    let atomic: Value =
+        serde_json::from_str(&atomic_stdout).expect("atomic stdout must be valid JSON");
+
+    let (success, stdout, stderr) = run_gg_with_env(&repo_path, &["inbox", "--jsonl"], &env);
+
+    assert!(success, "gg inbox --jsonl failed: {stderr}");
+    assert!(
+        stderr.trim().is_empty(),
+        "stderr should be empty in JSONL mode: {stderr}"
+    );
+    let events = parse_jsonl(&stdout);
+    assert_eq!(
+        events
+            .iter()
+            .map(|event| event["event"].as_str().unwrap())
+            .collect::<Vec<_>>(),
+        vec!["start", "entry", "summary"]
+    );
+    assert_eq!(events[1]["completed"], 1);
+    assert_eq!(events[1]["total_candidates"], 1);
+    assert_eq!(events[1]["included"], true);
+    assert_eq!(events[1]["bucket"], "ready_to_land");
+    assert_eq!(events[1]["remote_state"], "open");
+    assert_eq!(events[1]["entry"]["pr_number"], 42);
+
+    let summary = events.last().expect("summary event");
+    for field in ["total_items", "buckets", "stack_errors"] {
+        assert_eq!(
+            summary[field], atomic[field],
+            "streaming summary field {field} should match atomic JSON"
+        );
+    }
+}
+
+#[test]
+fn test_gg_inbox_jsonl_refresh_failure_emits_entry_error_and_summary() {
+    let (temp_dir, repo_path) = create_repo_with_inbox_item("github", 42);
+    let (fake_bin, log_path) = write_fake_gh(&temp_dir, true);
+
+    let (success, stdout, stderr) = run_gg_with_env(
+        &repo_path,
+        &["inbox", "--jsonl"],
+        &[
+            ("PATH", fake_bin.as_os_str()),
+            ("GG_FAKE_LOG", log_path.as_os_str()),
+        ],
+    );
+
+    assert!(
+        success,
+        "refresh failures should not fail inbox JSONL: {stderr}"
+    );
+    assert!(
+        stderr.trim().is_empty(),
+        "stderr should be empty in JSONL mode: {stderr}"
+    );
+    let events = parse_jsonl(&stdout);
+    assert_eq!(
+        events
+            .iter()
+            .map(|event| event["event"].as_str().unwrap())
+            .collect::<Vec<_>>(),
+        vec!["start", "entry_error", "summary"]
+    );
+    assert_eq!(events[1]["completed"], 1);
+    assert_eq!(events[1]["total_candidates"], 1);
+    assert_eq!(events[1]["included"], true);
+    assert_eq!(events[1]["bucket"], "refresh_failed");
+    assert_eq!(events[1]["entry"]["pr_number"], 42);
+    assert!(events[1]["error"]
+        .as_str()
+        .expect("entry error message")
+        .contains("simulated provider failure"));
+    assert_eq!(events[2]["total_items"], 1);
+    assert_eq!(
+        events[2]["buckets"]["refresh_failed"]
+            .as_array()
+            .expect("refresh_failed bucket")
+            .len(),
+        1
+    );
 }
 
 #[test]

--- a/crates/gg-core/src/commands/inbox.rs
+++ b/crates/gg-core/src/commands/inbox.rs
@@ -1,11 +1,13 @@
 //! Inbox command — multi-stack actionable triage view.
 
 mod refresh;
+mod render;
 
 use console::style;
 use serde::Serialize;
 
 use self::refresh::{refresh_candidates, InboxCompletion};
+use self::render::{InboxRowState, LiveInboxRenderer};
 use crate::config::Config;
 use crate::error::GgError;
 use crate::error::Result;
@@ -442,14 +444,12 @@ pub fn run(options: InboxOptions) -> Result<()> {
     }
 
     let provider = Provider::detect(&repo)?;
+    let mut renderer = if !options.json && !options.jsonl {
+        LiveInboxRenderer::stderr_if_interactive(&discovery.candidates, provider.pr_label())
+    } else {
+        None
+    };
     provider.check_installed()?;
-
-    if !options.json && !options.jsonl {
-        eprint!(
-            "{}",
-            style(format!("Refreshing {} status...", provider.pr_label())).dim()
-        );
-    }
 
     let mut completions: Vec<Option<InboxCompletion>> =
         (0..discovery.candidates.len()).map(|_| None).collect();
@@ -475,15 +475,19 @@ pub fn run(options: InboxOptions) -> Result<()> {
                     ),
                 );
             }
+            if let Some(renderer) = renderer.as_mut() {
+                let state = live_row_state_for_completion(&completion, provider, options.all);
+                renderer.update(completion.candidate.discovery_index, state);
+            }
             let index = completion.candidate.discovery_index;
             completions[index] = Some(completion);
         },
     );
-    let mut items = items_from_completions(completions, provider)?;
 
-    if !options.json && !options.jsonl {
-        eprintln!(" {}", style("done").green());
+    if let Some(renderer) = renderer.as_mut() {
+        renderer.finish_and_clear();
     }
+    let mut items = items_from_completions(completions, provider)?;
 
     // Closed entries are intentionally omitted from the inbox.
     items.retain(|item| item.bucket().is_some());
@@ -502,6 +506,25 @@ pub fn run(options: InboxOptions) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn live_row_state_for_completion<'a>(
+    completion: &'a InboxCompletion,
+    provider: Provider,
+    all: bool,
+) -> InboxRowState<'a> {
+    match &completion.result {
+        Ok(snapshot) => {
+            let item =
+                InboxItem::from_snapshot(completion.candidate.clone(), snapshot.clone(), provider);
+            match item.bucket() {
+                Some(ActionBucket::Merged) if !all => InboxRowState::MergedHidden,
+                Some(bucket) => InboxRowState::Bucket(bucket),
+                None => InboxRowState::ClosedHidden,
+            }
+        }
+        Err(error) => InboxRowState::RefreshFailed(error),
+    }
 }
 
 fn streaming_event_for_completion(
@@ -767,6 +790,7 @@ fn pr_state_str(state: &PrState) -> &'static str {
 
 #[cfg(test)]
 mod tests {
+    use super::render::InboxRowState;
     use super::*;
     use crate::provider::{CiStatus, PrState};
 
@@ -844,6 +868,56 @@ mod tests {
             items.iter().map(|item| item.mr_number).collect::<Vec<_>>(),
             vec![10, 11]
         );
+    }
+
+    #[test]
+    fn included_completion_uses_its_final_bucket_for_the_live_row() {
+        let mut completion = completion(candidate(0));
+        let Ok(snapshot) = &mut completion.result else {
+            unreachable!();
+        };
+        snapshot.approved = true;
+
+        assert!(matches!(
+            live_row_state_for_completion(&completion, Provider::GitHub, false),
+            InboxRowState::Bucket(ActionBucket::ReadyToLand)
+        ));
+    }
+
+    #[test]
+    fn excluded_completion_stays_visible_as_a_hidden_live_row() {
+        let mut merged = completion(candidate(0));
+        let Ok(snapshot) = &mut merged.result else {
+            unreachable!();
+        };
+        snapshot.state = PrState::Merged;
+        let mut closed = completion(candidate(1));
+        let Ok(snapshot) = &mut closed.result else {
+            unreachable!();
+        };
+        snapshot.state = PrState::Closed;
+
+        assert!(matches!(
+            live_row_state_for_completion(&merged, Provider::GitHub, false),
+            InboxRowState::MergedHidden
+        ));
+        assert!(matches!(
+            live_row_state_for_completion(&closed, Provider::GitHub, false),
+            InboxRowState::ClosedHidden
+        ));
+    }
+
+    #[test]
+    fn refresh_error_is_exposed_on_the_live_row() {
+        let completion = InboxCompletion {
+            candidate: candidate(0),
+            result: Err("provider timed out".to_string()),
+        };
+
+        assert!(matches!(
+            live_row_state_for_completion(&completion, Provider::GitHub, false),
+            InboxRowState::RefreshFailed("provider timed out")
+        ));
     }
 
     #[test]

--- a/crates/gg-core/src/commands/inbox.rs
+++ b/crates/gg-core/src/commands/inbox.rs
@@ -1,8 +1,11 @@
 //! Inbox command — multi-stack actionable triage view.
 
+mod refresh;
+
 use console::style;
 use serde::Serialize;
 
+use self::refresh::{refresh_candidates, InboxCompletion};
 use crate::config::Config;
 use crate::error::GgError;
 use crate::error::Result;
@@ -213,6 +216,27 @@ impl InboxItem {
     }
 }
 
+fn items_from_completions(
+    completions: Vec<Option<InboxCompletion>>,
+    provider: Provider,
+) -> Result<Vec<InboxItem>> {
+    completions
+        .into_iter()
+        .enumerate()
+        .map(|(index, completion)| {
+            let completion = completion.ok_or_else(|| {
+                GgError::Other(format!(
+                    "Internal error: missing inbox refresh completion for discovery index {index}"
+                ))
+            })?;
+            Ok(match completion.result {
+                Ok(snapshot) => InboxItem::from_snapshot(completion.candidate, snapshot, provider),
+                Err(error) => InboxItem::from_refresh_error(completion.candidate, error, provider),
+            })
+        })
+        .collect()
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct InboxCandidate {
     pub discovery_index: usize,
@@ -370,14 +394,21 @@ pub fn run(all: bool, json: bool) -> Result<()> {
         );
     }
 
-    let mut items = Vec::with_capacity(discovery.candidates.len());
-    for candidate in discovery.candidates {
-        let item = match provider.get_inbox_snapshot(candidate.pr_number) {
-            Ok(snapshot) => InboxItem::from_snapshot(candidate, snapshot, provider),
-            Err(error) => InboxItem::from_refresh_error(candidate, error.to_string(), provider),
-        };
-        items.push(item);
-    }
+    let mut completions: Vec<Option<InboxCompletion>> =
+        (0..discovery.candidates.len()).map(|_| None).collect();
+    refresh_candidates(
+        &discovery.candidates,
+        |candidate| {
+            provider
+                .get_inbox_snapshot(candidate.pr_number)
+                .map_err(|error| error.to_string())
+        },
+        |completion| {
+            let index = completion.candidate.discovery_index;
+            completions[index] = Some(completion);
+        },
+    );
+    let mut items = items_from_completions(completions, provider)?;
 
     if !json {
         eprintln!(" {}", style("done").green());
@@ -589,6 +620,32 @@ mod tests {
     use super::*;
     use crate::provider::{CiStatus, PrState};
 
+    fn candidate(discovery_index: usize) -> InboxCandidate {
+        InboxCandidate {
+            discovery_index,
+            stack_name: "stack".to_string(),
+            position: discovery_index + 1,
+            short_sha: format!("{discovery_index:07x}"),
+            title: format!("Candidate {discovery_index}"),
+            pr_number: discovery_index as u64 + 10,
+            behind_base: None,
+        }
+    }
+
+    fn completion(candidate: InboxCandidate) -> InboxCompletion {
+        InboxCompletion {
+            candidate,
+            result: Ok(InboxSnapshot {
+                state: PrState::Open,
+                url: "https://example.com/pull/1".to_string(),
+                approved: false,
+                changes_requested: false,
+                mergeable: true,
+                ci_status: None,
+            }),
+        }
+    }
+
     fn make_input(
         state: PrState,
         ci: Option<CiStatus>,
@@ -621,6 +678,33 @@ mod tests {
         };
 
         assert_eq!(bucket(&input), Some(ActionBucket::RefreshFailed));
+    }
+
+    #[test]
+    fn builds_items_in_discovery_order_after_out_of_order_completions() {
+        let mut completions: Vec<Option<InboxCompletion>> = (0..2).map(|_| None).collect();
+        for completion in [completion(candidate(1)), completion(candidate(0))] {
+            let index = completion.candidate.discovery_index;
+            completions[index] = Some(completion);
+        }
+
+        let items = items_from_completions(completions, Provider::GitHub).unwrap();
+
+        assert_eq!(
+            items.iter().map(|item| item.mr_number).collect::<Vec<_>>(),
+            vec![10, 11]
+        );
+    }
+
+    #[test]
+    fn missing_completion_is_an_internal_error() {
+        let error =
+            items_from_completions(vec![Some(completion(candidate(0))), None], Provider::GitHub)
+                .err()
+                .expect("missing completion should fail");
+
+        assert!(matches!(error, GgError::Other(_)));
+        assert!(error.to_string().contains("discovery index 1"));
     }
 
     #[test]

--- a/crates/gg-core/src/commands/inbox.rs
+++ b/crates/gg-core/src/commands/inbox.rs
@@ -588,6 +588,19 @@ fn emit_streaming_summary(
     );
 }
 
+fn sanitize_human_diagnostic(message: &str) -> String {
+    message
+        .chars()
+        .map(|character| {
+            if character.is_control() {
+                ' '
+            } else {
+                character
+            }
+        })
+        .collect()
+}
+
 fn print_human_output(items: &[InboxItem], stack_errors: &[StackLoadError]) {
     if items.is_empty() {
         println!(
@@ -654,9 +667,15 @@ fn print_human_output(items: &[InboxItem], stack_errors: &[StackLoadError]) {
                 Some(CiStatus::Failed) => " ✗",
                 _ => "",
             };
+            let refresh_diagnostic = item
+                .refresh_error
+                .as_deref()
+                .map(sanitize_human_diagnostic)
+                .map(|error| format!(" — {error}"))
+                .unwrap_or_default();
 
             println!(
-                "  {} {}  {}  {}  {} {}{}{}",
+                "  {} {}  {}  {}  {} {}{}{}{}",
                 style(format!("{} #{}", item.stack_name, item.position)).dim(),
                 style(&item.short_sha).dim(),
                 item.title,
@@ -665,6 +684,7 @@ fn print_human_output(items: &[InboxItem], stack_errors: &[StackLoadError]) {
                 item.mr_number_prefix,
                 item.mr_number,
                 ci_icon,
+                refresh_diagnostic,
             );
         }
         println!();
@@ -921,6 +941,33 @@ mod tests {
     }
 
     #[test]
+    fn human_diagnostic_preserves_ordinary_text() {
+        assert_eq!(
+            sanitize_human_diagnostic("Failed to check approvals for MR !42"),
+            "Failed to check approvals for MR !42"
+        );
+    }
+
+    #[test]
+    fn human_diagnostic_neutralizes_embedded_newlines() {
+        let sanitized = sanitize_human_diagnostic("first line\r\nsecond line");
+
+        assert!(!sanitized.contains('\r'));
+        assert!(!sanitized.contains('\n'));
+        assert!(sanitized.contains("first line"));
+        assert!(sanitized.contains("second line"));
+    }
+
+    #[test]
+    fn human_diagnostic_does_not_emit_terminal_controls() {
+        let sanitized = sanitize_human_diagnostic("failure: \u{1b}[31mred\u{7}");
+
+        assert!(!sanitized.chars().any(char::is_control));
+        assert!(sanitized.contains("failure:"));
+        assert!(sanitized.contains("red"));
+    }
+
+    #[test]
     fn missing_completion_is_an_internal_error() {
         let error =
             items_from_completions(vec![Some(completion(candidate(0))), None], Provider::GitHub)
@@ -999,6 +1046,12 @@ mod tests {
             false,
             false,
         );
+        assert_eq!(bucket(&input), Some(ActionBucket::AwaitingReview));
+    }
+
+    #[test]
+    fn approved_without_ci_but_not_mergeable_is_not_ready() {
+        let input = make_input(PrState::Open, None, true, false, false, false);
         assert_eq!(bucket(&input), Some(ActionBucket::AwaitingReview));
     }
 

--- a/crates/gg-core/src/commands/inbox.rs
+++ b/crates/gg-core/src/commands/inbox.rs
@@ -1,7 +1,5 @@
 //! Inbox command — multi-stack actionable triage view.
 
-use std::collections::HashMap;
-
 use console::style;
 use serde::Serialize;
 
@@ -13,7 +11,7 @@ use crate::output::{
     print_json, InboxBucketsJson, InboxEntryJson, InboxResponse, InboxStackErrorJson,
     OUTPUT_VERSION,
 };
-use crate::provider::{CiStatus, PrState, Provider};
+use crate::provider::{CiStatus, InboxSnapshot, PrState, Provider};
 use crate::stack;
 
 /// Action bucket for triage classification.
@@ -23,6 +21,7 @@ use crate::stack;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ActionBucket {
+    RefreshFailed,
     ReadyToLand,
     ChangesRequested,
     BlockedOnCi,
@@ -34,6 +33,7 @@ pub enum ActionBucket {
 
 /// Input fields for bucketing. Decoupled from StackEntry so the function is pure and testable.
 pub struct BucketInput {
+    pub refresh_failed: bool,
     pub mr_state: PrState,
     pub ci_status: Option<CiStatus>,
     pub approved: bool,
@@ -45,15 +45,20 @@ pub struct BucketInput {
 /// Classify a PR/MR into an action bucket.
 ///
 /// Priority order (first match wins):
-/// 1. Merged → Merged
-/// 2. Closed → None (skip)
-/// 3. Draft → Draft
-/// 4. Changes requested → ChangesRequested
-/// 5. Approved + CI green + mergeable → ReadyToLand
-/// 6. CI failed/running/pending → BlockedOnCi
-/// 7. Behind base → BehindBase
-/// 8. Fallthrough → AwaitingReview
+/// 1. Refresh failure → RefreshFailed
+/// 2. Merged → Merged
+/// 3. Closed → None (skip)
+/// 4. Draft → Draft
+/// 5. Changes requested → ChangesRequested
+/// 6. Approved + CI green + mergeable → ReadyToLand
+/// 7. CI failed/running/pending → BlockedOnCi
+/// 8. Behind base → BehindBase
+/// 9. Fallthrough → AwaitingReview
 pub fn bucket(input: &BucketInput) -> Option<ActionBucket> {
+    if input.refresh_failed {
+        return Some(ActionBucket::RefreshFailed);
+    }
+
     match input.mr_state {
         PrState::Merged => return Some(ActionBucket::Merged),
         PrState::Closed => return None,
@@ -126,7 +131,7 @@ fn load_stack_entries(
         .collect()
 }
 
-struct StackLoadError {
+pub(super) struct StackLoadError {
     stack_name: String,
     error: String,
 }
@@ -141,12 +146,89 @@ struct InboxItem {
     mr_url: String,
     mr_label: &'static str,
     mr_number_prefix: &'static str,
-    bucket: ActionBucket,
     ci_status: Option<CiStatus>,
+    approved: bool,
+    changes_requested: bool,
+    mergeable: bool,
     behind_base: Option<usize>,
+    remote_state: Option<PrState>,
+    refresh_error: Option<String>,
 }
 
-/// Run the inbox command.
+impl InboxItem {
+    fn from_snapshot(
+        candidate: InboxCandidate,
+        snapshot: InboxSnapshot,
+        provider: Provider,
+    ) -> Self {
+        Self {
+            stack_name: candidate.stack_name,
+            position: candidate.position,
+            short_sha: candidate.short_sha,
+            title: candidate.title,
+            mr_number: candidate.pr_number,
+            mr_url: snapshot.url,
+            mr_label: provider.pr_label(),
+            mr_number_prefix: provider.pr_number_prefix(),
+            ci_status: snapshot.ci_status,
+            approved: snapshot.approved,
+            changes_requested: snapshot.changes_requested,
+            mergeable: snapshot.mergeable,
+            behind_base: candidate.behind_base,
+            remote_state: Some(snapshot.state),
+            refresh_error: None,
+        }
+    }
+
+    fn from_refresh_error(candidate: InboxCandidate, error: String, provider: Provider) -> Self {
+        Self {
+            stack_name: candidate.stack_name,
+            position: candidate.position,
+            short_sha: candidate.short_sha,
+            title: candidate.title,
+            mr_number: candidate.pr_number,
+            mr_url: String::new(),
+            mr_label: provider.pr_label(),
+            mr_number_prefix: provider.pr_number_prefix(),
+            ci_status: None,
+            approved: false,
+            changes_requested: false,
+            mergeable: false,
+            behind_base: candidate.behind_base,
+            remote_state: None,
+            refresh_error: Some(error),
+        }
+    }
+
+    fn bucket(&self) -> Option<ActionBucket> {
+        bucket(&BucketInput {
+            refresh_failed: self.refresh_error.is_some(),
+            mr_state: self.remote_state.clone().unwrap_or(PrState::Open),
+            ci_status: self.ci_status.clone(),
+            approved: self.approved,
+            changes_requested: self.changes_requested,
+            mergeable: self.mergeable,
+            behind_base: self.behind_base.is_some(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct InboxCandidate {
+    pub discovery_index: usize,
+    pub stack_name: String,
+    pub position: usize,
+    pub short_sha: String,
+    pub title: String,
+    pub pr_number: u64,
+    pub behind_base: Option<usize>,
+}
+
+pub(super) struct InboxDiscovery {
+    pub candidates: Vec<InboxCandidate>,
+    pub stack_errors: Vec<StackLoadError>,
+}
+
 fn infer_stack_usernames(repo: &git2::Repository, config: &Config) -> Result<Vec<String>> {
     let mut usernames = Vec::new();
 
@@ -169,54 +251,19 @@ fn infer_stack_usernames(repo: &git2::Repository, config: &Config) -> Result<Vec
         }
     }
 
-    if usernames.is_empty() {
-        if let Ok(provider) = Provider::detect(repo) {
-            if let Ok(username) = provider.whoami() {
-                usernames.push(username);
-            }
-        }
-    }
-
     Ok(usernames)
 }
 
-pub fn run(all: bool, json: bool) -> Result<()> {
-    let repo = git::open_repo()?;
-    let config = Config::load_with_global(repo.commondir())?;
-
-    let usernames = infer_stack_usernames(&repo, &config)?;
-    if usernames.is_empty() {
-        if json {
-            print_json_output(&[], &[]);
-        } else {
-            println!(
-                "{}",
-                style("Inbox is empty — nothing needs attention.").dim()
-            );
-        }
-        return Ok(());
-    }
-
+fn discover_candidates(repo: &git2::Repository, config: &Config) -> Result<InboxDiscovery> {
+    let usernames = infer_stack_usernames(repo, config)?;
     let valid_usernames: Vec<String> = usernames
         .into_iter()
         .filter(|username| git::validate_branch_username(username).is_ok())
         .collect();
 
-    if valid_usernames.is_empty() {
-        if json {
-            print_json_output(&[], &[]);
-        } else {
-            println!(
-                "{}",
-                style("Inbox is empty — nothing needs attention.").dim()
-            );
-        }
-        return Ok(());
-    }
-
     let mut stack_branches: Vec<(String, String)> = Vec::new();
     for username in &valid_usernames {
-        for stack_name in stack::list_all_stacks(&repo, &config, username)? {
+        for stack_name in stack::list_all_stacks(repo, config, username)? {
             let full_branch = git::format_stack_branch(username, &stack_name);
             if repo
                 .find_branch(&full_branch, git2::BranchType::Local)
@@ -233,36 +280,11 @@ pub fn run(all: bool, json: bool) -> Result<()> {
         }
     }
 
-    if stack_branches.is_empty() {
-        if json {
-            print_json_output(&[], &[]);
-        } else {
-            println!(
-                "{}",
-                style("Inbox is empty — nothing needs attention.").dim()
-            );
-        }
-        return Ok(());
-    }
-
-    let detected_provider = Provider::detect(&repo).ok();
-    let mr_label = detected_provider
-        .as_ref()
-        .map(Provider::pr_label)
-        .unwrap_or("PR/MR");
-
-    if !json {
-        eprint!(
-            "{}",
-            style(format!("Refreshing {mr_label} status...")).dim()
-        );
-    }
-
-    let mut items: Vec<InboxItem> = Vec::new();
     let mut stack_errors: Vec<StackLoadError> = Vec::new();
+    let mut candidates = Vec::new();
 
     for (stack_name, full_branch) in &stack_branches {
-        let base = match resolve_base_branch(&repo, &config, stack_name) {
+        let base = match resolve_base_branch(repo, config, stack_name) {
             Ok(base) => base,
             Err(err) => {
                 stack_errors.push(StackLoadError {
@@ -272,7 +294,7 @@ pub fn run(all: bool, json: bool) -> Result<()> {
                 continue;
             }
         };
-        let mut entries = match load_stack_entries(&repo, &base, full_branch) {
+        let mut entries = match load_stack_entries(repo, &base, full_branch) {
             Ok(entries) => entries,
             Err(err) => {
                 stack_errors.push(StackLoadError {
@@ -293,96 +315,86 @@ pub fn run(all: bool, json: bool) -> Result<()> {
             }
         }
 
-        let provider = if entries.iter().any(|entry| entry.mr_number.is_some()) {
-            detected_provider
-        } else {
-            None
-        };
-
-        // Refresh PR/MR info from provider and cache URLs (T9 optimization)
-        let mut mr_urls: HashMap<u64, String> = HashMap::new();
-        for entry in &mut entries {
-            if let (Some(pr_num), Some(provider)) = (entry.mr_number, provider) {
-                if let Ok(info) = provider.get_pr_info(pr_num) {
-                    entry.mr_state = Some(info.state);
-                    entry.approved = info.approved;
-                    entry.changes_requested = info.changes_requested;
-                    entry.mergeable = info.mergeable;
-                    mr_urls.insert(pr_num, info.url);
-                }
-                if let Ok(ci) = provider.get_pr_ci_status(pr_num) {
-                    entry.ci_status = Some(ci);
-                }
-                if let Ok(approved) = provider.check_pr_approved(pr_num) {
-                    if approved || !entry.approved {
-                        entry.approved = approved;
-                    }
-                }
-            }
-        }
-
         // Compute behind-base from the actual stack tip, not the local base branch.
         // This avoids false positives when local `<base>` is stale but the stack
         // itself has already been rebased onto `origin/<base>`.
         let behind =
-            git::count_branch_behind_upstream(&repo, full_branch, &format!("origin/{}", base))
+            git::count_branch_behind_upstream(repo, full_branch, &format!("origin/{}", base))
                 .ok()
                 .filter(|&b| b > 0);
 
-        // Bucket each entry with a PR/MR
+        // Collect each entry with a mapped PR/MR for a later remote refresh.
         for entry in &entries {
             if let Some(mr_num) = entry.mr_number {
-                let mr_url = mr_urls.get(&mr_num).cloned().unwrap_or_default();
-
-                // If provider refresh failed (mr_state is None), default to
-                // PrState::Open so entries remain visible in the inbox rather
-                // than silently disappearing during transient failures.
-                let mr_state = entry.mr_state.clone().unwrap_or(PrState::Open);
-
-                let input = BucketInput {
-                    mr_state,
-                    ci_status: entry.ci_status.clone(),
-                    approved: entry.approved,
-                    changes_requested: entry.changes_requested,
-                    mergeable: entry.mergeable,
-                    behind_base: behind.is_some(),
-                };
-
-                if let Some(b) = bucket(&input) {
-                    items.push(InboxItem {
-                        stack_name: stack_name.clone(),
-                        position: entry.position,
-                        short_sha: entry.short_sha.clone(),
-                        title: entry.title.clone(),
-                        mr_number: mr_num,
-                        mr_url,
-                        mr_label: provider.as_ref().map(Provider::pr_label).unwrap_or("PR/MR"),
-                        mr_number_prefix: provider
-                            .as_ref()
-                            .map(Provider::pr_number_prefix)
-                            .unwrap_or("#"),
-                        bucket: b,
-                        ci_status: entry.ci_status.clone(),
-                        behind_base: behind,
-                    });
-                }
+                candidates.push(InboxCandidate {
+                    discovery_index: candidates.len(),
+                    stack_name: stack_name.clone(),
+                    position: entry.position,
+                    short_sha: entry.short_sha.clone(),
+                    title: entry.title.clone(),
+                    pr_number: mr_num,
+                    behind_base: behind,
+                });
             }
         }
+    }
+
+    Ok(InboxDiscovery {
+        candidates,
+        stack_errors,
+    })
+}
+
+/// Run the inbox command.
+pub fn run(all: bool, json: bool) -> Result<()> {
+    let repo = git::open_repo()?;
+    let config = Config::load_with_global(repo.commondir())?;
+    let discovery = discover_candidates(&repo, &config)?;
+
+    if discovery.candidates.is_empty() {
+        if json {
+            print_json_output(&[], &discovery.stack_errors);
+        } else {
+            print_human_output(&[], &discovery.stack_errors);
+        }
+        return Ok(());
+    }
+
+    let provider = Provider::detect(&repo)?;
+    provider.check_installed()?;
+
+    if !json {
+        eprint!(
+            "{}",
+            style(format!("Refreshing {} status...", provider.pr_label())).dim()
+        );
+    }
+
+    let mut items = Vec::with_capacity(discovery.candidates.len());
+    for candidate in discovery.candidates {
+        let item = match provider.get_inbox_snapshot(candidate.pr_number) {
+            Ok(snapshot) => InboxItem::from_snapshot(candidate, snapshot, provider),
+            Err(error) => InboxItem::from_refresh_error(candidate, error.to_string(), provider),
+        };
+        items.push(item);
     }
 
     if !json {
         eprintln!(" {}", style("done").green());
     }
 
+    // Closed entries are intentionally omitted from the inbox.
+    items.retain(|item| item.bucket().is_some());
+
     // Filter out merged unless --all
     if !all {
-        items.retain(|item| item.bucket != ActionBucket::Merged);
+        items.retain(|item| item.bucket() != Some(ActionBucket::Merged));
     }
 
     if json {
-        print_json_output(&items, &stack_errors);
+        print_json_output(&items, &discovery.stack_errors);
     } else {
-        print_human_output(&items, &stack_errors);
+        print_human_output(&items, &discovery.stack_errors);
     }
 
     Ok(())
@@ -427,6 +439,7 @@ fn print_human_output(items: &[InboxItem], stack_errors: &[StackLoadError]) {
     );
 
     let bucket_order = [
+        ActionBucket::RefreshFailed,
         ActionBucket::ReadyToLand,
         ActionBucket::ChangesRequested,
         ActionBucket::BlockedOnCi,
@@ -437,7 +450,10 @@ fn print_human_output(items: &[InboxItem], stack_errors: &[StackLoadError]) {
     ];
 
     for b in &bucket_order {
-        let group: Vec<&InboxItem> = items.iter().filter(|i| &i.bucket == b).collect();
+        let group: Vec<&InboxItem> = items
+            .iter()
+            .filter(|item| item.bucket() == Some(*b))
+            .collect();
         if group.is_empty() {
             continue;
         }
@@ -481,6 +497,7 @@ fn print_human_output(items: &[InboxItem], stack_errors: &[StackLoadError]) {
 
 fn bucket_label(b: ActionBucket) -> &'static str {
     match b {
+        ActionBucket::RefreshFailed => "Refresh failed",
         ActionBucket::ReadyToLand => "Ready to land",
         ActionBucket::ChangesRequested => "Changes requested",
         ActionBucket::BlockedOnCi => "Blocked on CI",
@@ -494,6 +511,7 @@ fn bucket_label(b: ActionBucket) -> &'static str {
 fn styled_bucket_label(b: ActionBucket) -> console::StyledObject<&'static str> {
     let label = bucket_label(b);
     match b {
+        ActionBucket::RefreshFailed => style(label).red().bold(),
         ActionBucket::ReadyToLand => style(label).green().bold(),
         ActionBucket::ChangesRequested => style(label).red().bold(),
         ActionBucket::BlockedOnCi => style(label).yellow().bold(),
@@ -505,6 +523,7 @@ fn styled_bucket_label(b: ActionBucket) -> console::StyledObject<&'static str> {
 
 fn print_json_output(items: &[InboxItem], stack_errors: &[StackLoadError]) {
     let mut buckets = InboxBucketsJson {
+        refresh_failed: vec![],
         ready_to_land: vec![],
         changes_requested: vec![],
         blocked_on_ci: vec![],
@@ -524,16 +543,19 @@ fn print_json_output(items: &[InboxItem], stack_errors: &[StackLoadError]) {
             pr_url: item.mr_url.clone(),
             ci_status: item.ci_status.as_ref().map(ci_status_str),
             behind_base: item.behind_base,
+            refresh_error: item.refresh_error.clone(),
         };
 
-        match item.bucket {
-            ActionBucket::ReadyToLand => buckets.ready_to_land.push(entry),
-            ActionBucket::ChangesRequested => buckets.changes_requested.push(entry),
-            ActionBucket::BlockedOnCi => buckets.blocked_on_ci.push(entry),
-            ActionBucket::AwaitingReview => buckets.awaiting_review.push(entry),
-            ActionBucket::BehindBase => buckets.behind_base.push(entry),
-            ActionBucket::Draft => buckets.draft.push(entry),
-            ActionBucket::Merged => buckets.merged.push(entry),
+        match item.bucket() {
+            Some(ActionBucket::RefreshFailed) => buckets.refresh_failed.push(entry),
+            Some(ActionBucket::ReadyToLand) => buckets.ready_to_land.push(entry),
+            Some(ActionBucket::ChangesRequested) => buckets.changes_requested.push(entry),
+            Some(ActionBucket::BlockedOnCi) => buckets.blocked_on_ci.push(entry),
+            Some(ActionBucket::AwaitingReview) => buckets.awaiting_review.push(entry),
+            Some(ActionBucket::BehindBase) => buckets.behind_base.push(entry),
+            Some(ActionBucket::Draft) => buckets.draft.push(entry),
+            Some(ActionBucket::Merged) => buckets.merged.push(entry),
+            None => continue,
         }
     }
 
@@ -576,6 +598,7 @@ mod tests {
         behind_base: bool,
     ) -> BucketInput {
         BucketInput {
+            refresh_failed: false,
             mr_state: state,
             ci_status: ci,
             approved,
@@ -583,6 +606,21 @@ mod tests {
             mergeable,
             behind_base,
         }
+    }
+
+    #[test]
+    fn refresh_failure_has_highest_priority() {
+        let input = BucketInput {
+            refresh_failed: true,
+            mr_state: PrState::Merged,
+            ci_status: Some(CiStatus::Success),
+            approved: true,
+            changes_requested: true,
+            mergeable: true,
+            behind_base: true,
+        };
+
+        assert_eq!(bucket(&input), Some(ActionBucket::RefreshFailed));
     }
 
     #[test]
@@ -794,6 +832,7 @@ mod tests {
 
     #[test]
     fn action_bucket_display_order() {
+        assert!(ActionBucket::RefreshFailed < ActionBucket::ReadyToLand);
         assert!(ActionBucket::ReadyToLand < ActionBucket::ChangesRequested);
         assert!(ActionBucket::ChangesRequested < ActionBucket::BlockedOnCi);
         assert!(ActionBucket::BlockedOnCi < ActionBucket::AwaitingReview);

--- a/crates/gg-core/src/commands/inbox.rs
+++ b/crates/gg-core/src/commands/inbox.rs
@@ -11,11 +11,19 @@ use crate::error::GgError;
 use crate::error::Result;
 use crate::git;
 use crate::output::{
-    print_json, InboxBucketsJson, InboxEntryJson, InboxResponse, InboxStackErrorJson,
+    print_json, InboxBucketsJson, InboxCandidateJson, InboxEntryJson, InboxResponse,
+    InboxStackErrorJson, InboxStreamingEvent, InboxStreamingResponse, StreamingJson,
     OUTPUT_VERSION,
 };
 use crate::provider::{CiStatus, InboxSnapshot, PrState, Provider};
 use crate::stack;
+
+#[derive(Debug, Clone, Copy)]
+pub struct InboxOptions {
+    pub all: bool,
+    pub json: bool,
+    pub jsonl: bool,
+}
 
 /// Action bucket for triage classification.
 ///
@@ -214,6 +222,20 @@ impl InboxItem {
             behind_base: self.behind_base.is_some(),
         })
     }
+
+    fn to_json(&self) -> InboxEntryJson {
+        InboxEntryJson {
+            stack_name: self.stack_name.clone(),
+            position: self.position,
+            sha: self.short_sha.clone(),
+            title: self.title.clone(),
+            pr_number: self.mr_number,
+            pr_url: self.mr_url.clone(),
+            ci_status: self.ci_status.as_ref().map(ci_status_str),
+            behind_base: self.behind_base,
+            refresh_error: self.refresh_error.clone(),
+        }
+    }
 }
 
 fn items_from_completions(
@@ -246,6 +268,19 @@ pub(super) struct InboxCandidate {
     pub title: String,
     pub pr_number: u64,
     pub behind_base: Option<usize>,
+}
+
+impl InboxCandidate {
+    fn to_json(&self) -> InboxCandidateJson {
+        InboxCandidateJson {
+            stack_name: self.stack_name.clone(),
+            position: self.position,
+            sha: self.short_sha.clone(),
+            title: self.title.clone(),
+            pr_number: self.pr_number,
+            behind_base: self.behind_base,
+        }
+    }
 }
 
 pub(super) struct InboxDiscovery {
@@ -370,13 +405,35 @@ fn discover_candidates(repo: &git2::Repository, config: &Config) -> Result<Inbox
 }
 
 /// Run the inbox command.
-pub fn run(all: bool, json: bool) -> Result<()> {
+pub fn run(options: InboxOptions) -> Result<()> {
     let repo = git::open_repo()?;
     let config = Config::load_with_global(repo.commondir())?;
     let discovery = discover_candidates(&repo, &config)?;
+    let mut streaming = options.jsonl.then(StreamingJson::new);
+
+    if let Some(streaming) = streaming.as_mut() {
+        emit_streaming_event(
+            streaming,
+            InboxStreamingEvent::Start {
+                total_candidates: discovery.candidates.len(),
+                total_stack_errors: discovery.stack_errors.len(),
+            },
+        );
+        for stack_error in &discovery.stack_errors {
+            emit_streaming_event(
+                streaming,
+                InboxStreamingEvent::StackError {
+                    stack_name: stack_error.stack_name.clone(),
+                    error: stack_error.error.clone(),
+                },
+            );
+        }
+    }
 
     if discovery.candidates.is_empty() {
-        if json {
+        if let Some(streaming) = streaming.as_mut() {
+            emit_streaming_summary(streaming, &[], &discovery.stack_errors);
+        } else if options.json {
             print_json_output(&[], &discovery.stack_errors);
         } else {
             print_human_output(&[], &discovery.stack_errors);
@@ -387,7 +444,7 @@ pub fn run(all: bool, json: bool) -> Result<()> {
     let provider = Provider::detect(&repo)?;
     provider.check_installed()?;
 
-    if !json {
+    if !options.json && !options.jsonl {
         eprint!(
             "{}",
             style(format!("Refreshing {} status...", provider.pr_label())).dim()
@@ -396,6 +453,7 @@ pub fn run(all: bool, json: bool) -> Result<()> {
 
     let mut completions: Vec<Option<InboxCompletion>> =
         (0..discovery.candidates.len()).map(|_| None).collect();
+    let mut completed = 0;
     refresh_candidates(
         &discovery.candidates,
         |candidate| {
@@ -404,13 +462,26 @@ pub fn run(all: bool, json: bool) -> Result<()> {
                 .map_err(|error| error.to_string())
         },
         |completion| {
+            completed += 1;
+            if let Some(streaming) = streaming.as_mut() {
+                emit_streaming_event(
+                    streaming,
+                    streaming_event_for_completion(
+                        &completion,
+                        provider,
+                        completed,
+                        discovery.candidates.len(),
+                        options.all,
+                    ),
+                );
+            }
             let index = completion.candidate.discovery_index;
             completions[index] = Some(completion);
         },
     );
     let mut items = items_from_completions(completions, provider)?;
 
-    if !json {
+    if !options.json && !options.jsonl {
         eprintln!(" {}", style("done").green());
     }
 
@@ -418,17 +489,80 @@ pub fn run(all: bool, json: bool) -> Result<()> {
     items.retain(|item| item.bucket().is_some());
 
     // Filter out merged unless --all
-    if !all {
+    if !options.all {
         items.retain(|item| item.bucket() != Some(ActionBucket::Merged));
     }
 
-    if json {
+    if let Some(streaming) = streaming.as_mut() {
+        emit_streaming_summary(streaming, &items, &discovery.stack_errors);
+    } else if options.json {
         print_json_output(&items, &discovery.stack_errors);
     } else {
         print_human_output(&items, &discovery.stack_errors);
     }
 
     Ok(())
+}
+
+fn streaming_event_for_completion(
+    completion: &InboxCompletion,
+    provider: Provider,
+    completed: usize,
+    total_candidates: usize,
+    all: bool,
+) -> InboxStreamingEvent {
+    match &completion.result {
+        Ok(snapshot) => {
+            let item =
+                InboxItem::from_snapshot(completion.candidate.clone(), snapshot.clone(), provider);
+            let bucket = item.bucket();
+            let included = bucket.is_some() && (all || bucket != Some(ActionBucket::Merged));
+            InboxStreamingEvent::Entry {
+                completed,
+                total_candidates,
+                included,
+                bucket: if included {
+                    bucket.map(|bucket| action_bucket_str(bucket).to_string())
+                } else {
+                    None
+                },
+                remote_state: pr_state_str(&snapshot.state).to_string(),
+                entry: item.to_json(),
+            }
+        }
+        Err(error) => InboxStreamingEvent::EntryError {
+            completed,
+            total_candidates,
+            included: true,
+            bucket: action_bucket_str(ActionBucket::RefreshFailed).to_string(),
+            entry: completion.candidate.to_json(),
+            error: error.clone(),
+        },
+    }
+}
+
+fn emit_streaming_event(streaming: &mut StreamingJson, event: InboxStreamingEvent) {
+    streaming.emit(&InboxStreamingResponse {
+        version: OUTPUT_VERSION,
+        command: "inbox".to_string(),
+        event,
+    });
+}
+
+fn emit_streaming_summary(
+    streaming: &mut StreamingJson,
+    items: &[InboxItem],
+    stack_errors: &[StackLoadError],
+) {
+    let response = build_json_response(items, stack_errors);
+    emit_streaming_event(
+        streaming,
+        InboxStreamingEvent::Summary {
+            total_items: response.total_items,
+            buckets: response.buckets,
+            stack_errors: response.stack_errors,
+        },
+    );
 }
 
 fn print_human_output(items: &[InboxItem], stack_errors: &[StackLoadError]) {
@@ -539,6 +673,19 @@ fn bucket_label(b: ActionBucket) -> &'static str {
     }
 }
 
+fn action_bucket_str(bucket: ActionBucket) -> &'static str {
+    match bucket {
+        ActionBucket::RefreshFailed => "refresh_failed",
+        ActionBucket::ReadyToLand => "ready_to_land",
+        ActionBucket::ChangesRequested => "changes_requested",
+        ActionBucket::BlockedOnCi => "blocked_on_ci",
+        ActionBucket::AwaitingReview => "awaiting_review",
+        ActionBucket::BehindBase => "behind_base",
+        ActionBucket::Draft => "draft",
+        ActionBucket::Merged => "merged",
+    }
+}
+
 fn styled_bucket_label(b: ActionBucket) -> console::StyledObject<&'static str> {
     let label = bucket_label(b);
     match b {
@@ -553,6 +700,10 @@ fn styled_bucket_label(b: ActionBucket) -> console::StyledObject<&'static str> {
 }
 
 fn print_json_output(items: &[InboxItem], stack_errors: &[StackLoadError]) {
+    print_json(&build_json_response(items, stack_errors));
+}
+
+fn build_json_response(items: &[InboxItem], stack_errors: &[StackLoadError]) -> InboxResponse {
     let mut buckets = InboxBucketsJson {
         refresh_failed: vec![],
         ready_to_land: vec![],
@@ -565,17 +716,7 @@ fn print_json_output(items: &[InboxItem], stack_errors: &[StackLoadError]) {
     };
 
     for item in items {
-        let entry = InboxEntryJson {
-            stack_name: item.stack_name.clone(),
-            position: item.position,
-            sha: item.short_sha.clone(),
-            title: item.title.clone(),
-            pr_number: item.mr_number,
-            pr_url: item.mr_url.clone(),
-            ci_status: item.ci_status.as_ref().map(ci_status_str),
-            behind_base: item.behind_base,
-            refresh_error: item.refresh_error.clone(),
-        };
+        let entry = item.to_json();
 
         match item.bucket() {
             Some(ActionBucket::RefreshFailed) => buckets.refresh_failed.push(entry),
@@ -590,7 +731,7 @@ fn print_json_output(items: &[InboxItem], stack_errors: &[StackLoadError]) {
         }
     }
 
-    print_json(&InboxResponse {
+    InboxResponse {
         version: OUTPUT_VERSION,
         total_items: items.len(),
         buckets,
@@ -601,7 +742,7 @@ fn print_json_output(items: &[InboxItem], stack_errors: &[StackLoadError]) {
                 error: stack_error.error.clone(),
             })
             .collect(),
-    });
+    }
 }
 
 fn ci_status_str(ci: &CiStatus) -> String {
@@ -612,6 +753,15 @@ fn ci_status_str(ci: &CiStatus) -> String {
         CiStatus::Failed => "failed".to_string(),
         CiStatus::Canceled => "canceled".to_string(),
         CiStatus::Unknown => "unknown".to_string(),
+    }
+}
+
+fn pr_state_str(state: &PrState) -> &'static str {
+    match state {
+        PrState::Open => "open",
+        PrState::Merged => "merged",
+        PrState::Closed => "closed",
+        PrState::Draft => "draft",
     }
 }
 

--- a/crates/gg-core/src/commands/inbox/refresh.rs
+++ b/crates/gg-core/src/commands/inbox/refresh.rs
@@ -1,0 +1,247 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::mpsc;
+use std::thread;
+
+use super::InboxCandidate;
+use crate::provider::InboxSnapshot;
+
+pub(super) const MAX_INBOX_REFRESH_WORKERS: usize = 4;
+
+#[derive(Debug)]
+pub(super) struct InboxCompletion {
+    pub candidate: InboxCandidate,
+    pub result: std::result::Result<InboxSnapshot, String>,
+}
+
+pub(super) fn refresh_candidates<F, C>(
+    candidates: &[InboxCandidate],
+    refresh: F,
+    mut on_completion: C,
+) where
+    F: Fn(&InboxCandidate) -> std::result::Result<InboxSnapshot, String> + Sync,
+    C: FnMut(InboxCompletion),
+{
+    let worker_count = candidates.len().min(MAX_INBOX_REFRESH_WORKERS);
+    if worker_count == 0 {
+        return;
+    }
+
+    let next = AtomicUsize::new(0);
+    let (sender, receiver) = mpsc::channel();
+
+    thread::scope(|scope| {
+        for _ in 0..worker_count {
+            let sender = sender.clone();
+            let next = &next;
+            let refresh = &refresh;
+            scope.spawn(move || loop {
+                let index = next.fetch_add(1, Ordering::Relaxed);
+                let Some(candidate) = candidates.get(index).cloned() else {
+                    break;
+                };
+                let result = refresh(&candidate);
+                if sender.send(InboxCompletion { candidate, result }).is_err() {
+                    break;
+                }
+            });
+        }
+
+        drop(sender);
+        for completion in receiver {
+            on_completion(completion);
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Barrier, Condvar, Mutex};
+    use std::thread;
+
+    use super::refresh_candidates;
+    use crate::commands::inbox::InboxCandidate;
+    use crate::provider::{InboxSnapshot, PrState};
+
+    fn candidate(discovery_index: usize) -> InboxCandidate {
+        InboxCandidate {
+            discovery_index,
+            stack_name: "stack".to_string(),
+            position: discovery_index + 1,
+            short_sha: format!("{discovery_index:07x}"),
+            title: format!("Candidate {discovery_index}"),
+            pr_number: discovery_index as u64 + 1,
+            behind_base: None,
+        }
+    }
+
+    fn candidates(count: usize) -> Vec<InboxCandidate> {
+        (0..count).map(candidate).collect()
+    }
+
+    fn snapshot() -> InboxSnapshot {
+        InboxSnapshot {
+            state: PrState::Open,
+            url: "https://example.com/pull/1".to_string(),
+            approved: false,
+            changes_requested: false,
+            mergeable: true,
+            ci_status: None,
+        }
+    }
+
+    #[test]
+    fn refreshes_at_most_four_candidates_at_once() {
+        let active = AtomicUsize::new(0);
+        let maximum = AtomicUsize::new(0);
+        let first_wave = Barrier::new(4);
+        let candidates = candidates(8);
+
+        refresh_candidates(
+            &candidates,
+            |candidate| {
+                let now = active.fetch_add(1, Ordering::SeqCst) + 1;
+                maximum.fetch_max(now, Ordering::SeqCst);
+                if candidate.discovery_index < 4 {
+                    first_wave.wait();
+                }
+                active.fetch_sub(1, Ordering::SeqCst);
+                Ok(snapshot())
+            },
+            |_| {},
+        );
+
+        assert_eq!(maximum.load(Ordering::SeqCst), 4);
+    }
+
+    #[test]
+    fn does_nothing_when_there_are_no_candidates() {
+        let refresh_count = AtomicUsize::new(0);
+        let mut completion_count = 0;
+
+        refresh_candidates(
+            &[],
+            |_| {
+                refresh_count.fetch_add(1, Ordering::SeqCst);
+                Ok(snapshot())
+            },
+            |_| completion_count += 1,
+        );
+
+        assert_eq!(refresh_count.load(Ordering::SeqCst), 0);
+        assert_eq!(completion_count, 0);
+    }
+
+    #[test]
+    fn refreshes_fewer_than_four_candidates_concurrently() {
+        let active = AtomicUsize::new(0);
+        let maximum = AtomicUsize::new(0);
+        let first_wave = Barrier::new(3);
+
+        refresh_candidates(
+            &candidates(3),
+            |_| {
+                let now = active.fetch_add(1, Ordering::SeqCst) + 1;
+                maximum.fetch_max(now, Ordering::SeqCst);
+                first_wave.wait();
+                active.fetch_sub(1, Ordering::SeqCst);
+                Ok(snapshot())
+            },
+            |_| {},
+        );
+
+        assert_eq!(maximum.load(Ordering::SeqCst), 3);
+    }
+
+    #[test]
+    fn refreshes_every_candidate_exactly_once() {
+        let refresh_counts: Vec<AtomicUsize> = (0..8).map(|_| AtomicUsize::new(0)).collect();
+        let mut completed = Vec::new();
+
+        refresh_candidates(
+            &candidates(8),
+            |candidate| {
+                refresh_counts[candidate.discovery_index].fetch_add(1, Ordering::SeqCst);
+                Ok(snapshot())
+            },
+            |completion| completed.push(completion.candidate.discovery_index),
+        );
+
+        completed.sort_unstable();
+        assert_eq!(completed, (0..8).collect::<Vec<_>>());
+        assert!(refresh_counts
+            .iter()
+            .all(|count| count.load(Ordering::SeqCst) == 1));
+    }
+
+    #[test]
+    fn worker_errors_do_not_cancel_later_candidates() {
+        let mut completions = Vec::new();
+
+        refresh_candidates(
+            &candidates(8),
+            |candidate| {
+                if candidate.discovery_index == 0 {
+                    Err("refresh failed".to_string())
+                } else {
+                    Ok(snapshot())
+                }
+            },
+            |completion| {
+                completions.push((
+                    completion.candidate.discovery_index,
+                    completion.result.map(|_| ()),
+                ));
+            },
+        );
+
+        completions.sort_by_key(|(index, _)| *index);
+        assert_eq!(completions.len(), 8);
+        assert_eq!(completions[0], (0, Err("refresh failed".to_string())));
+        assert!(completions[1..].iter().all(|(_, result)| result.is_ok()));
+    }
+
+    #[test]
+    fn reports_fast_later_candidate_before_blocked_first_candidate() {
+        let gate = (Mutex::new(0_u8), Condvar::new());
+        let mut order = Vec::new();
+
+        refresh_candidates(
+            &candidates(2),
+            |candidate| {
+                if candidate.discovery_index == 0 {
+                    let (lock, ready) = &gate;
+                    let released = lock.lock().unwrap();
+                    drop(ready.wait_while(released, |state| *state < 2).unwrap());
+                } else {
+                    *gate.0.lock().unwrap() = 1;
+                }
+                Ok(snapshot())
+            },
+            |completion| {
+                let index = completion.candidate.discovery_index;
+                order.push(index);
+                if index == 1 {
+                    *gate.0.lock().unwrap() = 2;
+                    gate.1.notify_one();
+                }
+            },
+        );
+
+        assert_eq!(order, vec![1, 0]);
+    }
+
+    #[test]
+    fn runs_completion_callbacks_on_the_coordinator_thread() {
+        let coordinator = thread::current().id();
+        let mut callback_threads = Vec::new();
+
+        refresh_candidates(
+            &candidates(8),
+            |_| Ok(snapshot()),
+            |_| callback_threads.push(thread::current().id()),
+        );
+
+        assert_eq!(callback_threads, vec![coordinator; 8]);
+    }
+}

--- a/crates/gg-core/src/commands/inbox/refresh.rs
+++ b/crates/gg-core/src/commands/inbox/refresh.rs
@@ -13,13 +13,23 @@ pub(super) struct InboxCompletion {
     pub result: std::result::Result<InboxSnapshot, String>,
 }
 
-pub(super) fn refresh_candidates<F, C>(
+pub(super) fn refresh_candidates<F, C>(candidates: &[InboxCandidate], refresh: F, on_completion: C)
+where
+    F: Fn(&InboxCandidate) -> std::result::Result<InboxSnapshot, String> + Sync,
+    C: FnMut(InboxCompletion),
+{
+    refresh_candidates_with_worker_count_observer(candidates, refresh, on_completion, |_| {});
+}
+
+fn refresh_candidates_with_worker_count_observer<F, C, O>(
     candidates: &[InboxCandidate],
     refresh: F,
     mut on_completion: C,
+    on_workers_spawned: O,
 ) where
     F: Fn(&InboxCandidate) -> std::result::Result<InboxSnapshot, String> + Sync,
     C: FnMut(InboxCompletion),
+    O: FnOnce(usize),
 {
     let worker_count = candidates.len().min(MAX_INBOX_REFRESH_WORKERS);
     if worker_count == 0 {
@@ -46,6 +56,7 @@ pub(super) fn refresh_candidates<F, C>(
             });
         }
 
+        on_workers_spawned(worker_count);
         drop(sender);
         for completion in receiver {
             on_completion(completion);
@@ -59,7 +70,7 @@ mod tests {
     use std::sync::{Barrier, Condvar, Mutex};
     use std::thread;
 
-    use super::refresh_candidates;
+    use super::{refresh_candidates, refresh_candidates_with_worker_count_observer};
     use crate::commands::inbox::InboxCandidate;
     use crate::provider::{InboxSnapshot, PrState};
 
@@ -90,25 +101,48 @@ mod tests {
         }
     }
 
+    #[derive(Default)]
+    struct FirstWave {
+        expected: Option<usize>,
+        entered: usize,
+        released: bool,
+    }
+
     #[test]
     fn refreshes_at_most_four_candidates_at_once() {
         let active = AtomicUsize::new(0);
         let maximum = AtomicUsize::new(0);
-        let first_wave = Barrier::new(4);
+        let first_wave = (Mutex::new(FirstWave::default()), Condvar::new());
         let candidates = candidates(8);
 
-        refresh_candidates(
+        refresh_candidates_with_worker_count_observer(
             &candidates,
-            |candidate| {
+            |_| {
                 let now = active.fetch_add(1, Ordering::SeqCst) + 1;
                 maximum.fetch_max(now, Ordering::SeqCst);
-                if candidate.discovery_index < 4 {
-                    first_wave.wait();
+
+                let (lock, ready) = &first_wave;
+                let mut wave = lock.lock().unwrap();
+                wave.entered += 1;
+                if wave.expected == Some(wave.entered) {
+                    wave.released = true;
+                    ready.notify_all();
                 }
+                drop(ready.wait_while(wave, |wave| !wave.released).unwrap());
+
                 active.fetch_sub(1, Ordering::SeqCst);
                 Ok(snapshot())
             },
             |_| {},
+            |worker_count| {
+                let (lock, ready) = &first_wave;
+                let mut wave = lock.lock().unwrap();
+                wave.expected = Some(worker_count);
+                if wave.entered == worker_count {
+                    wave.released = true;
+                }
+                ready.notify_all();
+            },
         );
 
         assert_eq!(maximum.load(Ordering::SeqCst), 4);

--- a/crates/gg-core/src/commands/inbox/render.rs
+++ b/crates/gg-core/src/commands/inbox/render.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
 
-use super::{bucket_label, ActionBucket, InboxCandidate};
+use super::{bucket_label, sanitize_human_diagnostic, ActionBucket, InboxCandidate};
 
 pub(super) enum InboxRowState<'a> {
     Refreshing,
@@ -134,7 +134,10 @@ fn format_row_message(
         InboxRowState::RefreshFailed(error) => {
             format!(
                 "refresh failed: {}",
-                error.split_whitespace().collect::<Vec<_>>().join(" ")
+                sanitize_human_diagnostic(error)
+                    .split_whitespace()
+                    .collect::<Vec<_>>()
+                    .join(" ")
             )
         }
     };
@@ -324,6 +327,19 @@ mod tests {
                 expected_message
             );
         }
+    }
+
+    #[test]
+    fn refresh_failure_row_neutralizes_terminal_control_characters() {
+        let candidate = candidate(0, "alpha", "aaaaaaa", "First candidate");
+        let message = format_row_message(
+            &candidate,
+            "PR",
+            InboxRowState::RefreshFailed("failure: \u{1b}[31mred\u{7}"),
+        );
+
+        assert!(!message.chars().any(char::is_control));
+        assert!(message.contains("refresh failed: failure: [31mred"));
     }
 
     #[test]

--- a/crates/gg-core/src/commands/inbox/render.rs
+++ b/crates/gg-core/src/commands/inbox/render.rs
@@ -1,0 +1,419 @@
+use std::io::{self, IsTerminal};
+use std::time::Duration;
+
+use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
+
+use super::{bucket_label, ActionBucket, InboxCandidate};
+
+pub(super) enum InboxRowState<'a> {
+    Refreshing,
+    Bucket(ActionBucket),
+    MergedHidden,
+    ClosedHidden,
+    RefreshFailed(&'a str),
+}
+
+pub(super) struct LiveInboxRenderer {
+    multi_progress: MultiProgress,
+    rows: Vec<ProgressBar>,
+    candidates: Vec<InboxCandidate>,
+    provider_label: String,
+    counter: ProgressBar,
+    completed: usize,
+    cleared: bool,
+}
+
+impl LiveInboxRenderer {
+    pub fn stderr_if_interactive(
+        candidates: &[InboxCandidate],
+        provider_label: &str,
+    ) -> Option<Self> {
+        live_rendering_enabled(io::stdout().is_terminal(), io::stderr().is_terminal()).then(|| {
+            Self::with_draw_target(candidates, provider_label, ProgressDrawTarget::stderr())
+        })
+    }
+
+    fn with_draw_target(
+        candidates: &[InboxCandidate],
+        provider_label: &str,
+        draw_target: ProgressDrawTarget,
+    ) -> Self {
+        let multi_progress = MultiProgress::with_draw_target(draw_target);
+        let row_style =
+            ProgressStyle::with_template("{spinner:.green} {msg}").expect("valid inbox row style");
+        let mut rows = Vec::with_capacity(candidates.len());
+
+        for candidate in candidates {
+            let row = ProgressBar::new_spinner();
+            row.set_style(row_style.clone());
+            let row = multi_progress.add(row);
+            row.set_message(format_row_message(
+                candidate,
+                provider_label,
+                InboxRowState::Refreshing,
+            ));
+            row.enable_steady_tick(Duration::from_millis(100));
+            rows.push(row);
+        }
+
+        let counter = ProgressBar::new_spinner();
+        counter
+            .set_style(ProgressStyle::with_template("{msg}").expect("valid inbox counter style"));
+        let counter = multi_progress.add(counter);
+        counter.set_message(format!("refreshed 0/{}", candidates.len()));
+
+        Self {
+            multi_progress,
+            rows,
+            candidates: candidates.to_vec(),
+            provider_label: provider_label.to_string(),
+            counter,
+            completed: 0,
+            cleared: false,
+        }
+    }
+
+    pub fn update(&mut self, discovery_index: usize, state: InboxRowState<'_>) {
+        let Some((candidate, row)) = self
+            .candidates
+            .get(discovery_index)
+            .zip(self.rows.get(discovery_index))
+        else {
+            return;
+        };
+
+        row.finish_with_message(format_row_message(candidate, &self.provider_label, state));
+        self.completed += 1;
+        self.counter.set_message(format!(
+            "refreshed {}/{}",
+            self.completed,
+            self.candidates.len()
+        ));
+    }
+
+    pub fn finish_and_clear(&mut self) {
+        self.clear();
+    }
+
+    fn clear(&mut self) {
+        if self.cleared {
+            return;
+        }
+
+        for row in &self.rows {
+            row.disable_steady_tick();
+        }
+        let _ = self.multi_progress.clear();
+        self.multi_progress
+            .set_draw_target(ProgressDrawTarget::hidden());
+        self.cleared = true;
+    }
+}
+
+impl Drop for LiveInboxRenderer {
+    fn drop(&mut self) {
+        self.clear();
+    }
+}
+
+pub(super) fn live_rendering_enabled(stdout_is_terminal: bool, stderr_is_terminal: bool) -> bool {
+    stdout_is_terminal && stderr_is_terminal
+}
+
+fn format_row_message(
+    candidate: &InboxCandidate,
+    provider_label: &str,
+    state: InboxRowState<'_>,
+) -> String {
+    let number_prefix = if provider_label == "MR" { "!" } else { "#" };
+    let status = match state {
+        InboxRowState::Refreshing => "refreshing".to_string(),
+        InboxRowState::Bucket(bucket) => bucket_label(bucket).to_string(),
+        InboxRowState::MergedHidden => "merged (hidden; use --all)".to_string(),
+        InboxRowState::ClosedHidden => "closed (hidden)".to_string(),
+        InboxRowState::RefreshFailed(error) => {
+            format!(
+                "refresh failed: {}",
+                error.split_whitespace().collect::<Vec<_>>().join(" ")
+            )
+        }
+    };
+
+    format!(
+        "{} #{}  {}  {}  {} {}{} — {}",
+        candidate.stack_name,
+        candidate.position,
+        candidate.short_sha,
+        candidate.title,
+        provider_label,
+        number_prefix,
+        candidate.pr_number,
+        status
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+    use std::sync::{Arc, Mutex};
+
+    use indicatif::{ProgressDrawTarget, TermLike};
+
+    use super::{format_row_message, live_rendering_enabled, InboxRowState, LiveInboxRenderer};
+    use crate::commands::inbox::{ActionBucket, InboxCandidate};
+
+    const CLEAR: &str = "<clear>";
+    const FLUSH: &str = "<flush>";
+
+    #[derive(Debug)]
+    struct RecordingTerm {
+        operations: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl RecordingTerm {
+        fn record(&self, operation: impl Into<String>) {
+            self.operations.lock().unwrap().push(operation.into());
+        }
+    }
+
+    impl TermLike for RecordingTerm {
+        fn width(&self) -> u16 {
+            160
+        }
+
+        fn height(&self) -> u16 {
+            20
+        }
+
+        fn move_cursor_up(&self, _n: usize) -> io::Result<()> {
+            Ok(())
+        }
+
+        fn move_cursor_down(&self, _n: usize) -> io::Result<()> {
+            Ok(())
+        }
+
+        fn move_cursor_right(&self, _n: usize) -> io::Result<()> {
+            Ok(())
+        }
+
+        fn move_cursor_left(&self, _n: usize) -> io::Result<()> {
+            Ok(())
+        }
+
+        fn write_line(&self, line: &str) -> io::Result<()> {
+            self.record(format!("{line}\n"));
+            Ok(())
+        }
+
+        fn write_str(&self, value: &str) -> io::Result<()> {
+            self.record(value);
+            Ok(())
+        }
+
+        fn clear_line(&self) -> io::Result<()> {
+            self.record(CLEAR);
+            Ok(())
+        }
+
+        fn flush(&self) -> io::Result<()> {
+            self.record(FLUSH);
+            Ok(())
+        }
+    }
+
+    fn candidate(
+        discovery_index: usize,
+        stack_name: &str,
+        short_sha: &str,
+        title: &str,
+    ) -> InboxCandidate {
+        InboxCandidate {
+            discovery_index,
+            stack_name: stack_name.to_string(),
+            position: discovery_index + 1,
+            short_sha: short_sha.to_string(),
+            title: title.to_string(),
+            pr_number: discovery_index as u64 + 10,
+            behind_base: None,
+        }
+    }
+
+    fn rendered_frames(operations: &[String]) -> Vec<String> {
+        let mut frames = Vec::new();
+        let mut frame = String::new();
+
+        for operation in operations {
+            match operation.as_str() {
+                FLUSH => {
+                    frames.push(std::mem::take(&mut frame));
+                }
+                CLEAR => {}
+                written => frame.push_str(written),
+            }
+        }
+
+        frames
+    }
+
+    #[test]
+    fn live_rendering_requires_both_output_streams_to_be_terminals() {
+        assert!(live_rendering_enabled(true, true));
+        assert!(!live_rendering_enabled(true, false));
+        assert!(!live_rendering_enabled(false, true));
+        assert!(!live_rendering_enabled(false, false));
+    }
+
+    #[test]
+    fn row_messages_keep_candidate_identity_and_describe_every_state() {
+        let candidate = candidate(0, "alpha", "aaaaaaa", "First candidate");
+        let expected = [
+            (
+                InboxRowState::Refreshing,
+                "alpha #1  aaaaaaa  First candidate  PR #10 — refreshing",
+            ),
+            (
+                InboxRowState::Bucket(ActionBucket::RefreshFailed),
+                "alpha #1  aaaaaaa  First candidate  PR #10 — Refresh failed",
+            ),
+            (
+                InboxRowState::Bucket(ActionBucket::ReadyToLand),
+                "alpha #1  aaaaaaa  First candidate  PR #10 — Ready to land",
+            ),
+            (
+                InboxRowState::Bucket(ActionBucket::ChangesRequested),
+                "alpha #1  aaaaaaa  First candidate  PR #10 — Changes requested",
+            ),
+            (
+                InboxRowState::Bucket(ActionBucket::BlockedOnCi),
+                "alpha #1  aaaaaaa  First candidate  PR #10 — Blocked on CI",
+            ),
+            (
+                InboxRowState::Bucket(ActionBucket::AwaitingReview),
+                "alpha #1  aaaaaaa  First candidate  PR #10 — Awaiting review",
+            ),
+            (
+                InboxRowState::Bucket(ActionBucket::BehindBase),
+                "alpha #1  aaaaaaa  First candidate  PR #10 — Behind base",
+            ),
+            (
+                InboxRowState::Bucket(ActionBucket::Draft),
+                "alpha #1  aaaaaaa  First candidate  PR #10 — Draft",
+            ),
+            (
+                InboxRowState::Bucket(ActionBucket::Merged),
+                "alpha #1  aaaaaaa  First candidate  PR #10 — Merged",
+            ),
+            (
+                InboxRowState::MergedHidden,
+                "alpha #1  aaaaaaa  First candidate  PR #10 — merged (hidden; use --all)",
+            ),
+            (
+                InboxRowState::ClosedHidden,
+                "alpha #1  aaaaaaa  First candidate  PR #10 — closed (hidden)",
+            ),
+            (
+                InboxRowState::RefreshFailed("timed out"),
+                "alpha #1  aaaaaaa  First candidate  PR #10 — refresh failed: timed out",
+            ),
+        ];
+
+        for (state, expected_message) in expected {
+            assert_eq!(
+                format_row_message(&candidate, "PR", state),
+                expected_message
+            );
+        }
+    }
+
+    #[test]
+    fn completing_one_row_preserves_stable_rows_and_advances_counter() {
+        let candidates = [
+            candidate(0, "alpha", "aaaaaaa", "First candidate"),
+            candidate(1, "beta", "bbbbbbb", "Second candidate"),
+            candidate(2, "gamma", "ccccccc", "Third candidate"),
+        ];
+        let operations = Arc::new(Mutex::new(Vec::new()));
+        let draw_target = ProgressDrawTarget::term_like(Box::new(RecordingTerm {
+            operations: operations.clone(),
+        }));
+        let mut renderer = LiveInboxRenderer::with_draw_target(&candidates, "PR", draw_target);
+
+        let initial_operations = operations.lock().unwrap().clone();
+        let initial_frame = rendered_frames(&initial_operations)
+            .into_iter()
+            .find(|frame| {
+                frame.contains("alpha #1  aaaaaaa  First candidate  PR #10 — refreshing")
+                    && frame.contains("beta #2  bbbbbbb  Second candidate  PR #11 — refreshing")
+                    && frame.contains("gamma #3  ccccccc  Third candidate  PR #12 — refreshing")
+                    && frame.contains("refreshed 0/3")
+            })
+            .expect("the initial display should render every stable row and the counter");
+
+        let alpha_initial = initial_frame.find("alpha #1").unwrap();
+        let beta_initial = initial_frame.find("beta #2").unwrap();
+        let gamma_initial = initial_frame.find("gamma #3").unwrap();
+        assert!(alpha_initial < beta_initial && beta_initial < gamma_initial);
+
+        let update_start = initial_operations.len();
+        renderer.update(1, InboxRowState::Bucket(ActionBucket::ReadyToLand));
+
+        let updated_operations = operations.lock().unwrap().clone();
+        let updated_frame = rendered_frames(&updated_operations[update_start..])
+            .into_iter()
+            .find(|frame| {
+                frame.contains("alpha #1  aaaaaaa  First candidate  PR #10 — refreshing")
+                    && frame.contains("beta #2  bbbbbbb  Second candidate  PR #11 — Ready to land")
+                    && frame.contains("gamma #3  ccccccc  Third candidate  PR #12 — refreshing")
+                    && frame.contains("refreshed 1/3")
+            })
+            .expect("updating one completion should redraw all stable rows and the counter");
+
+        let alpha_updated = updated_frame.find("alpha #1").unwrap();
+        let beta_updated = updated_frame.find("beta #2").unwrap();
+        let gamma_updated = updated_frame.find("gamma #3").unwrap();
+        assert!(alpha_updated < beta_updated && beta_updated < gamma_updated);
+
+        renderer.finish_and_clear();
+        drop(renderer);
+
+        let final_operations = operations.lock().unwrap().clone();
+        assert!(
+            final_operations.iter().any(|operation| operation == CLEAR),
+            "finishing the renderer should clear its temporary terminal rows"
+        );
+        assert!(
+            rendered_frames(&final_operations)
+                .last()
+                .is_some_and(|frame| frame.trim().is_empty()),
+            "dropping a cleared renderer must not redraw stale terminal rows"
+        );
+    }
+
+    #[test]
+    fn dropping_an_active_renderer_clears_temporary_rows() {
+        let candidates = [candidate(0, "alpha", "aaaaaaa", "First candidate")];
+        let operations = Arc::new(Mutex::new(Vec::new()));
+        let draw_target = ProgressDrawTarget::term_like(Box::new(RecordingTerm {
+            operations: operations.clone(),
+        }));
+        let renderer = LiveInboxRenderer::with_draw_target(&candidates, "PR", draw_target);
+
+        drop(renderer);
+
+        let final_operations = operations.lock().unwrap().clone();
+        assert!(final_operations.iter().any(|operation| operation == CLEAR));
+        assert!(
+            !rendered_frames(&final_operations)
+                .iter()
+                .any(|frame| { frame.contains("refreshed 0/1") && !frame.contains("alpha #1") }),
+            "cleanup must not transiently redraw the aggregate without its stable row"
+        );
+        assert!(
+            rendered_frames(&final_operations)
+                .last()
+                .is_some_and(|frame| frame.trim().is_empty()),
+            "Drop must leave no live row behind after a fatal command exit"
+        );
+    }
+}

--- a/crates/gg-core/src/commands/inbox/render.rs
+++ b/crates/gg-core/src/commands/inbox/render.rs
@@ -126,6 +126,10 @@ fn format_row_message(
     state: InboxRowState<'_>,
 ) -> String {
     let number_prefix = if provider_label == "MR" { "!" } else { "#" };
+    let title = sanitize_human_diagnostic(&candidate.title)
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
     let status = match state {
         InboxRowState::Refreshing => "refreshing".to_string(),
         InboxRowState::Bucket(bucket) => bucket_label(bucket).to_string(),
@@ -147,7 +151,7 @@ fn format_row_message(
         candidate.stack_name,
         candidate.position,
         candidate.short_sha,
-        candidate.title,
+        title,
         provider_label,
         number_prefix,
         candidate.pr_number,
@@ -340,6 +344,15 @@ mod tests {
 
         assert!(!message.chars().any(char::is_control));
         assert!(message.contains("refresh failed: failure: [31mred"));
+    }
+
+    #[test]
+    fn row_messages_neutralize_terminal_control_characters_in_titles() {
+        let candidate = candidate(0, "alpha", "aaaaaaa", "Apply \u{1b}[2Jupdate\r\nnow");
+        let message = format_row_message(&candidate, "PR", InboxRowState::Refreshing);
+
+        assert!(!message.chars().any(char::is_control));
+        assert!(message.contains("Apply [2Jupdate now"));
     }
 
     #[test]

--- a/crates/gg-core/src/gh.rs
+++ b/crates/gg-core/src/gh.rs
@@ -336,7 +336,7 @@ fn aggregate_status_checks(checks: &[GhStatusCheck]) -> Option<CiStatus> {
                 "FAILURE" | "FAILED" | "TIMED_OUT" | "ACTION_REQUIRED" | "ERROR"
                 | "STARTUP_FAILURE" => return Some(CiStatus::Failed),
                 "CANCELLED" | "CANCELED" => has_canceled = true,
-                "PENDING" | "QUEUED" | "IN_PROGRESS" => has_pending = true,
+                "EXPECTED" | "PENDING" | "QUEUED" | "IN_PROGRESS" => has_pending = true,
                 "SUCCESS" | "NEUTRAL" | "SKIPPED" => has_success = true,
                 _ => {}
             }
@@ -935,6 +935,7 @@ mod tests {
                 r#"[{"status":"IN_PROGRESS","conclusion":null}]"#,
                 CiStatus::Pending,
             ),
+            (r#"[{"state":"EXPECTED"}]"#, CiStatus::Pending),
             (
                 r#"[{"status":"COMPLETED","state":"ERROR"}]"#,
                 CiStatus::Failed,

--- a/crates/gg-core/src/gh.rs
+++ b/crates/gg-core/src/gh.rs
@@ -333,9 +333,8 @@ fn aggregate_status_checks(checks: &[GhStatusCheck]) -> Option<CiStatus> {
             .flatten()
         {
             match value {
-                "FAILURE" | "FAILED" | "TIMED_OUT" | "ACTION_REQUIRED" => {
-                    return Some(CiStatus::Failed)
-                }
+                "FAILURE" | "FAILED" | "TIMED_OUT" | "ACTION_REQUIRED" | "ERROR"
+                | "STARTUP_FAILURE" => return Some(CiStatus::Failed),
                 "CANCELLED" | "CANCELED" => has_canceled = true,
                 "PENDING" | "QUEUED" | "IN_PROGRESS" => has_pending = true,
                 "SUCCESS" | "NEUTRAL" | "SKIPPED" => has_success = true,
@@ -935,6 +934,14 @@ mod tests {
             (
                 r#"[{"status":"IN_PROGRESS","conclusion":null}]"#,
                 CiStatus::Pending,
+            ),
+            (
+                r#"[{"status":"COMPLETED","state":"ERROR"}]"#,
+                CiStatus::Failed,
+            ),
+            (
+                r#"[{"status":"COMPLETED","conclusion":"STARTUP_FAILURE"}]"#,
+                CiStatus::Failed,
             ),
             (
                 r#"[{"status":"COMPLETED","conclusion":"STALE"}]"#,

--- a/crates/gg-core/src/gh.rs
+++ b/crates/gg-core/src/gh.rs
@@ -307,7 +307,7 @@ fn parse_inbox_snapshot(bytes: &[u8]) -> Result<InboxPrSnapshot> {
     Ok(InboxPrSnapshot {
         state,
         url: pr_json.url,
-        approved: pr_json.review_decision.as_deref() == Some("APPROVED"),
+        approved: matches!(pr_json.review_decision.as_deref(), Some("APPROVED") | None),
         changes_requested: pr_json.review_decision.as_deref() == Some("CHANGES_REQUESTED"),
         mergeable: pr_json.mergeable.as_deref() == Some("MERGEABLE"),
         ci_status: aggregate_status_checks(&pr_json.status_check_rollup),
@@ -901,6 +901,24 @@ mod tests {
         let snapshot = parse_inbox_snapshot(json).unwrap();
         assert!(snapshot.changes_requested);
         assert_eq!(snapshot.ci_status, None);
+    }
+
+    #[test]
+    fn inbox_snapshot_treats_null_review_decision_as_no_review_required() {
+        let json = br#"{
+            "number": 44,
+            "title": "No required reviews",
+            "state": "OPEN",
+            "url": "https://github.com/acme/app/pull/44",
+            "isDraft": false,
+            "mergeable": "MERGEABLE",
+            "reviewDecision": null,
+            "statusCheckRollup": []
+        }"#;
+
+        let snapshot = parse_inbox_snapshot(json).unwrap();
+        assert!(snapshot.approved);
+        assert!(!snapshot.changes_requested);
     }
 
     #[test]

--- a/crates/gg-core/src/gh.rs
+++ b/crates/gg-core/src/gh.rs
@@ -32,6 +32,17 @@ pub struct PrInfo {
     pub changes_requested: bool,
 }
 
+/// The fields needed to display a PR in the review inbox.
+#[derive(Debug, Clone)]
+pub struct InboxPrSnapshot {
+    pub state: PrState,
+    pub url: String,
+    pub approved: bool,
+    pub changes_requested: bool,
+    pub mergeable: bool,
+    pub ci_status: Option<CiStatus>,
+}
+
 /// JSON response from `gh pr view --json`
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -48,12 +59,22 @@ struct GhPrJson {
     #[serde(default)]
     reviews: Vec<GhReview>,
     review_decision: Option<String>,
+    #[serde(default)]
+    status_check_rollup: Vec<GhStatusCheck>,
 }
 
 #[derive(Debug, Deserialize)]
 #[allow(dead_code)]
 struct GhReview {
     state: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GhStatusCheck {
+    conclusion: Option<String>,
+    status: Option<String>,
+    state: Option<String>,
 }
 
 /// Check if gh is installed
@@ -247,6 +268,101 @@ pub fn close_pr(pr_number: u64) -> Result<()> {
 /// Alias for view_pr for compatibility
 pub fn get_pr_info(pr_number: u64) -> Result<PrInfo> {
     view_pr(pr_number)
+}
+
+/// Get all inbox fields for a PR with one `gh pr view` request.
+pub fn get_inbox_snapshot(pr_number: u64) -> Result<InboxPrSnapshot> {
+    let output = Command::new("gh")
+        .args([
+            "pr",
+            "view",
+            &pr_number.to_string(),
+            "--json",
+            "number,title,state,url,headRefName,isDraft,mergeable,reviewDecision,statusCheckRollup",
+        ])
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(GgError::Other(format!(
+            "Failed to view PR #{}: {}",
+            pr_number, stderr
+        )));
+    }
+
+    parse_inbox_snapshot(&output.stdout)
+}
+
+fn parse_inbox_snapshot(bytes: &[u8]) -> Result<InboxPrSnapshot> {
+    let pr_json: GhPrJson = serde_json::from_slice(bytes)
+        .map_err(|e| GgError::Other(format!("Failed to parse PR JSON: {}", e)))?;
+
+    let state = match pr_json.state.to_uppercase().as_str() {
+        "MERGED" => PrState::Merged,
+        "CLOSED" => PrState::Closed,
+        _ if pr_json.is_draft => PrState::Draft,
+        _ => PrState::Open,
+    };
+
+    Ok(InboxPrSnapshot {
+        state,
+        url: pr_json.url,
+        approved: pr_json.review_decision.as_deref() == Some("APPROVED"),
+        changes_requested: pr_json.review_decision.as_deref() == Some("CHANGES_REQUESTED"),
+        mergeable: pr_json.mergeable.as_deref() == Some("MERGEABLE"),
+        ci_status: aggregate_status_checks(&pr_json.status_check_rollup),
+    })
+}
+
+fn aggregate_status_checks(checks: &[GhStatusCheck]) -> Option<CiStatus> {
+    if checks.is_empty() {
+        return None;
+    }
+
+    let mut has_canceled = false;
+    let mut has_pending = false;
+    let mut has_success = false;
+
+    for check in checks {
+        let conclusion = check.conclusion.as_deref().map(str::to_uppercase);
+        let status = check.status.as_deref().map(str::to_uppercase);
+        let state = check.state.as_deref().map(str::to_uppercase);
+
+        for value in [conclusion.as_deref(), state.as_deref()]
+            .into_iter()
+            .flatten()
+        {
+            match value {
+                "FAILURE" | "FAILED" | "TIMED_OUT" | "ACTION_REQUIRED" => {
+                    return Some(CiStatus::Failed)
+                }
+                "CANCELLED" | "CANCELED" => has_canceled = true,
+                "PENDING" | "QUEUED" | "IN_PROGRESS" => has_pending = true,
+                "SUCCESS" | "NEUTRAL" | "SKIPPED" => has_success = true,
+                _ => {}
+            }
+        }
+
+        if status.as_deref().is_some_and(|value| value != "COMPLETED")
+            || (check.state.is_none()
+                && check
+                    .conclusion
+                    .as_deref()
+                    .is_none_or(|value| value.trim().is_empty()))
+        {
+            has_pending = true;
+        }
+    }
+
+    if has_canceled {
+        Some(CiStatus::Canceled)
+    } else if has_pending {
+        Some(CiStatus::Pending)
+    } else if has_success {
+        Some(CiStatus::Success)
+    } else {
+        Some(CiStatus::Unknown)
+    }
 }
 
 /// Convert an existing PR to draft (GitHub only)
@@ -743,6 +859,88 @@ mod tests {
         assert!(!parsed.is_draft); // defaults to false
         assert!(parsed.mergeable.is_none());
         assert!(parsed.reviews.is_empty()); // defaults to empty
+    }
+
+    #[test]
+    fn inbox_snapshot_parses_review_and_ci_from_one_response() {
+        let json = br#"{
+            "number": 42,
+            "title": "Add login",
+            "state": "OPEN",
+            "url": "https://github.com/acme/app/pull/42",
+            "headRefName": "nacho/auth/c-abc1234",
+            "isDraft": false,
+            "mergeable": "MERGEABLE",
+            "reviewDecision": "APPROVED",
+            "statusCheckRollup": [
+                {"status": "COMPLETED", "conclusion": "SUCCESS"}
+            ]
+        }"#;
+
+        let snapshot = parse_inbox_snapshot(json).unwrap();
+        assert_eq!(snapshot.state, PrState::Open);
+        assert!(snapshot.approved);
+        assert!(!snapshot.changes_requested);
+        assert!(snapshot.mergeable);
+        assert_eq!(snapshot.ci_status, Some(CiStatus::Success));
+    }
+
+    #[test]
+    fn inbox_snapshot_treats_empty_rollup_as_no_ci() {
+        let json = br#"{
+            "number": 43,
+            "title": "No checks",
+            "state": "OPEN",
+            "url": "https://github.com/acme/app/pull/43",
+            "isDraft": false,
+            "mergeable": "MERGEABLE",
+            "reviewDecision": "CHANGES_REQUESTED",
+            "statusCheckRollup": []
+        }"#;
+
+        let snapshot = parse_inbox_snapshot(json).unwrap();
+        assert!(snapshot.changes_requested);
+        assert_eq!(snapshot.ci_status, None);
+    }
+
+    #[test]
+    fn inbox_snapshot_aggregates_rollup_statuses_by_priority() {
+        let cases = [
+            (
+                r#"[{"status":"COMPLETED","conclusion":"SUCCESS"},{"status":"COMPLETED","conclusion":"FAILURE"}]"#,
+                CiStatus::Failed,
+            ),
+            (
+                r#"[{"status":"COMPLETED","conclusion":"SUCCESS"},{"status":"COMPLETED","conclusion":"CANCELLED"}]"#,
+                CiStatus::Canceled,
+            ),
+            (
+                r#"[{"status":"IN_PROGRESS","conclusion":null}]"#,
+                CiStatus::Pending,
+            ),
+            (
+                r#"[{"status":"COMPLETED","conclusion":"STALE"}]"#,
+                CiStatus::Unknown,
+            ),
+        ];
+
+        for (rollup, expected) in cases {
+            let json = format!(
+                r#"{{
+                    "number": 44,
+                    "title": "Checks",
+                    "state": "OPEN",
+                    "url": "https://github.com/acme/app/pull/44",
+                    "isDraft": false,
+                    "mergeable": "MERGEABLE",
+                    "statusCheckRollup": {}
+                }}"#,
+                rollup
+            );
+
+            let snapshot = parse_inbox_snapshot(json.as_bytes()).unwrap();
+            assert_eq!(snapshot.ci_status, Some(expected));
+        }
     }
 
     #[test]

--- a/crates/gg-core/src/gh.rs
+++ b/crates/gg-core/src/gh.rs
@@ -333,7 +333,7 @@ fn aggregate_status_checks(checks: &[GhStatusCheck]) -> Option<CiStatus> {
             .flatten()
         {
             match value {
-                "FAILURE" | "FAILED" | "TIMED_OUT" | "ACTION_REQUIRED" | "ERROR"
+                "FAILURE" | "FAILED" | "TIMED_OUT" | "ACTION_REQUIRED" | "ERROR" | "STALE"
                 | "STARTUP_FAILURE" => return Some(CiStatus::Failed),
                 "CANCELLED" | "CANCELED" => has_canceled = true,
                 "EXPECTED" | "PENDING" | "QUEUED" | "IN_PROGRESS" => has_pending = true,
@@ -946,7 +946,7 @@ mod tests {
             ),
             (
                 r#"[{"status":"COMPLETED","conclusion":"STALE"}]"#,
-                CiStatus::Unknown,
+                CiStatus::Failed,
             ),
         ];
 

--- a/crates/gg-core/src/glab.rs
+++ b/crates/gg-core/src/glab.rs
@@ -36,6 +36,16 @@ pub struct MrInfo {
     pub detailed_merge_status: Option<String>,
 }
 
+/// The fields needed to display an MR in the review inbox.
+#[derive(Debug, Clone)]
+pub struct InboxMrDetails {
+    pub state: MrState,
+    pub web_url: String,
+    pub mergeable: bool,
+    pub changes_requested: bool,
+    pub ci_status: Option<CiStatus>,
+}
+
 /// JSON response from `glab mr view --json`
 #[derive(Debug, Deserialize)]
 struct GlabMrJson {
@@ -47,6 +57,12 @@ struct GlabMrJson {
     draft: Option<bool>,
     work_in_progress: Option<bool>,
     detailed_merge_status: Option<String>,
+    head_pipeline: Option<GlabPipelineJson>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GlabPipelineJson {
+    status: Option<String>,
 }
 
 /// Check if glab is installed
@@ -376,6 +392,64 @@ pub fn get_mr_info(mr_number: u64) -> Result<MrInfo> {
     view_mr(mr_number)
 }
 
+/// Get all inbox fields for an MR with one `glab mr view` request.
+///
+/// Approval is queried separately because GitLab exposes it from its approvals endpoint.
+pub fn get_inbox_snapshot(mr_number: u64) -> Result<(InboxMrDetails, bool)> {
+    let output = Command::new("glab")
+        .args(["mr", "view", &mr_number.to_string(), "--output", "json"])
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(GgError::GlabError(format!(
+            "Failed to view MR !{}: {}",
+            mr_number, stderr
+        )));
+    }
+
+    let details = parse_inbox_mr_details(&output.stdout)?;
+    let approved = check_mr_approved_strict(mr_number)?;
+    Ok((details, approved))
+}
+
+fn parse_inbox_mr_details(bytes: &[u8]) -> Result<InboxMrDetails> {
+    let mr_json: GlabMrJson = serde_json::from_slice(bytes)
+        .map_err(|e| GgError::GlabError(format!("Failed to parse MR JSON: {}", e)))?;
+
+    let draft = mr_json.draft.unwrap_or(false) || mr_json.work_in_progress.unwrap_or(false);
+    let state = match mr_json.state.as_str() {
+        "merged" => MrState::Merged,
+        "closed" => MrState::Closed,
+        _ if draft => MrState::Draft,
+        _ => MrState::Open,
+    };
+
+    let ci_status = mr_json.head_pipeline.map(|pipeline| {
+        match pipeline
+            .status
+            .as_deref()
+            .map(str::to_ascii_lowercase)
+            .as_deref()
+        {
+            Some("success") => CiStatus::Success,
+            Some("failed") => CiStatus::Failed,
+            Some("pending") => CiStatus::Pending,
+            Some("running") => CiStatus::Running,
+            Some("canceled") | Some("cancelled") => CiStatus::Canceled,
+            _ => CiStatus::Unknown,
+        }
+    });
+
+    Ok(InboxMrDetails {
+        state: state.clone(),
+        web_url: mr_json.web_url,
+        mergeable: state == MrState::Open && !draft,
+        changes_requested: false,
+        ci_status,
+    })
+}
+
 /// Update MR target branch
 pub fn update_mr_target(mr_number: u64, target_branch: &str) -> Result<()> {
     let output = Command::new("glab")
@@ -544,6 +618,14 @@ pub fn auto_merge_mr_when_pipeline_succeeds(
 
 /// Check approvals for an MR
 pub fn check_mr_approved(mr_number: u64) -> Result<bool> {
+    match check_mr_approved_strict(mr_number) {
+        Ok(approved) => Ok(approved),
+        Err(GgError::GlabError(_)) => Ok(false),
+        Err(error) => Err(error),
+    }
+}
+
+fn check_mr_approved_strict(mr_number: u64) -> Result<bool> {
     // Use glab api to check approvals
     // Note: We don't use --jq flag as it's not available in all glab versions
     let output = Command::new("glab")
@@ -554,21 +636,20 @@ pub fn check_mr_approved(mr_number: u64) -> Result<bool> {
         .output()?;
 
     if !output.status.success() {
-        // If the call fails, assume not approved
-        return Ok(false);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(GgError::GlabError(format!(
+            "Failed to check approvals for MR !{}: {}",
+            mr_number, stderr
+        )));
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-
-    // Parse JSON and extract .approved field
-    if let Ok(json) = serde_json::from_str::<serde_json::Value>(&stdout) {
-        return Ok(json
-            .get("approved")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false));
-    }
-
-    Ok(false)
+    let json: serde_json::Value = serde_json::from_str(&stdout)
+        .map_err(|e| GgError::GlabError(format!("Failed to parse MR approvals JSON: {}", e)))?;
+    Ok(json
+        .get("approved")
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false))
 }
 
 /// Get CI status for an MR
@@ -1746,6 +1827,57 @@ mod tests {
             parsed.detailed_merge_status.as_deref(),
             Some("ci_still_running")
         );
+    }
+
+    #[test]
+    fn inbox_snapshot_parses_typed_pipeline_status() {
+        let json = br#"{
+            "iid": 52,
+            "title": "Add login",
+            "state": "opened",
+            "web_url": "https://gitlab.com/acme/app/-/merge_requests/52",
+            "source_branch": "nacho/auth/c-abc1234",
+            "draft": false,
+            "detailed_merge_status": "mergeable",
+            "head_pipeline": {"status": "running"}
+        }"#;
+
+        let details = parse_inbox_mr_details(json).unwrap();
+        assert_eq!(details.state, MrState::Open);
+        assert_eq!(details.ci_status, Some(CiStatus::Running));
+    }
+
+    #[test]
+    fn inbox_snapshot_maps_typed_pipeline_statuses() {
+        let cases = [
+            (r#"{"status":"success"}"#, Some(CiStatus::Success)),
+            (r#"{"status":"failed"}"#, Some(CiStatus::Failed)),
+            (r#"{"status":"pending"}"#, Some(CiStatus::Pending)),
+            (r#"{"status":"canceled"}"#, Some(CiStatus::Canceled)),
+            ("null", None),
+            (
+                r#"{"status":"waiting_for_resource"}"#,
+                Some(CiStatus::Unknown),
+            ),
+        ];
+
+        for (pipeline, expected) in cases {
+            let json = format!(
+                r#"{{
+                    "iid": 53,
+                    "title": "Pipeline",
+                    "state": "opened",
+                    "web_url": "https://gitlab.com/acme/app/-/merge_requests/53",
+                    "draft": false,
+                    "detailed_merge_status": "mergeable",
+                    "head_pipeline": {}
+                }}"#,
+                pipeline
+            );
+
+            let details = parse_inbox_mr_details(json.as_bytes()).unwrap();
+            assert_eq!(details.ci_status, expected);
+        }
     }
 
     #[test]

--- a/crates/gg-core/src/glab.rs
+++ b/crates/gg-core/src/glab.rs
@@ -434,7 +434,12 @@ fn parse_inbox_mr_details(bytes: &[u8]) -> Result<InboxMrDetails> {
         {
             Some("success") => CiStatus::Success,
             Some("failed") => CiStatus::Failed,
-            Some("pending") => CiStatus::Pending,
+            Some("pending")
+            | Some("created")
+            | Some("preparing")
+            | Some("waiting_for_resource")
+            | Some("scheduled")
+            | Some("manual") => CiStatus::Pending,
             Some("running") => CiStatus::Running,
             Some("canceled") | Some("cancelled") => CiStatus::Canceled,
             _ => CiStatus::Unknown,
@@ -1897,10 +1902,14 @@ mod tests {
             (r#"{"status":"pending"}"#, Some(CiStatus::Pending)),
             (r#"{"status":"canceled"}"#, Some(CiStatus::Canceled)),
             ("null", None),
+            (r#"{"status":"created"}"#, Some(CiStatus::Pending)),
+            (r#"{"status":"preparing"}"#, Some(CiStatus::Pending)),
             (
                 r#"{"status":"waiting_for_resource"}"#,
-                Some(CiStatus::Unknown),
+                Some(CiStatus::Pending),
             ),
+            (r#"{"status":"scheduled"}"#, Some(CiStatus::Pending)),
+            (r#"{"status":"manual"}"#, Some(CiStatus::Pending)),
         ];
 
         for (pipeline, expected) in cases {

--- a/crates/gg-core/src/glab.rs
+++ b/crates/gg-core/src/glab.rs
@@ -440,11 +440,14 @@ fn parse_inbox_mr_details(bytes: &[u8]) -> Result<InboxMrDetails> {
             _ => CiStatus::Unknown,
         }
     });
+    let mergeable = state == MrState::Open
+        && !draft
+        && matches!(mr_json.detailed_merge_status.as_deref(), Some("mergeable"));
 
     Ok(InboxMrDetails {
         state: state.clone(),
         web_url: mr_json.web_url,
-        mergeable: state == MrState::Open && !draft,
+        mergeable,
         changes_requested: false,
         ci_status,
     })
@@ -1845,6 +1848,45 @@ mod tests {
         let details = parse_inbox_mr_details(json).unwrap();
         assert_eq!(details.state, MrState::Open);
         assert_eq!(details.ci_status, Some(CiStatus::Running));
+    }
+
+    #[test]
+    fn inbox_snapshot_mergeability_requires_mergeable_detailed_status() {
+        let json = br#"{
+            "iid": 54,
+            "title": "Ready",
+            "state": "opened",
+            "web_url": "https://gitlab.com/acme/app/-/merge_requests/54",
+            "draft": false,
+            "detailed_merge_status": "mergeable"
+        }"#;
+
+        let details = parse_inbox_mr_details(json).unwrap();
+
+        assert!(details.mergeable);
+    }
+
+    #[test]
+    fn inbox_snapshot_mergeability_rejects_blocked_or_missing_detailed_status() {
+        for detailed_status in [r#","detailed_merge_status":"conflict""#, ""] {
+            let json = format!(
+                r#"{{
+                    "iid": 55,
+                    "title": "Blocked",
+                    "state": "opened",
+                    "web_url": "https://gitlab.com/acme/app/-/merge_requests/55",
+                    "draft": false
+                    {detailed_status}
+                }}"#
+            );
+
+            let details = parse_inbox_mr_details(json.as_bytes()).unwrap();
+
+            assert!(
+                !details.mergeable,
+                "status fragment {detailed_status:?} must not be mergeable"
+            );
+        }
     }
 
     #[test]

--- a/crates/gg-core/src/glab.rs
+++ b/crates/gg-core/src/glab.rs
@@ -433,6 +433,7 @@ fn parse_inbox_mr_details(bytes: &[u8]) -> Result<InboxMrDetails> {
             .as_deref()
         {
             Some("success") => CiStatus::Success,
+            Some("skipped") => CiStatus::Success,
             Some("failed") => CiStatus::Failed,
             Some("pending")
             | Some("created")
@@ -1901,6 +1902,7 @@ mod tests {
             (r#"{"status":"failed"}"#, Some(CiStatus::Failed)),
             (r#"{"status":"pending"}"#, Some(CiStatus::Pending)),
             (r#"{"status":"canceled"}"#, Some(CiStatus::Canceled)),
+            (r#"{"status":"skipped"}"#, Some(CiStatus::Success)),
             ("null", None),
             (r#"{"status":"created"}"#, Some(CiStatus::Pending)),
             (r#"{"status":"preparing"}"#, Some(CiStatus::Pending)),

--- a/crates/gg-core/src/output.rs
+++ b/crates/gg-core/src/output.rs
@@ -395,8 +395,9 @@ pub struct InboxResponse {
     pub stack_errors: Vec<InboxStackErrorJson>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 pub struct InboxBucketsJson {
+    pub refresh_failed: Vec<InboxEntryJson>,
     pub ready_to_land: Vec<InboxEntryJson>,
     pub changes_requested: Vec<InboxEntryJson>,
     pub blocked_on_ci: Vec<InboxEntryJson>,
@@ -407,7 +408,7 @@ pub struct InboxBucketsJson {
     pub merged: Vec<InboxEntryJson>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 pub struct InboxEntryJson {
     pub stack_name: String,
     pub position: usize,
@@ -417,6 +418,8 @@ pub struct InboxEntryJson {
     pub pr_url: String,
     pub ci_status: Option<String>,
     pub behind_base: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refresh_error: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -525,8 +528,19 @@ mod tests {
     fn inbox_response_serializes() {
         let response = InboxResponse {
             version: OUTPUT_VERSION,
-            total_items: 1,
+            total_items: 2,
             buckets: InboxBucketsJson {
+                refresh_failed: vec![InboxEntryJson {
+                    stack_name: "auth".to_string(),
+                    position: 2,
+                    sha: "def5678".to_string(),
+                    title: "Refresh failed".to_string(),
+                    pr_number: 42,
+                    pr_url: String::new(),
+                    ci_status: None,
+                    behind_base: None,
+                    refresh_error: Some("failed to refresh PR #42".to_string()),
+                }],
                 ready_to_land: vec![InboxEntryJson {
                     stack_name: "auth".to_string(),
                     position: 1,
@@ -536,6 +550,7 @@ mod tests {
                     pr_url: "https://github.com/org/repo/pull/42".to_string(),
                     ci_status: Some("success".to_string()),
                     behind_base: None,
+                    refresh_error: None,
                 }],
                 changes_requested: vec![],
                 blocked_on_ci: vec![],
@@ -549,8 +564,15 @@ mod tests {
 
         let value = serde_json::to_value(&response).expect("should serialize");
         assert_eq!(value["version"], OUTPUT_VERSION);
-        assert_eq!(value["total_items"], 1);
+        assert_eq!(value["total_items"], 2);
+        assert_eq!(
+            value["buckets"]["refresh_failed"][0]["refresh_error"],
+            "failed to refresh PR #42"
+        );
         assert_eq!(value["buckets"]["ready_to_land"][0]["pr_number"], 42);
+        assert!(value["buckets"]["ready_to_land"][0]
+            .get("refresh_error")
+            .is_none());
         // merged bucket should be omitted when empty
         assert!(value["buckets"].get("merged").is_none());
     }

--- a/crates/gg-core/src/output.rs
+++ b/crates/gg-core/src/output.rs
@@ -75,6 +75,15 @@ pub struct ErrorJson<'a> {
     pub error: &'a str,
 }
 
+#[derive(Serialize)]
+pub struct StreamingErrorResponse<'a> {
+    pub version: u32,
+    pub command: &'a str,
+    pub status: &'static str,
+    pub event: &'static str,
+    pub message: String,
+}
+
 pub fn print_json_error(message: &str) {
     print_json(&ErrorJson {
         version: OUTPUT_VERSION,
@@ -387,6 +396,61 @@ pub struct LandedEntryJson {
 // Inbox responses
 // ---------------------------------------------------------------------------
 
+pub struct InboxStreamingResponse {
+    pub version: u32,
+    pub command: String,
+    pub event: InboxStreamingEvent,
+}
+
+impl Serialize for InboxStreamingResponse {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut value = serde_json::to_value(&self.event).map_err(serde::ser::Error::custom)?;
+        let object = value
+            .as_object_mut()
+            .ok_or_else(|| serde::ser::Error::custom("streaming event serialized non-object"))?;
+        object.insert("version".to_string(), serde_json::json!(self.version));
+        object.insert("command".to_string(), serde_json::json!(self.command));
+        value.serialize(serializer)
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "snake_case", tag = "event")]
+pub enum InboxStreamingEvent {
+    Start {
+        total_candidates: usize,
+        total_stack_errors: usize,
+    },
+    StackError {
+        stack_name: String,
+        error: String,
+    },
+    Entry {
+        completed: usize,
+        total_candidates: usize,
+        included: bool,
+        bucket: Option<String>,
+        remote_state: String,
+        entry: InboxEntryJson,
+    },
+    EntryError {
+        completed: usize,
+        total_candidates: usize,
+        included: bool,
+        bucket: String,
+        entry: InboxCandidateJson,
+        error: String,
+    },
+    Summary {
+        total_items: usize,
+        buckets: InboxBucketsJson,
+        stack_errors: Vec<InboxStackErrorJson>,
+    },
+}
+
 #[derive(Serialize)]
 pub struct InboxResponse {
     pub version: u32,
@@ -420,6 +484,16 @@ pub struct InboxEntryJson {
     pub behind_base: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub refresh_error: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct InboxCandidateJson {
+    pub stack_name: String,
+    pub position: usize,
+    pub sha: String,
+    pub title: String,
+    pub pr_number: u64,
+    pub behind_base: Option<usize>,
 }
 
 #[derive(Serialize)]
@@ -575,6 +649,152 @@ mod tests {
             .is_none());
         // merged bucket should be omitted when empty
         assert!(value["buckets"].get("merged").is_none());
+    }
+
+    fn inbox_streaming_entry() -> InboxEntryJson {
+        InboxEntryJson {
+            stack_name: "auth".to_string(),
+            position: 1,
+            sha: "abc1234".to_string(),
+            title: "Add login".to_string(),
+            pr_number: 42,
+            pr_url: "https://github.com/org/repo/pull/42".to_string(),
+            ci_status: Some("success".to_string()),
+            behind_base: None,
+            refresh_error: None,
+        }
+    }
+
+    #[test]
+    fn inbox_streaming_start_serializes_flat_envelope() {
+        let response = InboxStreamingResponse {
+            version: OUTPUT_VERSION,
+            command: "inbox".to_string(),
+            event: InboxStreamingEvent::Start {
+                total_candidates: 2,
+                total_stack_errors: 1,
+            },
+        };
+
+        let json = serde_json::to_value(&response).expect("should serialize");
+
+        assert_eq!(json["version"], 1);
+        assert_eq!(json["command"], "inbox");
+        assert_eq!(json["event"], "start");
+        assert_eq!(json["total_candidates"], 2);
+        assert_eq!(json["total_stack_errors"], 1);
+    }
+
+    #[test]
+    fn inbox_streaming_included_entry_serializes_bucket() {
+        let response = InboxStreamingResponse {
+            version: OUTPUT_VERSION,
+            command: "inbox".to_string(),
+            event: InboxStreamingEvent::Entry {
+                completed: 1,
+                total_candidates: 2,
+                included: true,
+                bucket: Some("ready_to_land".to_string()),
+                remote_state: "open".to_string(),
+                entry: inbox_streaming_entry(),
+            },
+        };
+
+        let json = serde_json::to_value(&response).expect("should serialize");
+
+        assert_eq!(json["version"], 1);
+        assert_eq!(json["command"], "inbox");
+        assert_eq!(json["event"], "entry");
+        assert_eq!(json["included"], true);
+        assert_eq!(json["bucket"], "ready_to_land");
+        assert_eq!(json["remote_state"], "open");
+        assert_eq!(json["entry"]["pr_number"], 42);
+    }
+
+    #[test]
+    fn inbox_streaming_excluded_merged_entry_serializes_null_bucket() {
+        let response = InboxStreamingResponse {
+            version: OUTPUT_VERSION,
+            command: "inbox".to_string(),
+            event: InboxStreamingEvent::Entry {
+                completed: 2,
+                total_candidates: 2,
+                included: false,
+                bucket: None,
+                remote_state: "merged".to_string(),
+                entry: inbox_streaming_entry(),
+            },
+        };
+
+        let json = serde_json::to_value(&response).expect("should serialize");
+
+        assert_eq!(json["event"], "entry");
+        assert_eq!(json["included"], false);
+        assert!(json["bucket"].is_null());
+        assert_eq!(json["remote_state"], "merged");
+    }
+
+    #[test]
+    fn inbox_streaming_entry_error_serializes_refresh_failed_bucket() {
+        let response = InboxStreamingResponse {
+            version: OUTPUT_VERSION,
+            command: "inbox".to_string(),
+            event: InboxStreamingEvent::EntryError {
+                completed: 1,
+                total_candidates: 1,
+                included: true,
+                bucket: "refresh_failed".to_string(),
+                entry: InboxCandidateJson {
+                    stack_name: "auth".to_string(),
+                    position: 1,
+                    sha: "abc1234".to_string(),
+                    title: "Add login".to_string(),
+                    pr_number: 42,
+                    behind_base: None,
+                },
+                error: "provider unavailable".to_string(),
+            },
+        };
+
+        let json = serde_json::to_value(&response).expect("should serialize");
+
+        assert_eq!(json["event"], "entry_error");
+        assert_eq!(json["included"], true);
+        assert_eq!(json["bucket"], "refresh_failed");
+        assert_eq!(json["entry"]["sha"], "abc1234");
+        assert_eq!(json["error"], "provider unavailable");
+    }
+
+    #[test]
+    fn inbox_streaming_summary_serializes_atomic_payload() {
+        let response = InboxStreamingResponse {
+            version: OUTPUT_VERSION,
+            command: "inbox".to_string(),
+            event: InboxStreamingEvent::Summary {
+                total_items: 1,
+                buckets: InboxBucketsJson {
+                    refresh_failed: vec![],
+                    ready_to_land: vec![inbox_streaming_entry()],
+                    changes_requested: vec![],
+                    blocked_on_ci: vec![],
+                    awaiting_review: vec![],
+                    behind_base: vec![],
+                    draft: vec![],
+                    merged: vec![],
+                },
+                stack_errors: vec![InboxStackErrorJson {
+                    stack_name: "stale".to_string(),
+                    error: "missing base".to_string(),
+                }],
+            },
+        };
+
+        let json = serde_json::to_value(&response).expect("should serialize");
+
+        assert_eq!(json["event"], "summary");
+        assert_eq!(json["total_items"], 1);
+        assert_eq!(json["buckets"]["ready_to_land"][0]["pr_number"], 42);
+        assert_eq!(json["stack_errors"][0]["stack_name"], "stale");
     }
 
     #[test]

--- a/crates/gg-core/src/provider.rs
+++ b/crates/gg-core/src/provider.rs
@@ -55,6 +55,17 @@ pub enum CiStatus {
     Unknown,
 }
 
+/// Provider-neutral fields needed to display a PR or MR in the review inbox.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InboxSnapshot {
+    pub state: PrState,
+    pub url: String,
+    pub approved: bool,
+    pub changes_requested: bool,
+    pub mergeable: bool,
+    pub ci_status: Option<CiStatus>,
+}
+
 /// Unified PR/MR information
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
@@ -217,6 +228,17 @@ impl Provider {
                     changes_requested: info.changes_requested,
                     detailed_merge_status: info.detailed_merge_status,
                 })
+            }
+        }
+    }
+
+    /// Get all inbox fields with the provider's minimal set of remote requests.
+    pub fn get_inbox_snapshot(&self, number: u64) -> Result<InboxSnapshot> {
+        match self {
+            Provider::GitHub => Ok(convert_gh_inbox_snapshot(gh::get_inbox_snapshot(number)?)),
+            Provider::GitLab => {
+                let (details, approved) = glab::get_inbox_snapshot(number)?;
+                Ok(convert_glab_inbox_snapshot(details, approved))
             }
         }
     }
@@ -509,9 +531,74 @@ fn convert_glab_ci_status(status: GlabCiStatus) -> CiStatus {
     }
 }
 
+fn convert_gh_inbox_snapshot(snapshot: gh::InboxPrSnapshot) -> InboxSnapshot {
+    InboxSnapshot {
+        state: convert_gh_state(snapshot.state),
+        url: snapshot.url,
+        approved: snapshot.approved,
+        changes_requested: snapshot.changes_requested,
+        mergeable: snapshot.mergeable,
+        ci_status: snapshot.ci_status.map(convert_gh_ci_status),
+    }
+}
+
+fn convert_glab_inbox_snapshot(details: glab::InboxMrDetails, approved: bool) -> InboxSnapshot {
+    InboxSnapshot {
+        state: convert_glab_state(details.state),
+        url: details.web_url,
+        approved,
+        changes_requested: details.changes_requested,
+        mergeable: details.mergeable,
+        ci_status: details.ci_status.map(convert_glab_ci_status),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn inbox_snapshot_preserves_github_inbox_fields() {
+        let snapshot = convert_gh_inbox_snapshot(gh::InboxPrSnapshot {
+            state: GhPrState::Open,
+            url: "https://github.com/acme/app/pull/42".to_string(),
+            approved: true,
+            changes_requested: false,
+            mergeable: true,
+            ci_status: Some(GhCiStatus::Success),
+        });
+
+        assert_eq!(snapshot.state, PrState::Open);
+        assert_eq!(snapshot.url, "https://github.com/acme/app/pull/42");
+        assert!(snapshot.approved);
+        assert!(!snapshot.changes_requested);
+        assert!(snapshot.mergeable);
+        assert_eq!(snapshot.ci_status, Some(CiStatus::Success));
+    }
+
+    #[test]
+    fn inbox_snapshot_preserves_gitlab_inbox_fields() {
+        let snapshot = convert_glab_inbox_snapshot(
+            glab::InboxMrDetails {
+                state: GlabMrState::Draft,
+                web_url: "https://gitlab.com/acme/app/-/merge_requests/52".to_string(),
+                mergeable: false,
+                changes_requested: false,
+                ci_status: None,
+            },
+            true,
+        );
+
+        assert_eq!(snapshot.state, PrState::Draft);
+        assert_eq!(
+            snapshot.url,
+            "https://gitlab.com/acme/app/-/merge_requests/52"
+        );
+        assert!(snapshot.approved);
+        assert!(!snapshot.changes_requested);
+        assert!(!snapshot.mergeable);
+        assert_eq!(snapshot.ci_status, None);
+    }
 
     #[test]
     fn test_provider_equality() {

--- a/docs/src/commands/inbox.md
+++ b/docs/src/commands/inbox.md
@@ -15,24 +15,26 @@ Use it when you want quick answers to questions like:
 gg inbox
 gg inbox --all
 gg inbox --json
+gg inbox --jsonl
 ```
 
 ## Buckets
 
 `gg inbox` classifies each PR or MR into exactly one bucket, in priority order:
 
-1. `ready_to_land`
-2. `changes_requested`
-3. `blocked_on_ci`
-4. `awaiting_review`
-5. `behind_base`
-6. `draft`
-7. `merged` (only with `--all`)
+1. `refresh_failed`
+2. `ready_to_land`
+3. `changes_requested`
+4. `blocked_on_ci`
+5. `awaiting_review`
+6. `behind_base`
+7. `draft`
+8. `merged` (only with `--all`)
 
 ### Classification notes
 
 - A canceled CI run counts as `blocked_on_ci`.
-- If remote refresh fails transiently, the entry stays visible instead of disappearing, so the inbox does not look empty because of a temporary provider error.
+- If remote refresh fails transiently, the entry stays visible in `refresh_failed` instead of disappearing, so the inbox does not look empty because of a temporary provider error.
 - `behind_base` is computed from the real stack tip versus `origin/<base>`, not from the state of your local base branch.
 
 ## Example human output
@@ -66,6 +68,17 @@ Awaiting review (1):
   auth #3  def5678  Add login API  stack/auth  MR !42
 ```
 
+## Live refresh
+
+When both stdout and stderr are terminals, `gg inbox` renders one stable row
+per discovered PR or MR while remote state is refreshed. Rows stay in discovery
+order, the aggregate counter advances as `refreshed N/M`, and a completed row
+remains visible until the refresh finishes. The live display is cleared before
+the final grouped inbox is printed.
+
+When output is redirected or piped, live progress is suppressed: stdout contains
+only the final grouped inbox and stderr contains no refresh progress.
+
 ## JSON
 
 With `--json`, `gg inbox` returns a versioned response designed for automation and MCP.
@@ -77,6 +90,7 @@ Example:
   "version": 1,
   "total_items": 2,
   "buckets": {
+    "refresh_failed": [],
     "ready_to_land": [
       {
         "stack_name": "auth",
@@ -115,11 +129,53 @@ Example:
 - `pr_url`: PR or MR URL
 - `ci_status`: `pending`, `running`, `success`, `failed`, `canceled`, `unknown`, or omitted
 - `behind_base`: number of commits behind `origin/<base>`, or `null`
+- `refresh_error`: remote-refresh error text, present for entries in `refresh_failed`
+
+## Streaming NDJSON (`--jsonl`)
+
+`gg inbox --jsonl` emits one flushed JSON object per line as discovery and
+refresh work completes. The first event is `start`; each discovery error emits
+`stack_error`; refresh completions emit `entry` or `entry_error`; and the final
+`summary` is the same deterministic payload as `--json` (apart from its event
+envelope). Consumers must wait for `summary` before making a complete-inbox
+claim. A fatal failure before the summary emits one `error` event and exits
+nonzero.
+
+These representative lines use the exact serialized event shapes covered by
+the inbox output tests:
+
+```ndjson
+{"event":"start","total_candidates":2,"total_stack_errors":1,"version":1,"command":"inbox"}
+{"event":"stack_error","stack_name":"stale","error":"missing base","version":1,"command":"inbox"}
+{"event":"entry","completed":1,"total_candidates":2,"included":true,"bucket":"ready_to_land","remote_state":"open","entry":{"stack_name":"auth","position":1,"sha":"abc1234","title":"Add login","pr_number":42,"pr_url":"https://github.com/org/repo/pull/42","ci_status":"success","behind_base":null},"version":1,"command":"inbox"}
+{"event":"entry_error","completed":1,"total_candidates":1,"included":true,"bucket":"refresh_failed","entry":{"stack_name":"auth","position":1,"sha":"abc1234","title":"Add login","pr_number":42,"behind_base":null},"error":"provider unavailable","version":1,"command":"inbox"}
+{"event":"summary","total_items":1,"buckets":{"refresh_failed":[],"ready_to_land":[{"stack_name":"auth","position":1,"sha":"abc1234","title":"Add login","pr_number":42,"pr_url":"https://github.com/org/repo/pull/42","ci_status":"success","behind_base":null}],"changes_requested":[],"blocked_on_ci":[],"awaiting_review":[],"behind_base":[],"draft":[]},"stack_errors":[{"stack_name":"stale","error":"missing base"}],"version":1,"command":"inbox"}
+{"version":1,"command":"inbox","status":"error","event":"error","message":"Not in a git repository"}
+```
+
+`entry` events are emitted in refresh-completion order. An entry omitted from
+the final inbox (for example, a merged entry without `--all`) has
+`"included": false` and `"bucket": null`.
+
+### `--json` vs `--jsonl`
+
+- Use `--json` for one final, structured cross-stack snapshot.
+- Use `--jsonl` when incremental results matter and a line-oriented consumer
+  can process completion events before the final summary.
+
+## Partial failures
+
+An individual remote refresh failure does not make `gg inbox` fail: the command
+exits zero and puts that entry in `buckets.refresh_failed` with a
+`refresh_error`. Discovery failures are reported in `stack_errors` and are
+also included in the JSONL `stack_error` events. Inspect both fields before
+treating the inbox as complete.
 
 ## Flags
 
 - `--all`: include items already marked as `merged`
 - `--json`: emit structured output for tooling and MCP
+- `--jsonl`: emit flushed NDJSON events as refreshes complete; conflicts with `--json`
 
 ## Relationship to other commands
 

--- a/docs/src/commands/inbox.md
+++ b/docs/src/commands/inbox.md
@@ -115,7 +115,8 @@ Example:
         "behind_base": 2
       }
     ]
-  }
+  },
+  "stack_errors": []
 }
 ```
 
@@ -126,8 +127,8 @@ Example:
 - `sha`: short SHA
 - `title`: commit title
 - `pr_number`: PR or MR number
-- `pr_url`: PR or MR URL
-- `ci_status`: `pending`, `running`, `success`, `failed`, `canceled`, `unknown`, or omitted
+- `pr_url`: PR or MR URL; empty for a `refresh_failed` entry when no URL was refreshed
+- `ci_status`: `pending`, `running`, `success`, `failed`, `canceled`, `unknown`, or `null`
 - `behind_base`: number of commits behind `origin/<base>`, or `null`
 - `refresh_error`: remote-refresh error text, present for entries in `refresh_failed`
 

--- a/docs/src/mcp-server.md
+++ b/docs/src/mcp-server.md
@@ -65,12 +65,18 @@ List all stacks in the repository with summary information.
 
 ### `stack_inbox`
 
-Show actionable triage across local stacks. Mirrors `gg inbox --json` and groups PRs/MRs into action buckets like ready to land, blocked on CI, awaiting review, behind base, draft, and optionally merged.
+Show actionable triage across local stacks. Mirrors the atomic `gg inbox --json` snapshot and groups PRs/MRs into action buckets like refresh failed, ready to land, blocked on CI, awaiting review, behind base, draft, and optionally merged.
 
 **Parameters:**
 - `all` (boolean, optional): Include merged items as well.
 
-**Returns:** A versioned JSON payload with `total_items` and `buckets`, where each bucket contains entries with stack name, position, SHA, title, PR/MR number, URL, CI status, and optional behind-base count.
+**Returns:** A versioned JSON payload with `total_items`, `buckets`, and
+`stack_errors`, where each bucket contains entries with stack name, position,
+SHA, title, PR/MR number, URL, CI status, and optional behind-base count.
+`stack_inbox` remains atomic; it does not stream JSONL events. A successful tool
+call can still contain `refresh_failed` entries with `refresh_error`, so callers
+must inspect those fields (and `stack_errors`) before treating the inbox as
+complete.
 
 ### `stack_status`
 

--- a/docs/superpowers/plans/2026-07-30-gg-inbox-progressive-refresh.md
+++ b/docs/superpowers/plans/2026-07-30-gg-inbox-progressive-refresh.md
@@ -1,0 +1,1285 @@
+# Progressive `gg inbox` Refresh Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `gg inbox` render useful human and machine-readable results immediately while reducing redundant provider requests and preserving a deterministic final snapshot.
+
+**Architecture:** Discover immutable local candidates first, refresh complete provider snapshots with a four-worker bounded scheduler, and feed completions to one coordinator. The coordinator alone renders stable terminal rows or emits completion-order JSONL events, then builds the same deterministic final inbox used by atomic JSON.
+
+**Tech Stack:** Rust 2021, `std::thread` scoped workers, `std::sync::mpsc`, `indicatif`, `serde`/`serde_json`, `git2`, Clap, fake `gh`/`glab` integration executables, mdBook.
+
+## Global Constraints
+
+- Process at most four PRs or MRs concurrently; do not add a concurrency flag or setting.
+- GitHub inbox refresh uses one `gh pr view --json` request per candidate.
+- GitLab inbox refresh reuses one `glab mr view --output json` response and performs one separate approval request.
+- `--json` remains one deterministic aggregate document.
+- `--jsonl` emits completion-order entry events and a deterministic final summary.
+- Live human rows appear only when both stdout and stderr are terminals; redirected output remains final-only.
+- Provider refresh failures remain visible in `refresh_failed`, emit structured errors, and do not make the command exit nonzero.
+- Provider detection failure, a missing provider CLI, and repository-wide discovery failure remain fatal.
+- Keep `stack_inbox` on atomic `gg inbox --json`; do not add streaming MCP transport.
+- Add no persistent cache, provider-wide batch API, job framework, or new dependency.
+- Preserve existing successful bucket classification and provider-specific PR/MR labels.
+- Every behavior change requires tests, `cargo fmt`, warning-free Clippy, and the all-feature test suite.
+
+---
+
+## File Structure
+
+### New files
+
+- `crates/gg-core/src/commands/inbox/refresh.rs`
+  - Fixed-width worker scheduling and completion delivery.
+  - Concurrency/order/error-isolation unit tests.
+- `crates/gg-core/src/commands/inbox/render.rs`
+  - Stable `indicatif::MultiProgress` terminal rows.
+  - TTY gating, row-state formatting, clearing, and terminal tests.
+
+### Modified files
+
+- `crates/gg-core/src/gh.rs`
+  - Parse PR details, review state, mergeability, and CI from one response.
+- `crates/gg-core/src/glab.rs`
+  - Parse MR details and CI from one typed response, then query approval.
+- `crates/gg-core/src/provider.rs`
+  - Provider-neutral `InboxSnapshot` and dispatch method.
+- `crates/gg-core/src/commands/inbox.rs`
+  - Candidate discovery, coordinator, classification, filtering, and final rendering.
+- `crates/gg-core/src/output.rs`
+  - Additive atomic inbox schema and inbox streaming event schema.
+- `crates/gg-cli/src/main.rs`
+  - `--jsonl` flag, `InboxOptions`, dispatch, and generic streaming fatal errors.
+- `crates/gg-cli/tests/integration_tests/inbox.rs`
+  - Fake-provider request-count, JSONL lifecycle, and partial-failure coverage.
+- `README.md`
+  - Progressive/streaming inbox command summary.
+- `docs/src/commands/inbox.md`
+  - Human UX, JSONL events, and failure semantics.
+- `docs/src/mcp-server.md`
+  - Additive `refresh_failed` atomic response behavior.
+- `skills/gg/SKILL.md`
+  - Generalize the JSONL guidance from sync-only to supported streaming commands.
+- `skills/gg/references/setup-and-inspection.md`
+  - Select atomic or streaming inbox inspection based on the caller's need.
+
+No Cargo manifest changes are expected.
+
+---
+
+### Task 1: Add Complete Provider Inbox Snapshots
+
+**Files:**
+- Modify: `crates/gg-core/src/gh.rs:23-49,182-230,423-493,680-750`
+- Modify: `crates/gg-core/src/glab.rs:20-49,309-350,546-645,1720-1760`
+- Modify: `crates/gg-core/src/provider.rs:37-64,189-218,363-383`
+
+**Interfaces:**
+- Produces:
+
+```rust
+// crates/gg-core/src/provider.rs
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InboxSnapshot {
+    pub state: PrState,
+    pub url: String,
+    pub approved: bool,
+    pub changes_requested: bool,
+    pub mergeable: bool,
+    pub ci_status: Option<CiStatus>,
+}
+
+impl Provider {
+    pub fn get_inbox_snapshot(&self, number: u64) -> Result<InboxSnapshot>;
+}
+```
+
+- `ci_status: None` means the provider returned no checks or pipeline.
+- `ci_status: Some(CiStatus::Unknown)` means checks existed but could not be mapped to a known aggregate state.
+- Later tasks consume only `Provider::get_inbox_snapshot`; they do not call the three legacy inbox methods.
+
+- [ ] **Step 1: Add failing GitHub combined-snapshot parser tests**
+
+Add focused tests in `gh.rs` for a response containing `reviewDecision`,
+`mergeable`, and `statusCheckRollup`:
+
+```rust
+#[test]
+fn inbox_snapshot_parses_review_and_ci_from_one_response() {
+    let json = br#"{
+        "number": 42,
+        "title": "Add login",
+        "state": "OPEN",
+        "url": "https://github.com/acme/app/pull/42",
+        "headRefName": "nacho/auth/c-abc1234",
+        "isDraft": false,
+        "mergeable": "MERGEABLE",
+        "reviewDecision": "APPROVED",
+        "statusCheckRollup": [
+            {"status": "COMPLETED", "conclusion": "SUCCESS"}
+        ]
+    }"#;
+
+    let snapshot = parse_inbox_snapshot(json).unwrap();
+    assert_eq!(snapshot.state, PrState::Open);
+    assert!(snapshot.approved);
+    assert!(!snapshot.changes_requested);
+    assert!(snapshot.mergeable);
+    assert_eq!(snapshot.ci_status, Some(CiStatus::Success));
+}
+
+#[test]
+fn inbox_snapshot_treats_empty_rollup_as_no_ci() {
+    let json = br#"{
+        "number": 43,
+        "title": "No checks",
+        "state": "OPEN",
+        "url": "https://github.com/acme/app/pull/43",
+        "isDraft": false,
+        "mergeable": "MERGEABLE",
+        "reviewDecision": "CHANGES_REQUESTED",
+        "statusCheckRollup": []
+    }"#;
+
+    let snapshot = parse_inbox_snapshot(json).unwrap();
+    assert!(snapshot.changes_requested);
+    assert_eq!(snapshot.ci_status, None);
+}
+```
+
+Add table cases proving failure/cancellation wins over success, an in-progress
+check maps to `Pending`, and an unmapped non-empty rollup maps to `Unknown`.
+
+- [ ] **Step 2: Run the GitHub parser tests and verify they fail**
+
+Run:
+
+```bash
+rtk cargo test -p gg-core --all-features gh::tests::inbox_snapshot
+```
+
+Expected: compilation fails because `parse_inbox_snapshot` and the rollup
+fields do not exist.
+
+- [ ] **Step 3: Implement the GitHub combined snapshot**
+
+Add private response types and a public low-level snapshot:
+
+```rust
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GhStatusCheck {
+    conclusion: Option<String>,
+    status: Option<String>,
+    state: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct InboxPrSnapshot {
+    pub state: PrState,
+    pub url: String,
+    pub approved: bool,
+    pub changes_requested: bool,
+    pub mergeable: bool,
+    pub ci_status: Option<CiStatus>,
+}
+
+fn parse_inbox_snapshot(bytes: &[u8]) -> Result<InboxPrSnapshot>;
+pub fn get_inbox_snapshot(pr_number: u64) -> Result<InboxPrSnapshot>;
+```
+
+Extend `GhPrJson` with a defaulted `status_check_rollup`. Have
+`get_inbox_snapshot` execute exactly:
+
+```rust
+Command::new("gh").args([
+    "pr",
+    "view",
+    &pr_number.to_string(),
+    "--json",
+    "number,title,state,url,headRefName,isDraft,mergeable,reviewDecision,statusCheckRollup",
+])
+```
+
+Aggregate checks in this priority order:
+
+1. `FAILURE`, `FAILED`, `TIMED_OUT`, or `ACTION_REQUIRED` -> `Failed`
+2. `CANCELLED` or `CANCELED` -> `Canceled`
+3. non-completed status, empty conclusion, `PENDING`, `QUEUED`, or
+   `IN_PROGRESS` -> `Pending`
+4. at least one `SUCCESS`, `NEUTRAL`, or `SKIPPED` and no earlier state ->
+   `Success`
+5. non-empty but unmapped -> `Unknown`
+6. empty rollup -> `None`
+
+Keep the legacy methods for other callers; only inbox switches to the new
+combined method.
+
+- [ ] **Step 4: Run the GitHub tests and verify they pass**
+
+Run:
+
+```bash
+rtk cargo test -p gg-core --all-features gh::tests::inbox_snapshot
+```
+
+Expected: all combined-snapshot parser tests pass.
+
+- [ ] **Step 5: Add failing GitLab typed-snapshot tests**
+
+Extend `GlabMrJson` test fixtures with `head_pipeline` and add:
+
+```rust
+#[test]
+fn inbox_snapshot_parses_typed_pipeline_status() {
+    let json = br#"{
+        "iid": 52,
+        "title": "Add login",
+        "state": "opened",
+        "web_url": "https://gitlab.com/acme/app/-/merge_requests/52",
+        "source_branch": "nacho/auth/c-abc1234",
+        "draft": false,
+        "detailed_merge_status": "mergeable",
+        "head_pipeline": {"status": "running"}
+    }"#;
+
+    let details = parse_inbox_mr_details(json).unwrap();
+    assert_eq!(details.state, MrState::Open);
+    assert_eq!(details.ci_status, Some(CiStatus::Running));
+}
+```
+
+Add cases for `success`, `failed`, `pending`, `canceled`, a missing pipeline,
+and an unknown non-empty pipeline status.
+
+- [ ] **Step 6: Run the GitLab parser tests and verify they fail**
+
+Run:
+
+```bash
+rtk cargo test -p gg-core --all-features glab::tests::inbox_snapshot
+```
+
+Expected: compilation fails because typed pipeline parsing does not exist.
+
+- [ ] **Step 7: Implement GitLab details reuse and provider-neutral dispatch**
+
+Add:
+
+```rust
+#[derive(Debug, Deserialize)]
+struct GlabPipelineJson {
+    status: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct InboxMrDetails {
+    pub state: MrState,
+    pub web_url: String,
+    pub mergeable: bool,
+    pub changes_requested: bool,
+    pub ci_status: Option<CiStatus>,
+}
+
+fn parse_inbox_mr_details(bytes: &[u8]) -> Result<InboxMrDetails>;
+pub fn get_inbox_snapshot(mr_number: u64) -> Result<(InboxMrDetails, bool)>;
+```
+
+`glab::get_inbox_snapshot` runs `glab mr view ... --output json` once, parses
+details and CI, then calls `check_mr_approved` once. A failure from either
+subprocess returns `Err`.
+
+Add the provider-neutral `InboxSnapshot` and map the GitHub/GitLab low-level
+types in `Provider::get_inbox_snapshot`.
+
+- [ ] **Step 8: Run provider tests**
+
+Run:
+
+```bash
+rtk cargo test -p gg-core --all-features gh::tests::inbox_snapshot
+rtk cargo test -p gg-core --all-features glab::tests::inbox_snapshot
+rtk cargo test -p gg-core --all-features provider::tests
+```
+
+Expected: all pass.
+
+- [ ] **Step 9: Commit the provider snapshot boundary**
+
+```bash
+rtk cargo fmt --all
+rtk git add crates/gg-core/src/gh.rs crates/gg-core/src/glab.rs crates/gg-core/src/provider.rs
+rtk git commit -m "feat(core): add inbox provider snapshots"
+```
+
+---
+
+### Task 2: Separate Local Discovery and Adopt Snapshot Classification
+
+**Files:**
+- Modify: `crates/gg-core/src/commands/inbox.rs:16-389,391-555,562-890`
+- Modify: `crates/gg-core/src/output.rs:387-430,525-585`
+- Modify: `crates/gg-cli/tests/integration_tests/inbox.rs:1-243`
+
+**Interfaces:**
+- Consumes: `Provider::get_inbox_snapshot(u64) -> Result<InboxSnapshot>`.
+- Produces:
+
+```rust
+// crates/gg-core/src/commands/inbox.rs
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct InboxCandidate {
+    pub discovery_index: usize,
+    pub stack_name: String,
+    pub position: usize,
+    pub short_sha: String,
+    pub title: String,
+    pub pr_number: u64,
+    pub behind_base: Option<usize>,
+}
+
+pub(super) struct InboxDiscovery {
+    pub candidates: Vec<InboxCandidate>,
+    pub stack_errors: Vec<StackLoadError>,
+}
+
+fn discover_candidates(
+    repo: &git2::Repository,
+    config: &Config,
+) -> Result<InboxDiscovery>;
+```
+
+- `InboxItem` gains `remote_state: Option<PrState>` and
+  `refresh_error: Option<String>`.
+- `InboxItem` provides:
+
+```rust
+fn from_snapshot(
+    candidate: InboxCandidate,
+    snapshot: InboxSnapshot,
+    provider: Provider,
+) -> Self;
+
+fn from_refresh_error(
+    candidate: InboxCandidate,
+    error: String,
+    provider: Provider,
+) -> Self;
+```
+
+- Atomic `InboxResponse` gains `buckets.refresh_failed`; successful entries
+  omit `refresh_error`.
+
+- [ ] **Step 1: Add failing refresh-failure bucketing and JSON tests**
+
+Add `refresh_failed` to `BucketInput` test construction and assert it wins over
+every remote state:
+
+```rust
+#[test]
+fn refresh_failure_has_highest_priority() {
+    let input = BucketInput {
+        refresh_failed: true,
+        mr_state: PrState::Merged,
+        ci_status: Some(CiStatus::Success),
+        approved: true,
+        changes_requested: true,
+        mergeable: true,
+        behind_base: true,
+    };
+
+    assert_eq!(bucket(&input), Some(ActionBucket::RefreshFailed));
+}
+```
+
+Extend `output.rs` serialization coverage:
+
+```rust
+assert_eq!(
+    json["buckets"]["refresh_failed"][0]["refresh_error"],
+    "failed to refresh PR #42"
+);
+assert!(json["buckets"]["ready_to_land"][0]
+    .get("refresh_error")
+    .is_none());
+```
+
+- [ ] **Step 2: Run the focused tests and verify they fail**
+
+Run:
+
+```bash
+rtk cargo test -p gg-core --all-features commands::inbox::tests::refresh_failure
+rtk cargo test -p gg-core --all-features output::tests::inbox_response_serializes
+```
+
+Expected: compilation or assertions fail because the new bucket and field are
+absent.
+
+- [ ] **Step 3: Add the refresh-failure model and additive atomic schema**
+
+Add `ActionBucket::RefreshFailed` first in display order. Add
+`refresh_failed: bool` to `BucketInput` and return `RefreshFailed` before
+checking `mr_state`.
+
+Change the JSON types to:
+
+```rust
+#[derive(Serialize, Clone)]
+pub struct InboxBucketsJson {
+    pub refresh_failed: Vec<InboxEntryJson>,
+    // existing buckets remain in their current schema order
+}
+
+#[derive(Serialize, Clone)]
+pub struct InboxEntryJson {
+    // existing fields
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refresh_error: Option<String>,
+}
+```
+
+Render `Refresh failed` before the existing groups. Keep successful bucketing
+rules unchanged.
+
+- [ ] **Step 4: Extract local candidate discovery**
+
+Move username inference, stack/base loading, MR-number mapping, and
+behind-base calculation into `discover_candidates`. Preserve:
+
+- duplicate `(stack_name, full_branch)` suppression
+- invalid username filtering
+- stale configured-stack skipping
+- same-name stacks under different usernames
+- stack-specific `StackLoadError` collection
+
+Assign `discovery_index` only when a mapped PR/MR becomes a candidate. Do not
+perform provider detection or provider subprocess work inside discovery.
+
+- [ ] **Step 5: Adopt complete snapshots serially before adding concurrency**
+
+Keep this task serial so request reduction and classification can be reviewed
+separately from scheduling. After discovery:
+
+```rust
+if discovery.candidates.is_empty() {
+    // Reuse the existing empty human/JSON branches, including stack_errors,
+    // and return Ok(()) without detecting or invoking a provider.
+}
+
+let provider = Provider::detect(&repo)?;
+provider.check_installed()?;
+
+for candidate in discovery.candidates {
+    let completion = match provider.get_inbox_snapshot(candidate.pr_number) {
+        Ok(snapshot) => InboxItem::from_snapshot(candidate, snapshot, provider),
+        Err(error) => InboxItem::from_refresh_error(candidate, error.to_string(), provider),
+    };
+    items.push(completion);
+}
+```
+
+Do not call `get_pr_info`, `get_pr_ci_status`, or `check_pr_approved` directly
+from `inbox.rs`. A refresh error remains included even without `--all`.
+Successful merged entries remain controlled by `--all`; closed entries remain
+excluded.
+
+- [ ] **Step 6: Add fake-provider request-count and failure integration tests**
+
+Add a local helper that writes an executable `gh` script and uses
+`run_gg_with_env` with an isolated `PATH`. The script must handle `--version`
+without counting it as a PR request:
+
+```rust
+fs::write(
+    fake_bin.join("gh"),
+    r#"#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "gh version test"
+  exit 0
+fi
+printf '%s\n' "$*" >> "$GG_FAKE_LOG"
+if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  printf '%s\n' '{"number":42,"title":"Inbox item","state":"OPEN","url":"https://github.com/acme/app/pull/42","headRefName":"testuser/inbox-copy/c-abc1234","isDraft":false,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS"}]}'
+  exit 0
+fi
+exit 1
+"#,
+)?;
+```
+
+Assert one candidate produces exactly one logged `pr view` line and lands in
+`ready_to_land`.
+
+Add a failing-script case and assert:
+
+- process exits zero
+- `buckets.refresh_failed` contains the entry
+- `refresh_error` is present
+- the entry does not appear in `awaiting_review`
+
+- [ ] **Step 7: Run inbox unit and integration tests**
+
+Run:
+
+```bash
+rtk cargo test -p gg-core --all-features commands::inbox
+rtk cargo test -p gg-core --all-features output::tests::inbox
+rtk cargo test -p gg-cli --all-features --test integration_tests inbox
+```
+
+Expected: all pass and the fake log contains one provider snapshot request per
+GitHub candidate.
+
+- [ ] **Step 8: Commit discovery and classification**
+
+```bash
+rtk cargo fmt --all
+rtk git add crates/gg-core/src/commands/inbox.rs crates/gg-core/src/output.rs crates/gg-cli/tests/integration_tests/inbox.rs
+rtk git commit -m "refactor(inbox): separate discovery from refresh"
+```
+
+---
+
+### Task 3: Refresh Candidates with Four Bounded Workers
+
+**Files:**
+- Create: `crates/gg-core/src/commands/inbox/refresh.rs`
+- Modify: `crates/gg-core/src/commands/inbox.rs:1-20,149-389`
+
+**Interfaces:**
+- Consumes: `InboxCandidate`, `InboxSnapshot`.
+- Produces:
+
+```rust
+pub(super) const MAX_INBOX_REFRESH_WORKERS: usize = 4;
+
+#[derive(Debug)]
+pub(super) struct InboxCompletion {
+    pub candidate: InboxCandidate,
+    pub result: std::result::Result<InboxSnapshot, String>,
+}
+
+pub(super) fn refresh_candidates<F, C>(
+    candidates: &[InboxCandidate],
+    refresh: F,
+    mut on_completion: C,
+)
+where
+    F: Fn(&InboxCandidate) -> std::result::Result<InboxSnapshot, String> + Sync,
+    C: FnMut(InboxCompletion);
+```
+
+- `refresh_candidates` calls the callback on its caller/coordinator thread, not
+  on worker threads.
+
+- [ ] **Step 1: Create failing bounded-concurrency tests**
+
+In `refresh.rs`, construct eight candidates and use atomics plus a four-party
+barrier:
+
+```rust
+#[test]
+fn refreshes_at_most_four_candidates_at_once() {
+    let active = AtomicUsize::new(0);
+    let maximum = AtomicUsize::new(0);
+    let first_wave = Barrier::new(4);
+    let candidates = candidates(8);
+
+    refresh_candidates(
+        &candidates,
+        |candidate| {
+            let now = active.fetch_add(1, Ordering::SeqCst) + 1;
+            maximum.fetch_max(now, Ordering::SeqCst);
+            if candidate.discovery_index < 4 {
+                first_wave.wait();
+            }
+            active.fetch_sub(1, Ordering::SeqCst);
+            Ok(snapshot())
+        },
+        |_| {},
+    );
+
+    assert_eq!(maximum.load(Ordering::SeqCst), 4);
+}
+```
+
+Add tests for zero candidates, fewer than four candidates, every candidate
+exactly once, and worker errors not canceling later candidates.
+
+- [ ] **Step 2: Add a failing completion-order test without sleeps**
+
+Use a `Condvar` so candidate zero waits until candidate one sets a flag:
+
+```rust
+#[test]
+fn reports_fast_later_candidate_before_blocked_first_candidate() {
+    let gate = (Mutex::new(false), Condvar::new());
+    let mut order = Vec::new();
+
+    refresh_candidates(
+        &candidates(2),
+        |candidate| {
+            if candidate.discovery_index == 0 {
+                let (lock, ready) = &gate;
+                let released = lock.lock().unwrap();
+                drop(ready.wait_while(released, |value| !*value).unwrap());
+            } else {
+                let (lock, ready) = &gate;
+                *lock.lock().unwrap() = true;
+                ready.notify_one();
+            }
+            Ok(snapshot())
+        },
+        |completion| order.push(completion.candidate.discovery_index),
+    );
+
+    assert_eq!(order, vec![1, 0]);
+}
+```
+
+- [ ] **Step 3: Run refresh tests and verify they fail**
+
+Run:
+
+```bash
+rtk cargo test -p gg-core --all-features commands::inbox::refresh::tests
+```
+
+Expected: compilation fails because the refresh module and scheduler do not
+exist.
+
+- [ ] **Step 4: Implement the scoped worker scheduler**
+
+Use `std::thread::scope`, an `AtomicUsize` next-index counter, and one
+`mpsc::channel`:
+
+```rust
+let worker_count = candidates.len().min(MAX_INBOX_REFRESH_WORKERS);
+if worker_count == 0 {
+    return;
+}
+
+thread::scope(|scope| {
+    let next = AtomicUsize::new(0);
+    let (sender, receiver) = mpsc::channel();
+
+    for _ in 0..worker_count {
+        let sender = sender.clone();
+        let next = &next;
+        let refresh = &refresh;
+        scope.spawn(move || loop {
+            let index = next.fetch_add(1, Ordering::Relaxed);
+            let Some(candidate) = candidates.get(index).cloned() else {
+                break;
+            };
+            let result = refresh(&candidate);
+            if sender.send(InboxCompletion { candidate, result }).is_err() {
+                break;
+            }
+        });
+    }
+
+    drop(sender);
+    for completion in receiver {
+        on_completion(completion);
+    }
+});
+```
+
+Do not spawn provider subprocesses outside this function and do not print from
+workers.
+
+- [ ] **Step 5: Integrate the scheduler into inbox coordination**
+
+Replace the serial snapshot loop with:
+
+```rust
+let mut completions: Vec<Option<InboxCompletion>> =
+    (0..discovery.candidates.len()).map(|_| None).collect();
+refresh_candidates(
+    &discovery.candidates,
+    |candidate| {
+        provider
+            .get_inbox_snapshot(candidate.pr_number)
+            .map_err(|error| error.to_string())
+    },
+    |completion| {
+        let index = completion.candidate.discovery_index;
+        completions[index] = Some(completion);
+    },
+);
+```
+
+Build final items by iterating `completions` in index order. Treat a missing
+slot as an internal `GgError::Other` rather than silently dropping a candidate.
+
+- [ ] **Step 6: Run concurrency and inbox regressions**
+
+Run:
+
+```bash
+rtk cargo test -p gg-core --all-features commands::inbox::refresh::tests
+rtk cargo test -p gg-core --all-features commands::inbox
+rtk cargo test -p gg-cli --all-features --test integration_tests inbox
+```
+
+Expected: all pass; the controlled order test reports `[1, 0]`, while atomic
+JSON remains in discovery order.
+
+- [ ] **Step 7: Commit bounded refresh**
+
+```bash
+rtk cargo fmt --all
+rtk git add crates/gg-core/src/commands/inbox.rs crates/gg-core/src/commands/inbox/refresh.rs
+rtk git commit -m "perf(inbox): refresh snapshots concurrently"
+```
+
+---
+
+### Task 4: Stream Inbox JSONL Events
+
+**Files:**
+- Modify: `crates/gg-core/src/output.rs:1-85,176-255,387-430,610-720`
+- Modify: `crates/gg-core/src/commands/inbox.rs:149-555`
+- Modify: `crates/gg-cli/src/main.rs:515-528,560-575,871-875,905-930`
+- Modify: `crates/gg-cli/tests/integration_tests/inbox.rs:1-243`
+
+**Interfaces:**
+- Consumes: completion callbacks from `refresh_candidates`.
+- Produces:
+
+```rust
+#[derive(Debug, Clone, Copy)]
+pub struct InboxOptions {
+    pub all: bool,
+    pub json: bool,
+    pub jsonl: bool,
+}
+
+pub struct InboxStreamingResponse {
+    pub version: u32,
+    pub command: String,
+    pub event: InboxStreamingEvent,
+}
+
+#[derive(Serialize)]
+pub struct InboxCandidateJson {
+    pub stack_name: String,
+    pub position: usize,
+    pub sha: String,
+    pub title: String,
+    pub pr_number: u64,
+    pub behind_base: Option<usize>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "snake_case", tag = "event")]
+pub enum InboxStreamingEvent {
+    Start { total_candidates: usize, total_stack_errors: usize },
+    StackError { stack_name: String, error: String },
+    Entry {
+        completed: usize,
+        total_candidates: usize,
+        included: bool,
+        bucket: Option<String>,
+        remote_state: String,
+        entry: InboxEntryJson,
+    },
+    EntryError {
+        completed: usize,
+        total_candidates: usize,
+        included: bool,
+        bucket: String,
+        entry: InboxCandidateJson,
+        error: String,
+    },
+    Summary {
+        total_items: usize,
+        buckets: InboxBucketsJson,
+        stack_errors: Vec<InboxStackErrorJson>,
+    },
+}
+```
+
+- `InboxStreamingResponse` serializes `version`, `command`, and the tagged event
+  into one flat object, matching `SyncStreamingResponse`.
+- `StreamingErrorResponse` is a generic flat fatal-error event used by both
+  sync and inbox in CLI dispatch.
+
+- [ ] **Step 1: Add failing streaming serialization tests**
+
+In `output.rs`, add tests that serialize start, included entry, excluded merged
+entry, entry error, and summary. Assert:
+
+```rust
+assert_eq!(json["version"], 1);
+assert_eq!(json["command"], "inbox");
+assert_eq!(json["event"], "entry");
+assert_eq!(json["included"], true);
+assert_eq!(json["bucket"], "ready_to_land");
+```
+
+For an excluded entry assert `included == false` and `bucket.is_null()`.
+For `EntryError`, assert `bucket == "refresh_failed"`.
+
+- [ ] **Step 2: Run serialization tests and verify they fail**
+
+Run:
+
+```bash
+rtk cargo test -p gg-core --all-features output::tests::inbox_streaming
+```
+
+Expected: compilation fails because inbox streaming types do not exist.
+
+- [ ] **Step 3: Implement inbox streaming and generic fatal-error envelopes**
+
+Implement `InboxStreamingResponse::serialize` using the same
+`serde_json::to_value` flattening pattern as sync.
+
+Add:
+
+```rust
+#[derive(Serialize)]
+pub struct StreamingErrorResponse<'a> {
+    pub version: u32,
+    pub command: &'a str,
+    pub status: &'static str,
+    pub event: &'static str,
+    pub message: String,
+}
+```
+
+Construct it with `status: "error"` and `event: "error"`. Replace the
+sync-specific fatal error object in `main.rs` with this generic envelope so
+inbox fatal errors report `command: "inbox"`.
+
+- [ ] **Step 4: Add the CLI flag and option object**
+
+Change the Clap variant to:
+
+```rust
+Inbox {
+    #[arg(short, long)]
+    all: bool,
+    #[arg(long)]
+    json: bool,
+    #[arg(long = "jsonl", conflicts_with = "json")]
+    jsonl: bool,
+}
+```
+
+Dispatch through `InboxOptions`. Track the active streaming command before the
+match result is handled:
+
+```rust
+let mut streaming_command: Option<&'static str> = None;
+```
+
+Set it to `Some("sync")` or `Some("inbox")` only when that command's `jsonl`
+flag is true. Use it to emit `StreamingErrorResponse` on a fatal `Err`.
+The inbox dispatch tuple is:
+
+```rust
+(
+    gg_core::commands::inbox::run(InboxOptions { all, json, jsonl }),
+    json || jsonl,
+    jsonl,
+)
+```
+
+- [ ] **Step 5: Emit lifecycle events from the coordinator**
+
+When `jsonl` is selected:
+
+1. Emit `Start` after discovery.
+2. Emit each `StackError` in discovery order.
+3. In the refresh completion callback, increment `completed` and emit `Entry`
+   or `EntryError` immediately.
+4. After collecting and sorting final items, emit `Summary` last.
+
+Every successful candidate emits `Entry`, including merged/closed candidates
+that will be excluded. Set:
+
+- merged without `--all`: `included: false`, `bucket: None`
+- closed: `included: false`, `bucket: None`
+- refresh failure: `included: true`, `bucket: "refresh_failed"`
+
+For an empty inbox, emit `Start` followed immediately by `Summary`.
+Suppress the static human refresh line in both structured modes.
+
+- [ ] **Step 6: Add JSONL CLI integration tests**
+
+Add tests for:
+
+- help contains `--jsonl`
+- `--json --jsonl` is rejected by Clap
+- empty inbox emits exactly `start`, `summary`
+- fake-provider success emits `start`, `entry`, `summary`
+- fake-provider failure emits `start`, `entry_error`, `summary` and exits zero
+- every line parses independently and stderr is empty
+- final summary matches an atomic `--json` run after removing the streaming
+  envelope fields
+
+Parse lines with:
+
+```rust
+let events: Vec<Value> = stdout
+    .lines()
+    .map(|line| serde_json::from_str(line).expect("every JSONL line must parse"))
+    .collect();
+```
+
+- [ ] **Step 7: Run streaming tests**
+
+Run:
+
+```bash
+rtk cargo test -p gg-core --all-features output::tests::inbox_streaming
+rtk cargo test -p gg-cli --all-features --test integration_tests inbox
+rtk cargo test -p gg-cli --all-features --test integration_tests sync::test_gg_sync_jsonl
+```
+
+Expected: all inbox JSONL tests pass and sync fatal-error compatibility remains
+green.
+
+- [ ] **Step 8: Commit streaming output**
+
+```bash
+rtk cargo fmt --all
+rtk git add crates/gg-core/src/output.rs crates/gg-core/src/commands/inbox.rs crates/gg-cli/src/main.rs crates/gg-cli/tests/integration_tests/inbox.rs
+rtk git commit -m "feat(inbox): stream refresh events"
+```
+
+---
+
+### Task 5: Render Stable Live Human Rows
+
+**Files:**
+- Create: `crates/gg-core/src/commands/inbox/render.rs`
+- Modify: `crates/gg-core/src/commands/inbox.rs:1-20,149-555`
+
+**Interfaces:**
+- Consumes: ordered candidates and `InboxCompletion` values.
+- Produces:
+
+```rust
+pub(super) enum InboxRowState<'a> {
+    Refreshing,
+    Bucket(ActionBucket),
+    MergedHidden,
+    ClosedHidden,
+    RefreshFailed(&'a str),
+}
+
+pub(super) struct LiveInboxRenderer {
+    // MultiProgress, one row per candidate, and one aggregate counter
+}
+
+impl LiveInboxRenderer {
+    pub fn stderr_if_interactive(
+        candidates: &[InboxCandidate],
+        provider_label: &str,
+    ) -> Option<Self>;
+
+    fn with_draw_target(
+        candidates: &[InboxCandidate],
+        provider_label: &str,
+        draw_target: ProgressDrawTarget,
+    ) -> Self;
+
+    pub fn update(&mut self, discovery_index: usize, state: InboxRowState<'_>);
+    pub fn finish_and_clear(&mut self);
+}
+
+pub(super) fn live_rendering_enabled(
+    stdout_is_terminal: bool,
+    stderr_is_terminal: bool,
+) -> bool;
+```
+
+- `Drop` clears a live renderer so provider-preflight and command-level errors
+  do not leave stale terminal rows.
+
+- [ ] **Step 1: Add failing TTY-gating and row-format tests**
+
+Test all four TTY combinations:
+
+```rust
+#[test]
+fn live_rendering_requires_both_output_streams_to_be_terminals() {
+    assert!(live_rendering_enabled(true, true));
+    assert!(!live_rendering_enabled(true, false));
+    assert!(!live_rendering_enabled(false, true));
+    assert!(!live_rendering_enabled(false, false));
+}
+```
+
+Add pure row-format assertions for:
+
+- `refreshing`
+- each final bucket label
+- `merged (hidden; use --all)`
+- `closed (hidden)`
+- `refresh failed`
+
+- [ ] **Step 2: Add a failing in-memory terminal stability test**
+
+Create a `RecordingTerm` implementing `indicatif::TermLike` and recording
+written strings behind `Arc<Mutex<Vec<String>>>`. Construct three rows with
+`with_draw_target`, update discovery index 1, then assert:
+
+- all three initial candidate labels were rendered
+- index 1 contains its new status
+- index 0 and index 2 retain their original identity/order
+- the aggregate message advances from `refreshed 0/3` to `refreshed 1/3`
+
+Clear the renderer and assert a terminal clear operation was recorded.
+
+- [ ] **Step 3: Run renderer tests and verify they fail**
+
+Run:
+
+```bash
+rtk cargo test -p gg-core --all-features commands::inbox::render::tests
+```
+
+Expected: compilation fails because the renderer module does not exist.
+
+- [ ] **Step 4: Implement stable `MultiProgress` rows**
+
+Use `MultiProgress::with_draw_target`, one spinner `ProgressBar` per candidate,
+and one aggregate progress bar. Add rows in discovery order and never remove or
+reinsert them.
+
+Use a row template equivalent to:
+
+```text
+{spinner:.green} {msg}
+```
+
+Format the message from immutable candidate identity plus the current status.
+Enable a 100 ms steady tick while a row is refreshing. Stop its spinner when
+the row reaches a completed state, but leave the row visible until the entire
+renderer clears.
+
+Use `std::io::IsTerminal` in `stderr_if_interactive`. Production draw target is
+`ProgressDrawTarget::stderr()`.
+
+- [ ] **Step 5: Wire live updates into the coordinator**
+
+Detect the provider after discovery, use it to obtain `mr_label`, create the
+renderer, and then check CLI availability. This puts the stable rows on screen
+before the `--version` subprocess while still keeping provider detection fatal:
+
+```rust
+let provider = Provider::detect(&repo)?;
+let mut renderer = if !options.json && !options.jsonl {
+    LiveInboxRenderer::stderr_if_interactive(
+        &discovery.candidates,
+        provider.pr_label(),
+    )
+} else {
+    None
+};
+provider.check_installed()?;
+```
+
+In the completion callback, compute the visible row state without changing
+final ordering:
+
+- successful included entry -> `Bucket(bucket)`
+- merged without `--all` -> `MergedHidden`
+- closed -> `ClosedHidden`
+- provider error -> `RefreshFailed(error)`
+
+Call `finish_and_clear` before printing the final grouped human inbox. Remove
+the old static `Refreshing ... done` stderr output. Non-TTY human mode performs
+no progress writes.
+
+- [ ] **Step 6: Run renderer and human-output regressions**
+
+Run:
+
+```bash
+rtk cargo test -p gg-core --all-features commands::inbox::render::tests
+rtk cargo test -p gg-core --all-features commands::inbox
+rtk cargo test -p gg-cli --all-features --test integration_tests inbox
+```
+
+Update the existing human provider-label tests: because `Command::output`
+creates non-TTY streams, they should assert clean final stdout and no static
+`Refreshing PR/MR status` stderr line while preserving `PR #N` and `MR !N`.
+
+- [ ] **Step 7: Commit live rendering**
+
+```bash
+rtk cargo fmt --all
+rtk git add crates/gg-core/src/commands/inbox.rs crates/gg-core/src/commands/inbox/render.rs crates/gg-cli/tests/integration_tests/inbox.rs
+rtk git commit -m "feat(inbox): render live refresh progress"
+```
+
+---
+
+### Task 6: Document, Validate, and Finish the Feature
+
+**Files:**
+- Modify: `README.md:183`
+- Modify: `docs/src/commands/inbox.md:1-132`
+- Modify: `docs/src/mcp-server.md:66-70`
+- Modify: `skills/gg/SKILL.md:45-58`
+- Modify: `skills/gg/references/setup-and-inspection.md:20-31`
+
+**Interfaces:**
+- Consumes: final CLI, JSON, JSONL, failure, and TTY contracts from Tasks 1-5.
+- Produces: human documentation and agent routing that exactly match the
+  implemented command.
+
+- [ ] **Step 1: Update the command documentation**
+
+Add these sections to `docs/src/commands/inbox.md`:
+
+- `Live refresh` with stable rows, the `refreshed N/M` counter, final clearing,
+  and final-only redirected output.
+- `Streaming NDJSON (--jsonl)` with exact start, stack-error, entry,
+  entry-error, summary, and fatal-error examples captured from tests.
+- `Partial failures` explaining exit zero plus inspection of
+  `refresh_failed`/`stack_errors`.
+- `--json vs --jsonl` selection guidance.
+- `refresh_failed` first in the bucket list.
+
+Update the flags list with:
+
+```text
+--jsonl: emit flushed NDJSON events as refreshes complete; conflicts with --json
+```
+
+- [ ] **Step 2: Update README and MCP documentation**
+
+Change the README command-table description to mention progressive refresh and
+streaming output without turning the table into a flag catalog.
+
+In `docs/src/mcp-server.md`, state that `stack_inbox` remains atomic and may
+return `refresh_failed` entries with `refresh_error`; MCP callers inspect those
+fields even when the tool call itself succeeds.
+
+- [ ] **Step 3: Update the agent skill**
+
+In `skills/gg/SKILL.md`, replace:
+
+```text
+Use JSON for decisions and JSONL for streaming sync.
+```
+
+with:
+
+```text
+Use JSON for final structured snapshots and JSONL when a supported long-running command must be monitored incrementally.
+```
+
+In `setup-and-inspection.md`, make step 5 explicit:
+
+```text
+Use `gg inbox --json` for one final cross-stack snapshot. Use
+`gg inbox --jsonl` when the caller benefits from results as each PR or MR
+refresh completes, and consume the final `summary` event before making a
+complete-inbox claim.
+```
+
+Do not copy the event schema into the skill.
+
+- [ ] **Step 4: Run focused documentation and contract validation**
+
+Run:
+
+```bash
+rtk mdbook build docs
+rtk skills-ref validate skills/gg
+rtk cargo test -p gg-cli --all-features --test skill_contract
+```
+
+Expected: mdBook builds, skill references validate, and the structural skill
+contract passes.
+
+- [ ] **Step 5: Run formatting and inspect the diff**
+
+Run:
+
+```bash
+rtk cargo fmt --all
+rtk git diff --check
+rtk git status --short
+rtk git diff --stat
+```
+
+Expected: no formatting or whitespace failures. Only intended inbox,
+provider, output, CLI, test, documentation, and skill files are modified.
+Do not stage `.superpowers/` visual-companion artifacts.
+
+- [ ] **Step 6: Run warning-free Clippy**
+
+Run:
+
+```bash
+rtk cargo clippy --all-targets --all-features -- -D warnings
+```
+
+Expected: exit zero with no warnings.
+
+- [ ] **Step 7: Run the complete test suite**
+
+Run:
+
+```bash
+rtk cargo test --all-features
+```
+
+Expected: all workspace tests pass.
+
+- [ ] **Step 8: Commit documentation and any final formatting**
+
+Review `rtk git diff` before staging, then:
+
+```bash
+rtk git add README.md docs/src/commands/inbox.md docs/src/mcp-server.md skills/gg/SKILL.md skills/gg/references/setup-and-inspection.md
+rtk git commit -m "docs(inbox): document progressive refresh"
+```
+
+`cargo fmt` should be a no-op because every Rust task formats before its commit.
+If it is not, stop and repair the task that left an unformatted Rust file
+before creating the documentation commit.
+
+- [ ] **Step 9: Verify the final committed tree**
+
+Run:
+
+```bash
+rtk git status --short
+rtk git log --oneline --decorate -8
+rtk git diff origin/main...HEAD --check
+```
+
+Expected: only `.superpowers/` companion artifacts may remain untracked; all
+feature and documentation changes are committed.
+
+---
+
+## Completion Criteria
+
+The implementation is complete only when all of the following are true:
+
+- Human TTY mode renders stable rows before provider refresh completes.
+- Human redirected output contains only the final grouped inbox.
+- GitHub performs one snapshot request per candidate.
+- GitLab performs one details request and one approval request per candidate.
+- No more than four candidates refresh concurrently.
+- `--json` remains atomic and deterministic.
+- `--jsonl` emits completion-order candidate events and a deterministic final
+  summary.
+- Partial and all-entry refresh failures exit zero and remain visible.
+- Fatal discovery/provider-preflight failures exit nonzero with the correct
+  structured error envelope.
+- MCP remains on atomic JSON.
+- Focused tests, mdBook, skill validation, format, Clippy, and all-feature tests
+  pass.

--- a/docs/superpowers/specs/2026-07-30-gg-inbox-progressive-refresh-design.md
+++ b/docs/superpowers/specs/2026-07-30-gg-inbox-progressive-refresh-design.md
@@ -1,0 +1,476 @@
+# Progressive `gg inbox` Refresh Design
+
+## Summary
+
+Make `gg inbox` useful immediately instead of waiting for every provider
+request to finish. Human mode will show stable rows as soon as local discovery
+completes and update each row as its remote state arrives. A new `--jsonl`
+mode will stream machine-readable completion events while preserving `--json`
+as the atomic final snapshot.
+
+The refresh path will also reduce redundant provider requests and process up to
+four PRs or MRs concurrently. The final inbox remains deterministic even though
+incremental results arrive in network completion order.
+
+## Problem
+
+The current implementation has two independent latency problems:
+
+1. Each PR or MR performs up to three provider calls for details, CI, and
+   approval.
+2. Entries and stacks are processed serially, and all results are buffered
+   before the command renders its inbox.
+
+Human mode prints only `Refreshing PR status...` or
+`Refreshing MR status...` during this work. `--json` emits nothing until the
+last request completes. A single slow provider call therefore delays every
+result for both people and automation.
+
+Some of the provider work is also redundant:
+
+- GitHub's existing PR-details response already contains the review decision,
+  while inbox performs a second approval request.
+- GitHub CI can be requested in the same `gh pr view --json` invocation.
+- GitLab's MR-details response is fetched separately for details and CI even
+  though both can be parsed from the same response.
+
+## Goals
+
+- Show the human inbox immediately after local candidate discovery.
+- Keep human rows stable while individual remote snapshots arrive.
+- Stream useful machine-readable results in completion order.
+- Preserve `gg inbox --json` as one deterministic aggregate document.
+- Reduce provider subprocess and request count.
+- Refresh at most four PRs or MRs concurrently.
+- Preserve useful results when one stack or provider refresh fails.
+- Keep the final grouped human inbox and existing bucket semantics.
+- Establish the same JSON-versus-JSONL convention used by `gg sync`.
+
+## Non-goals
+
+- Do not add persistent caching or stale-while-revalidate behavior.
+- Do not add a configurable concurrency flag or setting.
+- Do not build provider-wide GraphQL or paginated batch fetching.
+- Do not change the MCP transport to stream events.
+- Do not generalize the worker pool into a repository-wide job framework.
+- Do not migrate other commands to JSONL as part of this change.
+- Do not change which local stacks or entries `gg inbox` discovers.
+
+## User Experience
+
+### Interactive human mode
+
+Live rendering is enabled only for ordinary human mode when both stdout and
+stderr are terminals. The renderer writes its temporary display to stderr so
+stdout remains the home of the durable final inbox.
+
+Immediately after local discovery, the renderer shows:
+
+- one row for every locally known PR or MR candidate
+- stable stack and position ordering
+- `refreshing` as the initial state for each row
+- a `refreshed N/M` counter
+
+As a snapshot completes, only that row's status changes. Rows do not move into
+action buckets during refresh. This prevents the terminal from reordering
+content while the user is reading it.
+
+Successfully refreshed entries that will be omitted from the final inbox stay
+in place until the live display clears. Their temporary status reads
+`merged (hidden; use --all)` or `closed (hidden)` rather than disappearing and
+making the completion count look inconsistent.
+
+After all candidates complete, the live display clears and the existing
+grouped inbox is printed to stdout. The final display adds a
+`Refresh failed` group before the existing action groups.
+
+### Redirected and non-TTY output
+
+If either output stream is not a terminal, human mode does not create or repaint
+the live display. It prints only the final grouped inbox. For example,
+`gg inbox > report.txt` produces a clean report without progress output.
+
+### Empty inbox
+
+If local discovery finds no candidates, human mode skips the live display and
+prints the existing empty-inbox message immediately.
+
+## Architecture
+
+The command becomes a three-stage pipeline.
+
+### 1. Local discovery
+
+Local discovery resolves usernames, stack branches, bases, commits, configured
+PR or MR numbers, and behind-base counts. It produces:
+
+- an ordered `Vec<InboxCandidate>`
+- zero or more `StackLoadError` values
+
+`InboxCandidate` contains only immutable local identity and ordering data:
+
+- discovery index
+- stack name and position
+- commit SHA and title
+- PR or MR number
+- behind-base count
+
+Provider traffic does not begin until discovery is complete. This gives the
+human renderer a complete, stable set of rows before any row updates.
+
+If candidates exist, the coordinator detects the provider and checks that its
+CLI is installed once before starting workers. Failure of either preflight is a
+fatal command-level error because no candidate can be refreshed. The command
+does not add an authentication preflight request; authentication failures from
+an otherwise available provider CLI are handled as per-entry refresh errors.
+
+### 2. Bounded remote refresh
+
+`refresh_candidates` processes candidates with a fixed maximum of four worker
+threads. The worker count is `min(4, candidate_count)`.
+
+Workers receive immutable candidates and call
+`Provider::get_inbox_snapshot(number)`. They do not write stdout or stderr.
+Provider subprocess output is captured as it is today.
+
+Each completed worker sends an `InboxCompletion` to the coordinator. A
+completion contains either:
+
+- the candidate plus a complete `InboxSnapshot`, or
+- the candidate plus a provider refresh error
+
+The refresh function is injectable in tests so concurrency and ordering can be
+verified without real provider calls or timing-sensitive network behavior.
+
+### 3. Single coordinator
+
+The coordinator is the only owner of command output. It consumes completions
+in arrival order and:
+
+1. updates the corresponding stable live row, or emits one JSONL event
+2. records the completion by discovery index
+3. builds the final ordered item list after all candidates complete
+4. applies `--all` filtering
+5. prints or emits the deterministic final summary
+
+Network completion order therefore affects only progressive output. Final human
+and JSON output use discovery order within each action bucket.
+
+## Component Boundaries
+
+### `InboxCandidate`
+
+Represents a locally discovered PR or MR. It has no provider-derived state and
+can be rendered immediately.
+
+### `InboxSnapshot`
+
+Contains every remote field required for classification:
+
+- remote state
+- URL
+- approval
+- changes requested
+- mergeability
+- CI status
+
+An `InboxSnapshot` is complete or the refresh is an error. The command does not
+silently classify a partially refreshed entry.
+
+`CiStatus::Unknown` is a valid completed value and is not itself an error.
+
+### `refresh_candidates`
+
+Owns bounded scheduling only. It does not bucket, render, serialize, or mutate
+repository state.
+
+### `LiveInboxRenderer`
+
+Owns terminal rows, the completion counter, and clearing the temporary display.
+It receives candidates and completion states but does not perform provider work
+or classification.
+
+### Classification and serialization
+
+The existing pure bucketing and JSON-building functions remain responsible for
+the final model. A provider refresh error maps to the new
+`ActionBucket::RefreshFailed`, which has higher display priority than the
+existing buckets.
+
+## Provider Snapshots
+
+### GitHub
+
+GitHub uses one `gh pr view <number> --json ...` request per candidate. The
+requested fields cover:
+
+- number, title, state, URL, and head branch
+- draft state
+- mergeability
+- review decision
+- status-check rollup
+
+The response is parsed once into `InboxSnapshot`. The inbox path no longer
+calls `check_pr_approved` or `get_pr_ci_status` separately.
+
+### GitLab
+
+GitLab uses one `glab mr view <number> --output json` response for MR details
+and CI. Pipeline status is parsed from the typed response instead of scanning
+the raw JSON text.
+
+GitLab then performs its approvals API request because approval is not
+available in the MR-details response used by the current integration. Failure
+of either call makes that candidate a refresh error. This avoids confidently
+classifying an MR from incomplete review state.
+
+### Future batching
+
+The snapshot boundary permits later provider-wide batching without changing
+the worker/coordinator or output contracts. Provider-wide GraphQL and list API
+work is intentionally deferred until measurements show that per-entry
+snapshots remain insufficient.
+
+## Human Classification and Filtering
+
+Final bucket order is:
+
+1. `refresh_failed`
+2. `ready_to_land`
+3. `changes_requested`
+4. `blocked_on_ci`
+5. `awaiting_review`
+6. `behind_base`
+7. `draft`
+8. `merged`
+
+The existing first-match classification rules remain unchanged for successful
+snapshots. A failed refresh is classified before remote-state rules because its
+state cannot be trusted.
+
+`--all` continues to control inclusion of successfully refreshed merged
+entries. Closed entries remain excluded. A refresh failure remains visible
+regardless of `--all` because the command cannot safely infer whether it should
+be hidden.
+
+## Structured Output
+
+### Atomic JSON
+
+`gg inbox --json` remains one pretty-printed JSON document emitted only after
+refresh completes. Existing top-level fields remain:
+
+- `version`
+- `total_items`
+- `buckets`
+- `stack_errors`
+
+The schema gains:
+
+- `buckets.refresh_failed`
+- optional `refresh_error` on an inbox entry
+
+Successful entries omit `refresh_error`. `total_items` continues to mean items
+included in the final inbox after state and `--all` filtering.
+
+### Streaming JSONL
+
+`gg inbox --jsonl` conflicts with `--json`. It suppresses human/progress output
+and emits compact NDJSON on stdout, flushing after every event. Every event
+contains:
+
+- `version: 1`
+- `command: "inbox"`
+- `event`
+
+The event sequence begins with `start` and, for every non-fatal run, ends with
+`summary`.
+
+#### `start`
+
+Emitted after local discovery and before remote refresh:
+
+```json
+{"version":1,"command":"inbox","event":"start","total_candidates":5,"total_stack_errors":1}
+```
+
+#### `stack_error`
+
+Emitted once for every stack error discovered locally:
+
+```json
+{"version":1,"command":"inbox","event":"stack_error","stack_name":"legacy","error":"base branch not found"}
+```
+
+Stack errors are emitted immediately after `start` in deterministic discovery
+order.
+
+#### `entry`
+
+Emitted when a provider snapshot completes successfully:
+
+```json
+{"version":1,"command":"inbox","event":"entry","completed":1,"total_candidates":5,"included":true,"bucket":"ready_to_land","remote_state":"open","entry":{"stack_name":"auth","position":1,"sha":"abc1234","title":"Add login","pr_number":42,"pr_url":"https://github.com/org/repo/pull/42","ci_status":"success","behind_base":null}}
+```
+
+Every successful candidate emits an `entry` event. A merged entry without
+`--all`, or a closed entry, uses `included: false` and `bucket: null`. This
+keeps completion accounting exact without implying that the entry appears in
+the final inbox.
+
+#### `entry_error`
+
+Emitted when a provider snapshot fails:
+
+```json
+{"version":1,"command":"inbox","event":"entry_error","completed":2,"total_candidates":5,"included":true,"bucket":"refresh_failed","entry":{"stack_name":"docs","position":1,"sha":"def5678","title":"Document login","pr_number":43,"behind_base":null},"error":"failed to refresh PR #43"}
+```
+
+Entry and entry-error events are intentionally emitted in network completion
+order. `completed` is monotonic and reaches `total_candidates`.
+
+#### `summary`
+
+Emitted last after every candidate has completed:
+
+```json
+{"version":1,"command":"inbox","event":"summary","total_items":2,"buckets":{"refresh_failed":[],"ready_to_land":[],"changes_requested":[],"blocked_on_ci":[],"awaiting_review":[],"behind_base":[],"draft":[]},"stack_errors":[]}
+```
+
+The summary fields after the streaming envelope match the atomic `--json`
+payload. Bucket entries use deterministic discovery order.
+
+#### `error`
+
+A command-level failure that prevents a useful summary emits an `error` event
+and exits nonzero:
+
+```json
+{"version":1,"command":"inbox","event":"error","message":"not a git repository"}
+```
+
+The existing streaming writer behavior applies: a broken pipe stops the
+producer promptly.
+
+## Error and Exit Semantics
+
+- Repository or configuration errors that prevent local discovery are fatal.
+- Provider detection failure or a missing provider CLI is fatal when candidates
+  exist.
+- A broken stack becomes `stack_error`; other stacks continue.
+- A provider failure becomes an `entry_error` and a final
+  `refresh_failed` item; other entries continue.
+- Partial refresh failure exits zero after emitting a summary.
+- If every provider refresh fails, the command still exits zero with all
+  candidates in `refresh_failed`.
+- Process success means the inbox operation completed, not that every remote
+  refresh succeeded. Structured consumers inspect `refresh_failed` and
+  `stack_errors`.
+- JSON and JSONL modes emit no human progress output.
+
+## Determinism
+
+The following are deterministic:
+
+- local candidate discovery order
+- stack-error event order
+- order within final buckets
+- atomic JSON
+- final JSONL summary
+
+Only per-candidate `entry` and `entry_error` event order is nondeterministic.
+This is required to avoid head-of-line blocking behind a slow earlier entry.
+
+## Testing
+
+### Unit tests
+
+- Preserve all existing successful bucketing cases.
+- Verify refresh failures map to the highest-priority bucket.
+- Parse GitHub review, mergeability, and CI from one snapshot response.
+- Parse GitLab details and pipeline status from one typed MR response.
+- Treat GitLab approval failure as snapshot failure.
+- Verify atomic JSON omits `refresh_error` for successful entries.
+- Verify deterministic final ordering from out-of-order completions.
+
+### Concurrency tests
+
+Use injected refresh functions plus channels and barriers to verify:
+
+- no more than four refreshes run simultaneously
+- all candidates are processed
+- a fast later candidate completes before a blocked earlier candidate
+- worker errors do not stop remaining work
+
+Avoid wall-clock performance assertions and long sleeps.
+
+### Rendering tests
+
+Use an in-memory `indicatif::TermLike`, following the existing sync progress
+tests, to verify:
+
+- all candidate rows appear before refresh begins
+- completing one candidate updates only its stable row
+- the counter advances correctly
+- the live display clears before final output
+- non-TTY mode creates no live renderer
+
+### JSONL tests
+
+- `--jsonl` appears in help and conflicts with `--json`.
+- Every line is valid JSON and flushed independently.
+- `start` is first and `summary` is last for successful, partial, all-failed,
+  and empty runs.
+- Stack errors follow `start` deterministically.
+- Entry events follow controlled completion order.
+- Hidden merged and closed candidates report `included: false`.
+- Fatal errors emit an `error` event and no human stderr output.
+
+### Integration and regression tests
+
+Use fake provider executables to verify provider invocation count and the full
+CLI path without network access:
+
+- GitHub performs one details/CI/review request per candidate.
+- GitLab reuses one MR-details response and performs one approval request.
+- Existing atomic JSON fixtures continue to parse with additive fields.
+- Human GitHub `PR #N` and GitLab `MR !N` labels remain provider-specific.
+
+## Documentation
+
+Update:
+
+- `docs/src/commands/inbox.md` with live behavior, `--jsonl`, event schemas,
+  partial-success semantics, and `refresh_failed`
+- CLI help for `--jsonl`
+- the README command summary
+- `docs/src/mcp-server.md` for the additive atomic JSON bucket and error field
+- `skills/gg/SKILL.md` so JSONL applies to supported streaming commands rather
+  than sync alone
+- `skills/gg/references/setup-and-inspection.md` so agents select `--json` for
+  a final inbox snapshot and `--jsonl` when incremental results matter
+
+The MCP `stack_inbox` tool continues to invoke `gg inbox --json`.
+
+## Verification
+
+Before publication:
+
+```bash
+cargo fmt --all
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-features
+mdbook build docs
+skills-ref validate skills/gg
+```
+
+Also run the focused inbox, provider-parser, streaming-output, and skill
+contract tests during implementation.
+
+## Rollout and Compatibility
+
+`--jsonl` and the new JSON fields are additive. Existing `--json` callers keep
+receiving one complete document. Human redirected output remains final-only.
+The MCP tool retains its atomic response contract.
+
+No migration or configuration change is required.

--- a/skills/gg/SKILL.md
+++ b/skills/gg/SKILL.md
@@ -45,7 +45,7 @@ an error or interrupted state.
 ## Shared execution contract
 
 - Use `gg <command> --help` for installed flags.
-- Use JSON for decisions and JSONL for streaming sync.
+- Use JSON for final structured snapshots and JSONL when a supported long-running command must be monitored incrementally.
 - Prefer worktrees for newly created stacks.
 - Stage explicit reviewed files; never blindly stage all files.
 - Surface `ImmutableTargets` before requesting an override.

--- a/skills/gg/references/setup-and-inspection.md
+++ b/skills/gg/references/setup-and-inspection.md
@@ -23,7 +23,10 @@
    explicit effective `defaults.provider` wins, otherwise gg detects GitHub or
    GitLab from the remote URL.
 5. Match the stack scope with `gg ls --json`, `gg log --json`, or
-   `gg inbox --json`.
+   `gg inbox --json`. Use `gg inbox --json` for one final cross-stack snapshot.
+   Use `gg inbox --jsonl` when the caller benefits from results as each PR or MR
+   refresh completes, and consume the final `summary` event before making a
+   complete-inbox claim.
 6. Before reporting behind-base state, fetch the configured base when it is
    remote-backed and compare the stack tip with the fetched remote base:
    `git merge-base --is-ancestor origin/<base> <stack-tip>`. Do not rely on


### PR DESCRIPTION
## Summary
- show progressive terminal refresh rows only in an interactive terminal
- add completion-order JSONL inbox events while preserving atomic JSON output
- consolidate provider snapshots and bound refresh concurrency to four workers

## Verification
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-features