### PR TITLE
feat(sync): integrate native GitHub Stacks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1197,6 +1197,7 @@ dependencies = [
  "indicatif",
  "ratatui",
  "regex",
+ "semver",
  "serde",
  "serde_json",
  "skim",

--- a/README.md
+++ b/README.md
@@ -46,6 +46,31 @@ gh auth login
 glab auth login
 ```
 
+## GitHub Stacked PRs (public preview)
+
+On supported GitHub repositories, a full `gg sync` can also reconcile the
+native GitHub Stacked PRs map and UI. This is a GitHub public preview; git-gud
+continues to own its local stack metadata and ordinary GitHub sync works
+without the optional extension.
+
+Install GitHub's official extension when you want this integration:
+
+```sh
+gh extension install github/gh-stack
+```
+
+Configure `defaults.github.stacks_integration` in `.git/gg/config.json` or
+your global config:
+
+| Value | Behavior |
+|---|---|
+| `off` | Never inspect or update GitHub Stacked PRs. |
+| `auto` | Best-effort integration when the extension and repository support are available. |
+| `force` | Uses the same safe integration as `auto`, but makes missing capabilities visible as warnings. |
+
+The default is `auto`. `force` does not bypass extension-version, repository,
+or create/append-only safety checks.
+
 ## Quick Start
 
 ```bash

--- a/crates/gg-cli/tests/integration_tests/github_stacks.rs
+++ b/crates/gg-cli/tests/integration_tests/github_stacks.rs
@@ -9,6 +9,7 @@ use std::path::{Path, PathBuf};
 use std::os::unix::fs::PermissionsExt;
 
 struct GithubStackFixture {
+    _temp_dir: tempfile::TempDir,
     repo_path: PathBuf,
     fake_log: PathBuf,
     path_env: OsString,
@@ -48,8 +49,7 @@ impl GithubStackFixture {
 }
 
 fn setup_fixture(mode: &str) -> GithubStackFixture {
-    let (_temp_dir, repo_path, _remote_path) = create_test_repo_with_remote();
-    std::mem::forget(_temp_dir);
+    let (temp_dir, repo_path, _remote_path) = create_test_repo_with_remote();
 
     let gg_dir = repo_path.join(".git/gg");
     fs::create_dir_all(&gg_dir).expect("failed to create gg dir");
@@ -128,6 +128,7 @@ fn setup_fixture(mode: &str) -> GithubStackFixture {
     path_env.push(old_path);
 
     GithubStackFixture {
+        _temp_dir: temp_dir,
         repo_path,
         fake_log,
         path_env,
@@ -151,6 +152,10 @@ if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
 fi
 
 if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  if [ "$3" = "42" ] && [ -n "${GG_FAKE_PR_VIEW_42_FAIL:-}" ]; then
+    echo "failed to view PR #42" >&2
+    exit 1
+  fi
   case "$3" in
     41)
       echo '{"number":41,"title":"Entry one","state":"OPEN","url":"https://github.com/test/repo/pull/41","headRefName":"testuser/native-stack--c-1111111","isDraft":false,"mergeable":"MERGEABLE","reviews":[]}'
@@ -350,6 +355,20 @@ fn sync_off_reports_disabled_without_stack_command() {
     let value: Value = serde_json::from_str(&stdout).expect("sync should emit JSON");
     assert_eq!(value["sync"]["github_stack"]["reason"], "disabled");
     assert!(!fixture.log().contains("stack --version"));
+}
+
+#[test]
+fn sync_unresolved_pr_state_skips_without_stack_command() {
+    let fixture = setup_fixture("auto");
+    let (success, stdout, stderr) =
+        run_sync_json(&fixture, &[("GG_FAKE_PR_VIEW_42_FAIL", OsStr::new("1"))]);
+    assert!(success, "sync failed\nstdout:{stdout}\nstderr:{stderr}");
+    let value: Value = serde_json::from_str(&stdout).expect("sync should emit JSON");
+    assert_eq!(value["sync"]["github_stack"]["action"], "skipped");
+    assert_eq!(value["sync"]["github_stack"]["reason"], "unresolved_prs");
+    let log = fixture.log();
+    assert!(!log.contains("stack --version"));
+    assert!(!log.contains("/stacks"));
 }
 
 #[test]

--- a/crates/gg-cli/tests/integration_tests/github_stacks.rs
+++ b/crates/gg-cli/tests/integration_tests/github_stacks.rs
@@ -1,0 +1,455 @@
+use crate::helpers::{create_test_repo_with_remote, run_gg, run_gg_with_env, run_git};
+
+use serde_json::Value;
+use std::ffi::{OsStr, OsString};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+struct GithubStackFixture {
+    repo_path: PathBuf,
+    fake_log: PathBuf,
+    path_env: OsString,
+}
+
+impl GithubStackFixture {
+    fn env(&self) -> Vec<(&str, &OsStr)> {
+        vec![
+            ("PATH", self.path_env.as_os_str()),
+            ("GG_FAKE_GH_LOG", self.fake_log.as_os_str()),
+        ]
+    }
+
+    fn log(&self) -> String {
+        fs::read_to_string(&self.fake_log).unwrap_or_default()
+    }
+
+    fn set_stack_response(&self, name: &str, json: &str) -> PathBuf {
+        let path = self.repo_path.join(name);
+        fs::write(&path, json).expect("failed to write fake stack response");
+        path
+    }
+
+    fn set_link_failure(&self, message: &str) -> PathBuf {
+        let path = self.repo_path.join("fake-link-failure");
+        fs::write(&path, message).expect("failed to write fake link failure");
+        path
+    }
+}
+
+fn setup_fixture(mode: &str) -> GithubStackFixture {
+    let (_temp_dir, repo_path, _remote_path) = create_test_repo_with_remote();
+    std::mem::forget(_temp_dir);
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("failed to create gg dir");
+
+    fs::write(
+        gg_dir.join("config.json"),
+        format!(
+            r#"{{
+  "defaults": {{
+    "branch_username": "testuser",
+    "provider": "github",
+    "base": "main",
+    "sync_behind_threshold": 0,
+    "github": {{ "stacks_integration": "{mode}" }}
+  }}
+}}"#
+        ),
+    )
+    .expect("failed to write config");
+
+    let (success, _, stderr) = run_gg(&repo_path, &["co", "native-stack"]);
+    assert!(success, "failed to create stack: {stderr}");
+
+    fs::write(repo_path.join("one.txt"), "one\n").expect("failed to write one");
+    run_git(&repo_path, &["add", "one.txt"]);
+    run_git(
+        &repo_path,
+        &["commit", "-m", "Entry one\n\nGG-ID: c-1111111"],
+    );
+
+    fs::write(repo_path.join("two.txt"), "two\n").expect("failed to write two");
+    run_git(&repo_path, &["add", "two.txt"]);
+    run_git(
+        &repo_path,
+        &[
+            "commit",
+            "-m",
+            "Entry two\n\nGG-ID: c-2222222\nGG-Parent: c-1111111",
+        ],
+    );
+
+    fs::write(
+        gg_dir.join("config.json"),
+        format!(
+            r#"{{
+  "defaults": {{
+    "branch_username": "testuser",
+    "provider": "github",
+    "base": "main",
+    "sync_behind_threshold": 0,
+    "github": {{ "stacks_integration": "{mode}" }}
+  }},
+  "stacks": {{
+    "native-stack": {{
+      "base": "main",
+      "mrs": {{
+        "c-1111111": 41,
+        "c-2222222": 42
+      }}
+    }}
+  }}
+}}"#
+        ),
+    )
+    .expect("failed to write mapped config");
+
+    let fake_bin = repo_path.join("fake-bin");
+    fs::create_dir_all(&fake_bin).expect("failed to create fake-bin");
+    let fake_log = repo_path.join("fake-gh.log");
+    fs::write(&fake_log, "").expect("failed to create fake log");
+    write_fake_gh(&fake_bin.join("gh"));
+
+    let old_path = std::env::var_os("PATH").unwrap_or_default();
+    let mut path_env = OsString::from(fake_bin.as_os_str());
+    path_env.push(":");
+    path_env.push(old_path);
+
+    GithubStackFixture {
+        repo_path,
+        fake_log,
+        path_env,
+    }
+}
+
+fn write_fake_gh(path: &Path) {
+    fs::write(
+        path,
+        r#"#!/bin/sh
+set -eu
+echo "$@" >> "$GG_FAKE_GH_LOG"
+
+if [ "$1" = "--version" ]; then
+  echo "gh version 2.97.0"
+  exit 0
+fi
+
+if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
+  exit 0
+fi
+
+if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  case "$3" in
+    41)
+      echo '{"number":41,"title":"Entry one","state":"OPEN","url":"https://github.com/test/repo/pull/41","headRefName":"testuser/native-stack--c-1111111","isDraft":false,"mergeable":"MERGEABLE","reviews":[]}'
+      exit 0
+      ;;
+    42)
+      echo '{"number":42,"title":"Entry two","state":"OPEN","url":"https://github.com/test/repo/pull/42","headRefName":"testuser/native-stack--c-2222222","isDraft":false,"mergeable":"MERGEABLE","reviews":[]}'
+      exit 0
+      ;;
+  esac
+fi
+
+if [ "$1" = "pr" ] && [ "$2" = "edit" ]; then
+  exit 0
+fi
+
+if [ "$1" = "api" ] && printf '%s' "$2" | grep -q '/issues/'; then
+  echo '[]'
+  exit 0
+fi
+
+if [ "$1" = "api" ] && printf '%s' "$2" | grep -q '/stacks?pull_request='; then
+  if [ -n "${GG_FAKE_STACK_404:-}" ]; then
+    echo 'gh: HTTP 404: Not Found' >&2
+    exit 1
+  fi
+  if [ "$2" = "repos/{owner}/{repo}/stacks?pull_request=41" ] && [ -n "${GG_FAKE_STACK_AFTER_41:-}" ] && [ -f "${GG_FAKE_STACK_AFTER_41}" ] && [ -n "${GG_FAKE_LINKED_FILE:-}" ] && [ -f "${GG_FAKE_LINKED_FILE}" ]; then
+    cat "${GG_FAKE_STACK_AFTER_41}"
+    exit 0
+  fi
+  if [ -n "${GG_FAKE_STACK_RESPONSE:-}" ] && [ -f "${GG_FAKE_STACK_RESPONSE}" ]; then
+    cat "${GG_FAKE_STACK_RESPONSE}"
+    exit 0
+  fi
+  echo '[]'
+  exit 0
+fi
+
+if [ "$1" = "stack" ] && [ "$2" = "--version" ]; then
+  if [ -n "${GG_FAKE_STACK_VERSION_EXIT:-}" ]; then
+    exit "$GG_FAKE_STACK_VERSION_EXIT"
+  fi
+  echo "gh stack version ${GG_FAKE_STACK_VERSION:-0.1.0}"
+  exit 0
+fi
+
+if [ "$1" = "stack" ] && [ "$2" = "link" ]; then
+  if [ -n "${GG_FAKE_LINK_FAILURE:-}" ]; then
+    cat "${GG_FAKE_LINK_FAILURE}" >&2
+    exit 1
+  fi
+  if [ -n "${GG_FAKE_LINKED_FILE:-}" ]; then
+    echo linked > "${GG_FAKE_LINKED_FILE}"
+  fi
+  exit 0
+fi
+
+echo "unexpected gh invocation: $@" >&2
+exit 1
+"#,
+    )
+    .expect("failed to write fake gh");
+
+    #[cfg(unix)]
+    {
+        let mut perms = fs::metadata(path)
+            .expect("failed to stat fake gh")
+            .permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(path, perms).expect("failed to chmod fake gh");
+    }
+}
+
+fn stack_created_json() -> &'static str {
+    r#"[{"number":7,"pull_requests":[
+{"number":41,"state":"open","draft":false,"merged_at":null},
+{"number":42,"state":"open","draft":false,"merged_at":null}
+]}]"#
+}
+
+fn stack_prefix_json() -> &'static str {
+    r#"[{"number":7,"pull_requests":[
+{"number":40,"state":"closed","draft":false,"merged_at":"2026-07-01T00:00:00Z"},
+{"number":41,"state":"open","draft":false,"merged_at":null}
+]}]"#
+}
+
+fn stack_diverged_json() -> &'static str {
+    r#"[{"number":7,"pull_requests":[
+{"number":42,"state":"open","draft":false,"merged_at":null},
+{"number":41,"state":"open","draft":false,"merged_at":null}
+]}]"#
+}
+
+fn run_sync_json(
+    fixture: &GithubStackFixture,
+    extra_env: &[(&str, &OsStr)],
+) -> (bool, String, String) {
+    let mut env = fixture.env();
+    env.extend_from_slice(extra_env);
+    run_gg_with_env(
+        &fixture.repo_path,
+        &["sync", "--json", "--no-rebase-check"],
+        &env,
+    )
+}
+
+#[test]
+fn sync_json_creates_native_stack_with_exact_pr_order() {
+    let fixture = setup_fixture("auto");
+    let after = fixture.set_stack_response("stack-after.json", stack_created_json());
+    let linked = fixture.repo_path.join("fake-linked");
+    let (success, stdout, stderr) = run_sync_json(
+        &fixture,
+        &[
+            ("GG_FAKE_STACK_AFTER_41", after.as_os_str()),
+            ("GG_FAKE_LINKED_FILE", linked.as_os_str()),
+        ],
+    );
+    assert!(success, "sync failed\nstdout:{stdout}\nstderr:{stderr}");
+    assert!(stderr.trim().is_empty(), "stderr should be empty: {stderr}");
+
+    let value: Value = serde_json::from_str(&stdout).expect("sync should emit JSON");
+    let stack = &value["sync"]["github_stack"];
+    assert_eq!(stack["action"], "created");
+    assert_eq!(stack["stack_number"], 7);
+    assert_eq!(stack["pr_numbers"], serde_json::json!([41, 42]));
+    assert!(fixture.log().contains("stack link --base main 41 42"));
+}
+
+#[test]
+fn sync_jsonl_appends_after_merged_prefix_and_repeats_result_in_summary() {
+    let fixture = setup_fixture("auto");
+    let prefix = fixture.set_stack_response("stack-prefix.json", stack_prefix_json());
+    let mut env = fixture.env();
+    env.push(("GG_FAKE_STACK_RESPONSE", prefix.as_os_str()));
+    let (success, stdout, stderr) = run_gg_with_env(
+        &fixture.repo_path,
+        &["sync", "--jsonl", "--no-rebase-check"],
+        &env,
+    );
+    assert!(success, "sync failed\nstdout:{stdout}\nstderr:{stderr}");
+    assert!(stderr.trim().is_empty(), "stderr should be empty: {stderr}");
+
+    let events: Vec<Value> = stdout
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("every JSONL line must parse"))
+        .collect();
+    let github_event_index = events
+        .iter()
+        .position(|event| event["event"] == "github_stack")
+        .expect("github_stack event should be emitted");
+    let summary_index = events
+        .iter()
+        .position(|event| event["event"] == "summary")
+        .expect("summary should be emitted");
+    assert!(github_event_index < summary_index);
+    assert_eq!(events[github_event_index]["action"], "appended");
+    assert_eq!(events[github_event_index]["stack_number"], 7);
+    assert_eq!(
+        events[summary_index]["github_stack"]["action"],
+        events[github_event_index]["action"]
+    );
+    assert_eq!(
+        events[summary_index]["github_stack"]["stack_number"],
+        events[github_event_index]["stack_number"]
+    );
+    assert_eq!(
+        events[summary_index]["github_stack"]["pr_numbers"],
+        events[github_event_index]["pr_numbers"]
+    );
+    assert!(fixture.log().contains("stack link 7 42"));
+}
+
+#[test]
+fn sync_until_reports_partial_skip_without_stack_command() {
+    let fixture = setup_fixture("auto");
+    let env = fixture.env();
+    let (success, stdout, stderr) = run_gg_with_env(
+        &fixture.repo_path,
+        &["sync", "--json", "--until", "1", "--no-rebase-check"],
+        &env,
+    );
+    assert!(success, "sync failed\nstdout:{stdout}\nstderr:{stderr}");
+    let value: Value = serde_json::from_str(&stdout).expect("sync should emit JSON");
+    assert_eq!(value["sync"]["github_stack"]["reason"], "partial_sync");
+    let log = fixture.log();
+    assert!(!log.contains("stack --version"));
+    assert!(!log.contains("/stacks"));
+}
+
+#[test]
+fn sync_off_reports_disabled_without_stack_command() {
+    let fixture = setup_fixture("off");
+    let (success, stdout, stderr) = run_sync_json(&fixture, &[]);
+    assert!(success, "sync failed\nstdout:{stdout}\nstderr:{stderr}");
+    let value: Value = serde_json::from_str(&stdout).expect("sync should emit JSON");
+    assert_eq!(value["sync"]["github_stack"]["reason"], "disabled");
+    assert!(!fixture.log().contains("stack --version"));
+}
+
+#[test]
+fn sync_auto_missing_extension_is_silent_and_non_fatal() {
+    let fixture = setup_fixture("auto");
+    let (success, stdout, stderr) =
+        run_sync_json(&fixture, &[("GG_FAKE_STACK_VERSION_EXIT", OsStr::new("1"))]);
+    assert!(success, "sync failed\nstdout:{stdout}\nstderr:{stderr}");
+    assert!(stderr.trim().is_empty(), "stderr should be empty: {stderr}");
+    let value: Value = serde_json::from_str(&stdout).expect("sync should emit JSON");
+    assert_eq!(value["sync"]["github_stack"]["action"], "skipped");
+    assert_eq!(value["sync"]["github_stack"]["reason"], "missing_extension");
+    assert_eq!(value["sync"]["warnings"], serde_json::json!([]));
+}
+
+#[test]
+fn sync_force_missing_extension_is_warning_and_non_fatal() {
+    let fixture = setup_fixture("force");
+    let (success, stdout, stderr) =
+        run_sync_json(&fixture, &[("GG_FAKE_STACK_VERSION_EXIT", OsStr::new("1"))]);
+    assert!(success, "sync failed\nstdout:{stdout}\nstderr:{stderr}");
+    let value: Value = serde_json::from_str(&stdout).expect("sync should emit JSON");
+    assert_eq!(value["sync"]["github_stack"]["action"], "warning");
+    assert_eq!(value["sync"]["github_stack"]["reason"], "missing_extension");
+    assert!(value["sync"]["warnings"].as_array().unwrap().len() == 1);
+}
+
+#[test]
+fn sync_divergence_warns_without_link() {
+    let fixture = setup_fixture("auto");
+    let diverged = fixture.set_stack_response("stack-diverged.json", stack_diverged_json());
+    let (success, stdout, stderr) = run_sync_json(
+        &fixture,
+        &[("GG_FAKE_STACK_RESPONSE", diverged.as_os_str())],
+    );
+    assert!(success, "sync failed\nstdout:{stdout}\nstderr:{stderr}");
+    let value: Value = serde_json::from_str(&stdout).expect("sync should emit JSON");
+    assert_eq!(value["sync"]["github_stack"]["action"], "warning");
+    assert_eq!(value["sync"]["github_stack"]["reason"], "diverged");
+    assert!(!fixture.log().contains("stack link"));
+}
+
+#[test]
+fn sync_link_failure_warns_without_corrupting_json() {
+    let fixture = setup_fixture("auto");
+    let link_failure = fixture.set_link_failure("link failed");
+    let (success, stdout, stderr) = run_sync_json(
+        &fixture,
+        &[("GG_FAKE_LINK_FAILURE", link_failure.as_os_str())],
+    );
+    assert!(success, "sync failed\nstdout:{stdout}\nstderr:{stderr}");
+    let value: Value = serde_json::from_str(&stdout).expect("sync should remain one JSON document");
+    assert_eq!(value["sync"]["github_stack"]["action"], "warning");
+    assert_eq!(value["sync"]["github_stack"]["reason"], "backend_failed");
+    assert_eq!(value["sync"]["github_stack"]["message"], "link failed");
+}
+
+#[test]
+fn sync_gitlab_never_invokes_or_serializes_github_stacks() {
+    let (_temp_dir, repo_path, _remote_path) = create_test_repo_with_remote();
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser","provider":"gitlab","base":"main","sync_behind_threshold":0}}"#,
+    )
+    .expect("failed to write config");
+    let (success, _, stderr) = run_gg(&repo_path, &["co", "gitlab-stack"]);
+    assert!(success, "failed to create stack: {stderr}");
+    fs::write(repo_path.join("one.txt"), "one\n").expect("failed to write one");
+    run_git(&repo_path, &["add", "one.txt"]);
+    run_git(
+        &repo_path,
+        &["commit", "-m", "Entry one\n\nGG-ID: c-1111111"],
+    );
+
+    let fake_bin = repo_path.join("fake-bin");
+    fs::create_dir_all(&fake_bin).expect("failed to create fake-bin");
+    fs::write(
+        fake_bin.join("glab"),
+        r#"#!/bin/sh
+set -eu
+if [ "$1" = "--version" ]; then echo "glab version 1.0.0"; exit 0; fi
+if [ "$1" = "auth" ] && [ "$2" = "status" ]; then exit 0; fi
+if [ "$1" = "mr" ] && [ "$2" = "create" ]; then echo "https://gitlab.com/test/repo/-/merge_requests/51"; exit 0; fi
+echo "unexpected glab invocation: $@" >&2
+exit 1
+"#,
+    )
+    .expect("failed to write fake glab");
+    #[cfg(unix)]
+    {
+        let mut perms = fs::metadata(fake_bin.join("glab"))
+            .expect("failed to stat fake glab")
+            .permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(fake_bin.join("glab"), perms).expect("failed to chmod fake glab");
+    }
+    let old_path = std::env::var_os("PATH").unwrap_or_default();
+    let mut new_path = OsString::from(fake_bin.as_os_str());
+    new_path.push(":");
+    new_path.push(old_path);
+    let (success, stdout, stderr) = run_gg_with_env(
+        &repo_path,
+        &["sync", "--json", "--no-rebase-check"],
+        &[("PATH", new_path.as_os_str())],
+    );
+    assert!(success, "sync failed\nstdout:{stdout}\nstderr:{stderr}");
+    let value: Value = serde_json::from_str(&stdout).expect("sync should emit JSON");
+    assert!(value["sync"]["github_stack"].is_null());
+}

--- a/crates/gg-cli/tests/integration_tests/github_stacks.rs
+++ b/crates/gg-cli/tests/integration_tests/github_stacks.rs
@@ -162,10 +162,23 @@ if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
       exit 0
       ;;
     42)
+      if [ -n "${GG_FAKE_PR_VIEW_42_OLD_HEAD:-}" ]; then
+        echo '{"number":42,"title":"Entry two","state":"OPEN","url":"https://github.com/test/repo/pull/42","headRefName":"testuser/old-stack--c-2222222","isDraft":false,"mergeable":"MERGEABLE","reviews":[]}'
+        exit 0
+      fi
       echo '{"number":42,"title":"Entry two","state":"OPEN","url":"https://github.com/test/repo/pull/42","headRefName":"testuser/native-stack--c-2222222","isDraft":false,"mergeable":"MERGEABLE","reviews":[]}'
       exit 0
       ;;
   esac
+fi
+
+if [ "$1" = "pr" ] && [ "$2" = "create" ]; then
+  if [ -n "${GG_FAKE_PR_CREATE_FAIL:-}" ]; then
+    echo "failed to create replacement PR" >&2
+    exit 1
+  fi
+  echo "https://github.com/test/repo/pull/99"
+  exit 0
 fi
 
 if [ "$1" = "pr" ] && [ "$2" = "edit" ]; then
@@ -386,6 +399,26 @@ fn sync_base_update_failure_skips_without_stack_command() {
     assert_eq!(value["sync"]["github_stack"]["reason"], "unresolved_prs");
     let log = fixture.log();
     assert!(log.contains("pr edit 41 --base main"));
+    assert!(!log.contains("stack --version"));
+    assert!(!log.contains("/stacks"));
+}
+
+#[test]
+fn sync_replacement_create_failure_skips_without_stack_command() {
+    let fixture = setup_fixture("auto");
+    let (success, stdout, stderr) = run_sync_json(
+        &fixture,
+        &[
+            ("GG_FAKE_PR_VIEW_42_OLD_HEAD", OsStr::new("1")),
+            ("GG_FAKE_PR_CREATE_FAIL", OsStr::new("1")),
+        ],
+    );
+    assert!(success, "sync failed\nstdout:{stdout}\nstderr:{stderr}");
+    let value: Value = serde_json::from_str(&stdout).expect("sync should emit JSON");
+    assert_eq!(value["sync"]["github_stack"]["action"], "skipped");
+    assert_eq!(value["sync"]["github_stack"]["reason"], "unresolved_prs");
+    let log = fixture.log();
+    assert!(log.contains("pr create --head testuser/native-stack--c-2222222"));
     assert!(!log.contains("stack --version"));
     assert!(!log.contains("/stacks"));
 }

--- a/crates/gg-cli/tests/integration_tests/github_stacks.rs
+++ b/crates/gg-cli/tests/integration_tests/github_stacks.rs
@@ -169,6 +169,10 @@ if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
 fi
 
 if [ "$1" = "pr" ] && [ "$2" = "edit" ]; then
+  if [ -n "${GG_FAKE_PR_EDIT_FAIL:-}" ]; then
+    echo "failed to update PR base" >&2
+    exit 1
+  fi
   exit 0
 fi
 
@@ -367,6 +371,21 @@ fn sync_unresolved_pr_state_skips_without_stack_command() {
     assert_eq!(value["sync"]["github_stack"]["action"], "skipped");
     assert_eq!(value["sync"]["github_stack"]["reason"], "unresolved_prs");
     let log = fixture.log();
+    assert!(!log.contains("stack --version"));
+    assert!(!log.contains("/stacks"));
+}
+
+#[test]
+fn sync_base_update_failure_skips_without_stack_command() {
+    let fixture = setup_fixture("auto");
+    let (success, stdout, stderr) =
+        run_sync_json(&fixture, &[("GG_FAKE_PR_EDIT_FAIL", OsStr::new("1"))]);
+    assert!(success, "sync failed\nstdout:{stdout}\nstderr:{stderr}");
+    let value: Value = serde_json::from_str(&stdout).expect("sync should emit JSON");
+    assert_eq!(value["sync"]["github_stack"]["action"], "skipped");
+    assert_eq!(value["sync"]["github_stack"]["reason"], "unresolved_prs");
+    let log = fixture.log();
+    assert!(log.contains("pr edit 41 --base main"));
     assert!(!log.contains("stack --version"));
     assert!(!log.contains("/stacks"));
 }

--- a/crates/gg-cli/tests/integration_tests/github_stacks.rs
+++ b/crates/gg-cli/tests/integration_tests/github_stacks.rs
@@ -26,6 +26,14 @@ impl GithubStackFixture {
         fs::read_to_string(&self.fake_log).unwrap_or_default()
     }
 
+    fn link_lines(&self) -> Vec<String> {
+        self.log()
+            .lines()
+            .filter(|line| line.starts_with("stack link"))
+            .map(ToString::to_string)
+            .collect()
+    }
+
     fn set_stack_response(&self, name: &str, json: &str) -> PathBuf {
         let path = self.repo_path.join(name);
         fs::write(&path, json).expect("failed to write fake stack response");
@@ -270,7 +278,7 @@ fn sync_json_creates_native_stack_with_exact_pr_order() {
     assert_eq!(stack["action"], "created");
     assert_eq!(stack["stack_number"], 7);
     assert_eq!(stack["pr_numbers"], serde_json::json!([41, 42]));
-    assert!(fixture.log().contains("stack link --base main 41 42"));
+    assert_eq!(fixture.link_lines(), vec!["stack link --base main 41 42"]);
 }
 
 #[test]
@@ -314,7 +322,7 @@ fn sync_jsonl_appends_after_merged_prefix_and_repeats_result_in_summary() {
         events[summary_index]["github_stack"]["pr_numbers"],
         events[github_event_index]["pr_numbers"]
     );
-    assert!(fixture.log().contains("stack link 7 42"));
+    assert_eq!(fixture.link_lines(), vec!["stack link 7 42"]);
 }
 
 #[test]
@@ -397,6 +405,22 @@ fn sync_link_failure_warns_without_corrupting_json() {
     assert_eq!(value["sync"]["github_stack"]["action"], "warning");
     assert_eq!(value["sync"]["github_stack"]["reason"], "backend_failed");
     assert_eq!(value["sync"]["github_stack"]["message"], "link failed");
+
+    let (success, undo_stdout, undo_stderr) =
+        run_gg(&fixture.repo_path, &["undo", "--list", "--json"]);
+    assert!(
+        success,
+        "undo list failed\nstdout:{undo_stdout}\nstderr:{undo_stderr}"
+    );
+    let listed: Value = serde_json::from_str(&undo_stdout).expect("undo list should emit JSON");
+    let sync_record = listed["operations"]
+        .as_array()
+        .expect("operations should be an array")
+        .iter()
+        .find(|record| record["kind"] == "sync")
+        .expect("sync operation should be recorded");
+    assert_eq!(sync_record["touched_remote"], true);
+    assert_eq!(sync_record["is_undoable"], false);
 }
 
 #[test]
@@ -452,4 +476,73 @@ exit 1
     assert!(success, "sync failed\nstdout:{stdout}\nstderr:{stderr}");
     let value: Value = serde_json::from_str(&stdout).expect("sync should emit JSON");
     assert!(value["sync"]["github_stack"].is_null());
+}
+
+#[test]
+fn sync_gitlab_jsonl_omits_github_stack_field_and_event() {
+    let (_temp_dir, repo_path, _remote_path) = create_test_repo_with_remote();
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser","provider":"gitlab","base":"main","sync_behind_threshold":0}}"#,
+    )
+    .expect("failed to write config");
+    let (success, _, stderr) = run_gg(&repo_path, &["co", "gitlab-jsonl-stack"]);
+    assert!(success, "failed to create stack: {stderr}");
+    fs::write(repo_path.join("one.txt"), "one\n").expect("failed to write one");
+    run_git(&repo_path, &["add", "one.txt"]);
+    run_git(
+        &repo_path,
+        &["commit", "-m", "Entry one\n\nGG-ID: c-1111111"],
+    );
+
+    let fake_bin = repo_path.join("fake-bin");
+    fs::create_dir_all(&fake_bin).expect("failed to create fake-bin");
+    fs::write(
+        fake_bin.join("glab"),
+        r#"#!/bin/sh
+set -eu
+if [ "$1" = "--version" ]; then echo "glab version 1.0.0"; exit 0; fi
+if [ "$1" = "auth" ] && [ "$2" = "status" ]; then exit 0; fi
+if [ "$1" = "mr" ] && [ "$2" = "create" ]; then echo "https://gitlab.com/test/repo/-/merge_requests/51"; exit 0; fi
+echo "unexpected glab invocation: $@" >&2
+exit 1
+"#,
+    )
+    .expect("failed to write fake glab");
+    #[cfg(unix)]
+    {
+        let mut perms = fs::metadata(fake_bin.join("glab"))
+            .expect("failed to stat fake glab")
+            .permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(fake_bin.join("glab"), perms).expect("failed to chmod fake glab");
+    }
+    let old_path = std::env::var_os("PATH").unwrap_or_default();
+    let mut new_path = OsString::from(fake_bin.as_os_str());
+    new_path.push(":");
+    new_path.push(old_path);
+    let (success, stdout, stderr) = run_gg_with_env(
+        &repo_path,
+        &["sync", "--jsonl", "--no-rebase-check"],
+        &[("PATH", new_path.as_os_str())],
+    );
+    assert!(success, "sync failed\nstdout:{stdout}\nstderr:{stderr}");
+    let events: Vec<Value> = stdout
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("every JSONL line should parse"))
+        .collect();
+    assert!(
+        !events.iter().any(|event| event["event"] == "github_stack"),
+        "GitLab JSONL must not emit github_stack events"
+    );
+    let summary = events
+        .iter()
+        .find(|event| event["event"] == "summary")
+        .expect("summary should be emitted");
+    assert!(
+        summary.get("github_stack").is_none(),
+        "GitLab JSONL summary must omit github_stack"
+    );
 }

--- a/crates/gg-cli/tests/integration_tests/main.rs
+++ b/crates/gg-cli/tests/integration_tests/main.rs
@@ -9,6 +9,7 @@ mod checkout;
 mod clean;
 mod continue_flow;
 mod drop;
+mod github_stacks;
 mod inbox;
 mod land;
 mod lint;

--- a/crates/gg-core/Cargo.toml
+++ b/crates/gg-core/Cargo.toml
@@ -39,6 +39,7 @@ ctrlc = "3"
 atty = "0.2"
 fs2 = "0.4"
 dirs = "6"
+semver = "1"
 
 # TUI (for split and reorder)
 ratatui = "0.30"

--- a/crates/gg-core/src/commands/setup.rs
+++ b/crates/gg-core/src/commands/setup.rs
@@ -4,7 +4,7 @@ use console::style;
 use dialoguer::theme::ColorfulTheme;
 use dialoguer::{Confirm, Input, Select};
 
-use crate::config::{Config, Defaults, UnstagedAction};
+use crate::config::{Config, Defaults, GithubStacksIntegration, UnstagedAction};
 use crate::error::{GgError, Result};
 use crate::git;
 use crate::provider::Provider;
@@ -172,6 +172,19 @@ fn prompt_defaults_full(
         .interact()
         .map_err(|e| GgError::Other(format!("Prompt failed: {}", e)))?;
 
+    // ── GitHub ── (only if provider is GitHub)
+    if should_prompt_github_stacks(defaults.provider.as_deref()) {
+        print_group_header("GitHub");
+        let choices = ["Auto (recommended)", "Off", "Force (warn when unavailable)"];
+        let selected = Select::with_theme(theme)
+            .with_prompt("Link synced PRs into GitHub's native Stacked PRs UI?")
+            .items(choices)
+            .default(github_stacks_mode_index(existing.github.stacks_integration))
+            .interact()
+            .map_err(|e| GgError::Other(format!("Prompt failed: {}", e)))?;
+        defaults.github.stacks_integration = github_stacks_mode_from_index(selected);
+    }
+
     // ── Land ──
     print_group_header("Land");
     defaults.land_auto_clean = Confirm::with_theme(theme)
@@ -206,6 +219,26 @@ fn prompt_defaults_full(
     }
 
     Ok(defaults)
+}
+
+fn should_prompt_github_stacks(provider: Option<&str>) -> bool {
+    provider == Some("github")
+}
+
+fn github_stacks_mode_index(mode: GithubStacksIntegration) -> usize {
+    match mode {
+        GithubStacksIntegration::Auto => 0,
+        GithubStacksIntegration::Off => 1,
+        GithubStacksIntegration::Force => 2,
+    }
+}
+
+fn github_stacks_mode_from_index(index: usize) -> GithubStacksIntegration {
+    match index {
+        1 => GithubStacksIntegration::Off,
+        2 => GithubStacksIntegration::Force,
+        _ => GithubStacksIntegration::Auto,
+    }
 }
 
 fn prompt_sync_auto_lint(existing: bool, theme: &ColorfulTheme) -> Result<bool> {
@@ -527,4 +560,43 @@ fn detect_lint_suggestions(repo: &git2::Repository) -> Vec<String> {
     }
 
     suggestions
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn github_stacks_prompt_is_github_only() {
+        assert!(should_prompt_github_stacks(Some("github")));
+        assert!(!should_prompt_github_stacks(Some("gitlab")));
+        assert!(!should_prompt_github_stacks(None));
+    }
+
+    #[test]
+    fn github_stacks_mode_indices_round_trip() {
+        for mode in [
+            GithubStacksIntegration::Auto,
+            GithubStacksIntegration::Off,
+            GithubStacksIntegration::Force,
+        ] {
+            assert_eq!(
+                github_stacks_mode_from_index(github_stacks_mode_index(mode)),
+                mode
+            );
+        }
+    }
+
+    #[test]
+    fn gitlab_setup_preserves_existing_github_stacks_mode() {
+        let mut defaults = Defaults::default();
+        defaults.github.stacks_integration = GithubStacksIntegration::Force;
+        if should_prompt_github_stacks(Some("gitlab")) {
+            defaults.github.stacks_integration = GithubStacksIntegration::Off;
+        }
+        assert_eq!(
+            defaults.github.stacks_integration,
+            GithubStacksIntegration::Force
+        );
+    }
 }

--- a/crates/gg-core/src/commands/setup.rs
+++ b/crates/gg-core/src/commands/setup.rs
@@ -1,10 +1,14 @@
 //! `gg setup` - Interactive config generator
 
+use std::fs;
+
 use console::style;
 use dialoguer::theme::ColorfulTheme;
 use dialoguer::{Confirm, Input, Select};
 
-use crate::config::{Config, Defaults, GithubStacksIntegration, UnstagedAction};
+use crate::config::{
+    local_config_has_github_defaults, Config, Defaults, GithubStacksIntegration, UnstagedAction,
+};
 use crate::error::{GgError, Result};
 use crate::git;
 use crate::provider::Provider;
@@ -28,6 +32,14 @@ pub fn run(all: bool) -> Result<()> {
 
     // Load global config to use as effective defaults
     let global = Config::load_global()?.unwrap_or_default();
+    if config_path.exists() {
+        let contents = fs::read_to_string(&config_path)?;
+        preserve_inherited_github_defaults_for_legacy_local(
+            &mut config,
+            &global,
+            local_config_has_github_defaults(&contents),
+        );
+    }
 
     if config_path.exists() {
         let proceed = Confirm::with_theme(&theme)
@@ -223,6 +235,16 @@ fn prompt_defaults_full(
 
 fn should_prompt_github_stacks(provider: Option<&str>) -> bool {
     provider == Some("github")
+}
+
+fn preserve_inherited_github_defaults_for_legacy_local(
+    config: &mut Config,
+    global: &Config,
+    local_has_github_defaults: bool,
+) {
+    if !local_has_github_defaults {
+        config.defaults.github = global.defaults.github.clone();
+    }
 }
 
 fn github_stacks_mode_index(mode: GithubStacksIntegration) -> usize {
@@ -597,6 +619,36 @@ mod tests {
         assert_eq!(
             defaults.github.stacks_integration,
             GithubStacksIntegration::Force
+        );
+    }
+
+    #[test]
+    fn legacy_local_setup_preserves_inherited_github_stacks_mode() {
+        let mut config = Config::default();
+        config.defaults.github.stacks_integration = GithubStacksIntegration::Auto;
+        let mut global = Config::default();
+        global.defaults.github.stacks_integration = GithubStacksIntegration::Force;
+
+        preserve_inherited_github_defaults_for_legacy_local(&mut config, &global, false);
+
+        assert_eq!(
+            config.defaults.github.stacks_integration,
+            GithubStacksIntegration::Force
+        );
+    }
+
+    #[test]
+    fn setup_keeps_explicit_local_github_stacks_mode() {
+        let mut config = Config::default();
+        config.defaults.github.stacks_integration = GithubStacksIntegration::Off;
+        let mut global = Config::default();
+        global.defaults.github.stacks_integration = GithubStacksIntegration::Force;
+
+        preserve_inherited_github_defaults_for_legacy_local(&mut config, &global, true);
+
+        assert_eq!(
+            config.defaults.github.stacks_integration,
+            GithubStacksIntegration::Off
         );
     }
 }

--- a/crates/gg-core/src/commands/sync.rs
+++ b/crates/gg-core/src/commands/sync.rs
@@ -6,9 +6,12 @@ use git2::Repository;
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use std::time::Duration;
 
-use crate::config::Config;
+use crate::config::{Config, GithubStacksIntegration};
 use crate::error::{GgError, Result};
 use crate::git::{self, get_commit_description, strip_gg_id_from_message};
+use crate::github_stacks::{
+    reconcile_with_gh, GithubStackAction, GithubStackReason, GithubStackSyncResult,
+};
 use crate::managed_body;
 use crate::operations::{OperationKind, RemoteEffect, SnapshotScope};
 use crate::output::{
@@ -27,6 +30,31 @@ struct NavEntrySnapshot {
     pr_state: stack_nav::PrEntryState,
     /// Index into `json_entries` so we can attach the nav action result.
     json_index: usize,
+}
+
+fn github_stack_preflight_skip(
+    mode: GithubStacksIntegration,
+    until: Option<&str>,
+    active_pr_numbers: &[u64],
+    has_unresolved_active_pr: bool,
+) -> Option<GithubStackSyncResult> {
+    let reason = if mode == GithubStacksIntegration::Off {
+        GithubStackReason::Disabled
+    } else if until.is_some() {
+        GithubStackReason::PartialSync
+    } else if has_unresolved_active_pr {
+        GithubStackReason::UnresolvedPrs
+    } else if active_pr_numbers.len() < 2 {
+        GithubStackReason::InsufficientPrs
+    } else {
+        return None;
+    };
+
+    Some(GithubStackSyncResult::skipped(
+        mode,
+        reason,
+        active_pr_numbers.to_vec(),
+    ))
 }
 
 fn sync_progress_bar(len: u64, draw_target: ProgressDrawTarget) -> ProgressBar {
@@ -264,7 +292,7 @@ pub fn run(
 
     // Load stack early to validate --until
     let initial_stack = Stack::load(&repo, &config)?;
-    let warnings: Vec<String> = initial_stack
+    let mut warnings: Vec<String> = initial_stack
         .prefix_mismatch(&config)
         .map(|mismatch| mismatch.warning_message())
         .into_iter()
@@ -283,6 +311,7 @@ pub fn run(
                     base: initial_stack.base.clone(),
                     rebased_before_sync: false,
                     warnings: warnings.clone(),
+                    github_stack: None,
                     metadata: SyncMetadataJson::default(),
                     entries: vec![],
                 },
@@ -300,6 +329,7 @@ pub fn run(
                     base: initial_stack.base,
                     rebased_before_sync: false,
                     warnings,
+                    github_stack: None,
                     metadata: SyncMetadataJson::default(),
                     entries: vec![],
                 },
@@ -398,6 +428,7 @@ pub fn run(
                     base: stack.base.clone(),
                     rebased_before_sync,
                     warnings: warnings.clone(),
+                    github_stack: None,
                     metadata: SyncMetadataJson::default(),
                     entries: vec![],
                 },
@@ -414,6 +445,7 @@ pub fn run(
                     base: stack.base,
                     rebased_before_sync,
                     warnings: warnings.clone(),
+                    github_stack: None,
                     metadata: SyncMetadataJson::default(),
                     entries: vec![],
                 },
@@ -1144,6 +1176,127 @@ pub fn run(
         pb.finish_with_message("Done!");
     }
 
+    let active_pr_numbers: Vec<u64> = nav_snapshots
+        .iter()
+        .zip(&entry_is_closed)
+        .filter_map(|(snapshot, is_closed)| {
+            if *is_closed {
+                None
+            } else {
+                snapshot.as_ref().map(|value| value.pr_number)
+            }
+        })
+        .collect();
+    let has_unresolved_active_pr = nav_snapshots
+        .iter()
+        .zip(&entry_is_closed)
+        .any(|(snapshot, is_closed)| !*is_closed && snapshot.is_none());
+
+    let github_stack_result = match provider {
+        Provider::GitHub => {
+            let mode = config.get_github_stacks_integration();
+            let result = if let Some(result) = github_stack_preflight_skip(
+                mode,
+                until.as_deref(),
+                &active_pr_numbers,
+                has_unresolved_active_pr,
+            ) {
+                result
+            } else {
+                let outcome = reconcile_with_gh(mode, &stack.base, &active_pr_numbers);
+                if outcome.mutation_attempted {
+                    touched_remote = true;
+                    guard.mark_touched_remote();
+                }
+                outcome.result
+            };
+
+            let warning_message = result.is_warning().then(|| {
+                result.message.clone().unwrap_or_else(|| {
+                    let reason = match result.reason {
+                        Some(GithubStackReason::Disabled) => "integration disabled",
+                        Some(GithubStackReason::PartialSync) => "partial sync",
+                        Some(GithubStackReason::InsufficientPrs) => {
+                            "insufficient active pull requests"
+                        }
+                        Some(GithubStackReason::UnresolvedPrs) => "unresolved active pull requests",
+                        Some(GithubStackReason::MissingExtension) => "missing gh stack extension",
+                        Some(GithubStackReason::OutdatedExtension) => "outdated gh stack extension",
+                        Some(GithubStackReason::UnsupportedRepository) => {
+                            "repository does not support GitHub Stacked PRs"
+                        }
+                        Some(GithubStackReason::Diverged) => "native stack diverged",
+                        Some(GithubStackReason::BackendFailed) => "gh stack backend failed",
+                        None => "unknown reason",
+                    };
+                    format!("GitHub Stacked PR reconciliation warning: {reason}")
+                })
+            });
+            if let Some(message) = &warning_message {
+                warnings.push(message.clone());
+            }
+
+            if !json && !jsonl {
+                match result.action {
+                    GithubStackAction::Created => match result.stack_number {
+                        Some(number) => println!(
+                            "{} Created GitHub stack #{}",
+                            style("OK").green().bold(),
+                            number
+                        ),
+                        None => println!("{} Created GitHub stack", style("OK").green().bold()),
+                    },
+                    GithubStackAction::Appended => match result.stack_number {
+                        Some(number) => println!(
+                            "{} Updated GitHub stack #{}",
+                            style("OK").green().bold(),
+                            number
+                        ),
+                        None => println!("{} Updated GitHub stack", style("OK").green().bold()),
+                    },
+                    GithubStackAction::Unchanged => match result.stack_number {
+                        Some(number) => println!(
+                            "{}",
+                            style(format!("GitHub stack #{} is already up to date", number)).dim()
+                        ),
+                        None => println!("{}", style("GitHub stack is already up to date").dim()),
+                    },
+                    GithubStackAction::Warning => println!(
+                        "{} {}",
+                        style("Warning:").yellow(),
+                        warning_message
+                            .as_deref()
+                            .expect("warning actions have a warning message")
+                    ),
+                    GithubStackAction::Skipped => {
+                        if result.reason == Some(GithubStackReason::UnresolvedPrs) {
+                            println!(
+                                "{}",
+                                style(
+                                    "GitHub stack reconciliation skipped because some active pull requests could not be resolved"
+                                )
+                                .dim()
+                            );
+                        }
+                    }
+                }
+            }
+
+            if let Some(s) = streamer.as_mut() {
+                s.emit(&SyncStreamingResponse {
+                    version: OUTPUT_VERSION,
+                    command: "sync".to_string(),
+                    event: SyncStreamingEvent::GithubStack {
+                        result: result.clone(),
+                    },
+                });
+            }
+
+            Some(result)
+        }
+        Provider::GitLab => None,
+    };
+
     // --- Nav-comment reconcile pass ---
     //
     // Skipped under --until to avoid inconsistent nav comments: a partial sync
@@ -1355,6 +1508,7 @@ pub fn run(
                 base: stack.base.clone(),
                 rebased_before_sync,
                 warnings: warnings.clone(),
+                github_stack: github_stack_result.clone(),
                 metadata: SyncMetadataJson {
                     gg_ids_added: metadata_counts.gg_ids_added,
                     gg_parents_updated: metadata_counts.gg_parents_updated,
@@ -1373,6 +1527,7 @@ pub fn run(
                     base: stack.base,
                     rebased_before_sync,
                     warnings: warnings.clone(),
+                    github_stack: github_stack_result,
                     metadata: SyncMetadataJson {
                         gg_ids_added: metadata_counts.gg_ids_added,
                         gg_parents_updated: metadata_counts.gg_parents_updated,
@@ -1567,10 +1722,13 @@ fn create_entry_branch(
 mod tests {
     use super::{
         build_pr_payload, clean_title, compute_target_branch, description_with_replacement_note,
-        ensure_draft_prefix_for_gitlab, is_wip_or_draft_prefix, mismatched_pr_head_branch,
-        replacement_closing_comment, suspend_sync_progress, sync_progress_bar,
+        ensure_draft_prefix_for_gitlab, github_stack_preflight_skip, is_wip_or_draft_prefix,
+        mismatched_pr_head_branch, replacement_closing_comment, suspend_sync_progress,
+        sync_progress_bar,
     };
+    use crate::config::GithubStacksIntegration;
     use crate::git;
+    use crate::github_stacks::{GithubStackReason, GithubStackSyncResult};
     use crate::output::{
         SyncEntryResultJson, SyncMetadataJson, SyncResponse, SyncResultJson, OUTPUT_VERSION,
     };
@@ -2007,6 +2165,11 @@ mod tests {
 
     #[test]
     fn test_sync_json_response_structure() {
+        let github_stack = GithubStackSyncResult::skipped(
+            GithubStacksIntegration::Auto,
+            GithubStackReason::InsufficientPrs,
+            vec![42],
+        );
         let response = SyncResponse {
             version: OUTPUT_VERSION,
             sync: SyncResultJson {
@@ -2014,6 +2177,7 @@ mod tests {
                 base: "main".to_string(),
                 rebased_before_sync: false,
                 warnings: vec![],
+                github_stack: Some(github_stack),
                 metadata: SyncMetadataJson::default(),
                 entries: vec![SyncEntryResultJson {
                     position: 1,
@@ -2040,6 +2204,7 @@ mod tests {
         assert_eq!(parsed["sync"]["base"], "main");
         assert_eq!(parsed["sync"]["rebased_before_sync"], false);
         assert!(parsed["sync"]["warnings"].is_array());
+        assert_eq!(parsed["sync"]["github_stack"]["reason"], "insufficient_prs");
         assert!(parsed["sync"]["entries"].is_array());
 
         let entry = &parsed["sync"]["entries"][0];
@@ -2048,6 +2213,36 @@ mod tests {
         assert_eq!(entry["pr_number"], 42);
         assert_eq!(entry["pushed"], true);
         assert!(entry["error"].is_null());
+    }
+
+    #[test]
+    fn github_stack_preflight_off_is_disabled() {
+        let result =
+            github_stack_preflight_skip(GithubStacksIntegration::Off, None, &[41, 42], false)
+                .unwrap();
+        assert_eq!(result.reason, Some(GithubStackReason::Disabled));
+    }
+
+    #[test]
+    fn github_stack_preflight_partial_sync_skips_before_backend() {
+        let result =
+            github_stack_preflight_skip(GithubStacksIntegration::Auto, Some("2"), &[41, 42], false)
+                .unwrap();
+        assert_eq!(result.reason, Some(GithubStackReason::PartialSync));
+    }
+
+    #[test]
+    fn github_stack_preflight_unresolved_prs_skip_before_insufficient_prs() {
+        let result =
+            github_stack_preflight_skip(GithubStacksIntegration::Auto, None, &[41], true).unwrap();
+        assert_eq!(result.reason, Some(GithubStackReason::UnresolvedPrs));
+    }
+
+    #[test]
+    fn github_stack_preflight_fewer_than_two_active_prs_is_insufficient() {
+        let result =
+            github_stack_preflight_skip(GithubStacksIntegration::Auto, None, &[41], false).unwrap();
+        assert_eq!(result.reason, Some(GithubStackReason::InsufficientPrs));
     }
 
     // --- Tests for compute_target_branch (walk-back algorithm) ---

--- a/crates/gg-core/src/commands/sync.rs
+++ b/crates/gg-core/src/commands/sync.rs
@@ -10,8 +10,7 @@ use crate::config::{Config, GithubStacksIntegration};
 use crate::error::{GgError, Result};
 use crate::git::{self, get_commit_description, strip_gg_id_from_message};
 use crate::github_stacks::{
-    reconcile_with_gh, GithubStackAction, GithubStackReason, GithubStackReconcileOutcome,
-    GithubStackSyncResult,
+    reconcile_with_gh_before_mutation, GithubStackAction, GithubStackReason, GithubStackSyncResult,
 };
 use crate::managed_body;
 use crate::operations::{OperationKind, RemoteEffect, SnapshotScope};
@@ -56,18 +55,6 @@ fn github_stack_preflight_skip(
         reason,
         active_pr_numbers.to_vec(),
     ))
-}
-
-fn consume_github_stack_outcome(
-    outcome: GithubStackReconcileOutcome,
-    touched_remote: &mut bool,
-    mark_touched_remote: impl FnOnce(),
-) -> GithubStackSyncResult {
-    if outcome.mutation_attempted {
-        *touched_remote = true;
-        mark_touched_remote();
-    }
-    outcome.result
 }
 
 fn sync_progress_bar(len: u64, draw_target: ProgressDrawTarget) -> ProgressBar {
@@ -521,6 +508,7 @@ pub fn run(
     // Track which entries are closed/merged so downstream entries can skip them
     // when computing their target branch (walk-back algorithm for stacked MRs).
     let mut entry_is_closed: Vec<bool> = Vec::with_capacity(entries_to_sync.len());
+    let mut entry_has_unresolved_pr_state: Vec<bool> = Vec::with_capacity(entries_to_sync.len());
 
     if let Some(s) = streamer.as_mut() {
         s.emit(&SyncStreamingResponse {
@@ -569,6 +557,7 @@ pub fn run(
         let mut pr_state_cached: Option<crate::stack_nav::PrEntryState> = None;
         let mut effective_draft = entry_draft;
         let mut is_entry_closed = false;
+        let mut pr_state_unresolved = false;
 
         let (title, description) = build_pr_payload(
             &title,
@@ -643,6 +632,7 @@ pub fn run(
                     });
                     nav_snapshots.push(None);
                     entry_is_closed.push(false);
+                    entry_has_unresolved_pr_state.push(true);
                     continue;
                 }
 
@@ -686,7 +676,13 @@ pub fn run(
             Some(pr_num) => {
                 pr_number = Some(pr_num);
                 // Check if PR is still open before updating
-                let pr_info = provider.get_pr_info(pr_num).ok();
+                let pr_info = match provider.get_pr_info(pr_num) {
+                    Ok(info) => Some(info),
+                    Err(_) => {
+                        pr_state_unresolved = true;
+                        None
+                    }
+                };
                 pr_url = pr_info.as_ref().map(|info| info.url.clone());
                 // Cache the state so the nav reconcile pass can reuse it without
                 // a second network round-trip.
@@ -1181,6 +1177,7 @@ pub fn run(
         };
         nav_snapshots.push(nav_snapshot);
         entry_is_closed.push(is_entry_closed);
+        entry_has_unresolved_pr_state.push(pr_state_unresolved);
 
         pb.inc(1);
     }
@@ -1203,7 +1200,10 @@ pub fn run(
     let has_unresolved_active_pr = nav_snapshots
         .iter()
         .zip(&entry_is_closed)
-        .any(|(snapshot, is_closed)| !*is_closed && snapshot.is_none());
+        .zip(&entry_has_unresolved_pr_state)
+        .any(|((snapshot, is_closed), unresolved)| {
+            !*is_closed && (snapshot.is_none() || *unresolved)
+        });
 
     let github_stack_result = match provider {
         Provider::GitHub => {
@@ -1216,10 +1216,20 @@ pub fn run(
             ) {
                 result
             } else {
-                let outcome = reconcile_with_gh(mode, &stack.base, &active_pr_numbers);
-                consume_github_stack_outcome(outcome, &mut touched_remote, || {
+                let outcome = reconcile_with_gh_before_mutation(
+                    mode,
+                    &stack.base,
+                    &active_pr_numbers,
+                    || {
+                        touched_remote = true;
+                        guard.mark_touched_remote();
+                    },
+                );
+                if outcome.mutation_attempted {
+                    touched_remote = true;
                     guard.mark_touched_remote();
-                })
+                }
+                outcome.result
             };
 
             let warning_message = result.is_warning().then(|| {
@@ -1732,16 +1742,14 @@ fn create_entry_branch(
 #[cfg(test)]
 mod tests {
     use super::{
-        build_pr_payload, clean_title, compute_target_branch, consume_github_stack_outcome,
-        description_with_replacement_note, ensure_draft_prefix_for_gitlab,
-        github_stack_preflight_skip, is_wip_or_draft_prefix, mismatched_pr_head_branch,
-        replacement_closing_comment, suspend_sync_progress, sync_progress_bar,
+        build_pr_payload, clean_title, compute_target_branch, description_with_replacement_note,
+        ensure_draft_prefix_for_gitlab, github_stack_preflight_skip, is_wip_or_draft_prefix,
+        mismatched_pr_head_branch, replacement_closing_comment, suspend_sync_progress,
+        sync_progress_bar,
     };
     use crate::config::GithubStacksIntegration;
     use crate::git;
-    use crate::github_stacks::{
-        GithubStackAction, GithubStackReason, GithubStackReconcileOutcome, GithubStackSyncResult,
-    };
+    use crate::github_stacks::{GithubStackReason, GithubStackSyncResult};
     use crate::output::{
         SyncEntryResultJson, SyncMetadataJson, SyncResponse, SyncResultJson, OUTPUT_VERSION,
     };
@@ -2256,51 +2264,6 @@ mod tests {
         let result =
             github_stack_preflight_skip(GithubStacksIntegration::Auto, None, &[41], false).unwrap();
         assert_eq!(result.reason, Some(GithubStackReason::InsufficientPrs));
-    }
-
-    #[test]
-    fn github_stack_mutation_attempt_marks_remote_touched() {
-        let outcome = GithubStackReconcileOutcome {
-            result: GithubStackSyncResult {
-                mode: GithubStacksIntegration::Auto,
-                action: GithubStackAction::Warning,
-                reason: Some(GithubStackReason::BackendFailed),
-                stack_number: None,
-                pr_numbers: vec![41, 42],
-                message: Some("link failed".to_string()),
-            },
-            mutation_attempted: true,
-        };
-        let mut touched_remote = false;
-        let mut guard_marked = false;
-
-        let result =
-            consume_github_stack_outcome(outcome, &mut touched_remote, || guard_marked = true);
-
-        assert!(touched_remote);
-        assert!(guard_marked);
-        assert_eq!(result.reason, Some(GithubStackReason::BackendFailed));
-    }
-
-    #[test]
-    fn github_stack_non_mutating_outcome_does_not_mark_remote_touched() {
-        let outcome = GithubStackReconcileOutcome {
-            result: GithubStackSyncResult::skipped(
-                GithubStacksIntegration::Auto,
-                GithubStackReason::MissingExtension,
-                vec![41, 42],
-            ),
-            mutation_attempted: false,
-        };
-        let mut touched_remote = false;
-        let mut guard_marked = false;
-
-        let result =
-            consume_github_stack_outcome(outcome, &mut touched_remote, || guard_marked = true);
-
-        assert!(!touched_remote);
-        assert!(!guard_marked);
-        assert_eq!(result.reason, Some(GithubStackReason::MissingExtension));
     }
 
     // --- Tests for compute_target_branch (walk-back algorithm) ---

--- a/crates/gg-core/src/commands/sync.rs
+++ b/crates/gg-core/src/commands/sync.rs
@@ -867,6 +867,12 @@ pub fn run(
                             }
                         }
                         Err(e) => {
+                            // The old PR still exists, but its head branch no
+                            // longer represents this local entry. If creating
+                            // the replacement fails, skip native GitHub stack
+                            // reconciliation instead of linking the stale PR
+                            // into the native stack.
+                            pr_state_unresolved = true;
                             action = "error".to_string();
                             entry_error = Some(e.to_string());
                             if !json && !jsonl {

--- a/crates/gg-core/src/commands/sync.rs
+++ b/crates/gg-core/src/commands/sync.rs
@@ -10,7 +10,8 @@ use crate::config::{Config, GithubStacksIntegration};
 use crate::error::{GgError, Result};
 use crate::git::{self, get_commit_description, strip_gg_id_from_message};
 use crate::github_stacks::{
-    reconcile_with_gh, GithubStackAction, GithubStackReason, GithubStackSyncResult,
+    reconcile_with_gh, GithubStackAction, GithubStackReason, GithubStackReconcileOutcome,
+    GithubStackSyncResult,
 };
 use crate::managed_body;
 use crate::operations::{OperationKind, RemoteEffect, SnapshotScope};
@@ -55,6 +56,18 @@ fn github_stack_preflight_skip(
         reason,
         active_pr_numbers.to_vec(),
     ))
+}
+
+fn consume_github_stack_outcome(
+    outcome: GithubStackReconcileOutcome,
+    touched_remote: &mut bool,
+    mark_touched_remote: impl FnOnce(),
+) -> GithubStackSyncResult {
+    if outcome.mutation_attempted {
+        *touched_remote = true;
+        mark_touched_remote();
+    }
+    outcome.result
 }
 
 fn sync_progress_bar(len: u64, draw_target: ProgressDrawTarget) -> ProgressBar {
@@ -1204,11 +1217,9 @@ pub fn run(
                 result
             } else {
                 let outcome = reconcile_with_gh(mode, &stack.base, &active_pr_numbers);
-                if outcome.mutation_attempted {
-                    touched_remote = true;
+                consume_github_stack_outcome(outcome, &mut touched_remote, || {
                     guard.mark_touched_remote();
-                }
-                outcome.result
+                })
             };
 
             let warning_message = result.is_warning().then(|| {
@@ -1721,14 +1732,16 @@ fn create_entry_branch(
 #[cfg(test)]
 mod tests {
     use super::{
-        build_pr_payload, clean_title, compute_target_branch, description_with_replacement_note,
-        ensure_draft_prefix_for_gitlab, github_stack_preflight_skip, is_wip_or_draft_prefix,
-        mismatched_pr_head_branch, replacement_closing_comment, suspend_sync_progress,
-        sync_progress_bar,
+        build_pr_payload, clean_title, compute_target_branch, consume_github_stack_outcome,
+        description_with_replacement_note, ensure_draft_prefix_for_gitlab,
+        github_stack_preflight_skip, is_wip_or_draft_prefix, mismatched_pr_head_branch,
+        replacement_closing_comment, suspend_sync_progress, sync_progress_bar,
     };
     use crate::config::GithubStacksIntegration;
     use crate::git;
-    use crate::github_stacks::{GithubStackReason, GithubStackSyncResult};
+    use crate::github_stacks::{
+        GithubStackAction, GithubStackReason, GithubStackReconcileOutcome, GithubStackSyncResult,
+    };
     use crate::output::{
         SyncEntryResultJson, SyncMetadataJson, SyncResponse, SyncResultJson, OUTPUT_VERSION,
     };
@@ -2243,6 +2256,51 @@ mod tests {
         let result =
             github_stack_preflight_skip(GithubStacksIntegration::Auto, None, &[41], false).unwrap();
         assert_eq!(result.reason, Some(GithubStackReason::InsufficientPrs));
+    }
+
+    #[test]
+    fn github_stack_mutation_attempt_marks_remote_touched() {
+        let outcome = GithubStackReconcileOutcome {
+            result: GithubStackSyncResult {
+                mode: GithubStacksIntegration::Auto,
+                action: GithubStackAction::Warning,
+                reason: Some(GithubStackReason::BackendFailed),
+                stack_number: None,
+                pr_numbers: vec![41, 42],
+                message: Some("link failed".to_string()),
+            },
+            mutation_attempted: true,
+        };
+        let mut touched_remote = false;
+        let mut guard_marked = false;
+
+        let result =
+            consume_github_stack_outcome(outcome, &mut touched_remote, || guard_marked = true);
+
+        assert!(touched_remote);
+        assert!(guard_marked);
+        assert_eq!(result.reason, Some(GithubStackReason::BackendFailed));
+    }
+
+    #[test]
+    fn github_stack_non_mutating_outcome_does_not_mark_remote_touched() {
+        let outcome = GithubStackReconcileOutcome {
+            result: GithubStackSyncResult::skipped(
+                GithubStacksIntegration::Auto,
+                GithubStackReason::MissingExtension,
+                vec![41, 42],
+            ),
+            mutation_attempted: false,
+        };
+        let mut touched_remote = false;
+        let mut guard_marked = false;
+
+        let result =
+            consume_github_stack_outcome(outcome, &mut touched_remote, || guard_marked = true);
+
+        assert!(!touched_remote);
+        assert!(!guard_marked);
+        assert_eq!(result.reason, Some(GithubStackReason::MissingExtension));
     }
 
     // --- Tests for compute_target_branch (walk-back algorithm) ---

--- a/crates/gg-core/src/commands/sync.rs
+++ b/crates/gg-core/src/commands/sync.rs
@@ -986,6 +986,12 @@ pub fn run(
                             guard.mark_touched_remote();
                         }
                         Err(e) => {
+                            // Native GitHub stack reconciliation must reflect
+                            // the ordinary PR base chain. If the provider
+                            // rejects that base update, skip the later native
+                            // stack mutation rather than linking a topology
+                            // `gg sync` did not actually establish.
+                            pr_state_unresolved = true;
                             if !json && !jsonl {
                                 pb.println(format!(
                                     "{} Could not update {} {}{}: {}",

--- a/crates/gg-core/src/config.rs
+++ b/crates/gg-core/src/config.rs
@@ -16,6 +16,7 @@ use crate::error::{GgError, Result};
 
 /// Default configuration values
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct Defaults {
     /// Git hosting provider ("github" or "gitlab")
     /// Used for self-hosted instances where URL detection fails
@@ -24,6 +25,10 @@ pub struct Defaults {
     /// GitLab-specific defaults
     #[serde(default)]
     pub gitlab: GitLabDefaults,
+
+    /// GitHub-specific defaults
+    #[serde(default)]
+    pub github: GithubDefaults,
 
     /// Base branch name (default: auto-detect main/master/trunk)
     pub base: Option<String>,
@@ -115,6 +120,7 @@ impl Default for Defaults {
         Self {
             provider: None,
             gitlab: GitLabDefaults::default(),
+            github: GithubDefaults::default(),
             base: None,
             branch_username: None,
             lint: Vec::new(),
@@ -141,6 +147,23 @@ pub struct GitLabDefaults {
     /// ("merge when pipeline succeeds") instead of attempting an immediate merge.
     #[serde(default)]
     pub auto_merge_on_land: bool,
+}
+
+/// GitHub Stacked PR integration behavior during sync.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum GithubStacksIntegration {
+    Off,
+    #[default]
+    Auto,
+    Force,
+}
+
+/// GitHub-specific default settings.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct GithubDefaults {
+    #[serde(default)]
+    pub stacks_integration: GithubStacksIntegration,
 }
 
 /// Per-stack configuration
@@ -346,6 +369,11 @@ impl Config {
     /// Get whether GitLab auto-merge-on-land is enabled by default (default: false)
     pub fn get_gitlab_auto_merge_on_land(&self) -> bool {
         self.defaults.gitlab.auto_merge_on_land
+    }
+
+    /// Get the GitHub Stacked PR integration behavior (default: auto).
+    pub fn get_github_stacks_integration(&self) -> GithubStacksIntegration {
+        self.defaults.github.stacks_integration
     }
 
     /// Get whether to auto-lint before sync (default: false)
@@ -681,6 +709,54 @@ mod tests {
         assert!(
             contents.contains("gitlab"),
             "gitlab defaults should always be serialized"
+        );
+    }
+
+    #[test]
+    fn test_github_stacks_integration_defaults_to_auto() {
+        let config: Config = serde_json::from_str(r#"{"defaults":{}}"#).unwrap();
+        assert_eq!(
+            config.get_github_stacks_integration(),
+            GithubStacksIntegration::Auto
+        );
+    }
+
+    #[test]
+    fn test_github_stacks_integration_round_trips_all_modes() {
+        for mode in [
+            GithubStacksIntegration::Off,
+            GithubStacksIntegration::Auto,
+            GithubStacksIntegration::Force,
+        ] {
+            let mut config = Config::default();
+            config.defaults.github.stacks_integration = mode;
+            let json = serde_json::to_string(&config).unwrap();
+            let parsed: Config = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed.get_github_stacks_integration(), mode);
+        }
+    }
+
+    #[test]
+    fn test_github_stacks_integration_uses_lowercase_json() {
+        let config: Config =
+            serde_json::from_str(r#"{"defaults":{"github":{"stacks_integration":"force"}}}"#)
+                .unwrap();
+        assert_eq!(
+            config.get_github_stacks_integration(),
+            GithubStacksIntegration::Force
+        );
+    }
+
+    #[test]
+    fn test_local_config_overrides_global_github_stacks_mode() {
+        let mut effective = Config::default();
+        effective.defaults.github.stacks_integration = GithubStacksIntegration::Force;
+        let mut local = Config::default();
+        local.defaults.github.stacks_integration = GithubStacksIntegration::Off;
+        effective.merge_local(local);
+        assert_eq!(
+            effective.get_github_stacks_integration(),
+            GithubStacksIntegration::Off
         );
     }
 

--- a/crates/gg-core/src/config.rs
+++ b/crates/gg-core/src/config.rs
@@ -456,8 +456,12 @@ impl Config {
             let local: Config = serde_json::from_str(&contents)?;
             drop(lock);
 
-            // Local overrides global
-            config.merge_local(local);
+            // Local overrides global. Preserve new nested defaults when an
+            // older repo-local config does not contain the nested object yet.
+            config.merge_local_with_github_presence(
+                local,
+                local_config_has_github_defaults(&contents),
+            );
         }
 
         Ok(config)
@@ -466,7 +470,14 @@ impl Config {
     /// Merge a local config on top of self (global).
     /// Local stacks always replace. Local defaults override global defaults.
     /// worktree_base_path from local overrides global if set.
+    #[cfg(test)]
     fn merge_local(&mut self, local: Config) {
+        self.merge_local_with_github_presence(local, true);
+    }
+
+    fn merge_local_with_github_presence(&mut self, local: Config, local_has_github: bool) {
+        let inherited_github = self.defaults.github.clone();
+
         // Stacks are always local
         self.stacks = local.stacks;
 
@@ -475,9 +486,11 @@ impl Config {
             self.worktree_base_path = local.worktree_base_path;
         }
 
-        // Defaults: local wins entirely (since we serialize all fields,
-        // the local JSON will have explicit values for every field)
+        // Defaults: local wins entirely for established serialized configs.
         self.defaults = local.defaults;
+        if !local_has_github {
+            self.defaults.github = inherited_github;
+        }
     }
 
     /// Render the target worktree path for a stack.
@@ -505,6 +518,18 @@ impl Config {
             repo_root.join(path)
         }
     }
+}
+
+fn local_config_has_github_defaults(contents: &str) -> bool {
+    serde_json::from_str::<serde_json::Value>(contents)
+        .ok()
+        .and_then(|value| {
+            value
+                .get("defaults")
+                .and_then(|defaults| defaults.get("github"))
+                .map(|_| ())
+        })
+        .is_some()
 }
 
 #[cfg(test)]
@@ -754,6 +779,35 @@ mod tests {
         let mut local = Config::default();
         local.defaults.github.stacks_integration = GithubStacksIntegration::Off;
         effective.merge_local(local);
+        assert_eq!(
+            effective.get_github_stacks_integration(),
+            GithubStacksIntegration::Off
+        );
+    }
+
+    #[test]
+    fn test_old_local_config_preserves_global_github_stacks_mode() {
+        let mut effective = Config::default();
+        effective.defaults.github.stacks_integration = GithubStacksIntegration::Off;
+        let local: Config = serde_json::from_str(
+            r#"{"defaults":{"branch_username":"testuser","provider":"github"}}"#,
+        )
+        .unwrap();
+        effective.merge_local_with_github_presence(local, false);
+        assert_eq!(
+            effective.get_github_stacks_integration(),
+            GithubStacksIntegration::Off
+        );
+    }
+
+    #[test]
+    fn test_explicit_local_github_stacks_mode_still_overrides_global() {
+        let mut effective = Config::default();
+        effective.defaults.github.stacks_integration = GithubStacksIntegration::Force;
+        let local: Config =
+            serde_json::from_str(r#"{"defaults":{"github":{"stacks_integration":"off"}}}"#)
+                .unwrap();
+        effective.merge_local_with_github_presence(local, true);
         assert_eq!(
             effective.get_github_stacks_integration(),
             GithubStacksIntegration::Off

--- a/crates/gg-core/src/config.rs
+++ b/crates/gg-core/src/config.rs
@@ -520,7 +520,7 @@ impl Config {
     }
 }
 
-fn local_config_has_github_defaults(contents: &str) -> bool {
+pub(crate) fn local_config_has_github_defaults(contents: &str) -> bool {
     serde_json::from_str::<serde_json::Value>(contents)
         .ok()
         .and_then(|value| {

--- a/crates/gg-core/src/github_stacks.rs
+++ b/crates/gg-core/src/github_stacks.rs
@@ -60,13 +60,6 @@ pub fn plan_reconciliation(
         .position(|entry| entry.state != RemotePullRequestState::Merged)
         .unwrap_or(stack.entries.len());
 
-    if stack.entries[..active_start]
-        .iter()
-        .any(|entry| entry.state != RemotePullRequestState::Merged)
-    {
-        return diverged("Native stack has an invalid merged prefix");
-    }
-
     let active_entries = &stack.entries[active_start..];
     if active_entries.iter().any(|entry| {
         !matches!(
@@ -218,14 +211,36 @@ pub fn reconcile_with_gh(
     base: &str,
     pr_numbers: &[u64],
 ) -> GithubStackReconcileOutcome {
-    reconcile_with_runner(&SystemGhRunner, mode, base, pr_numbers)
+    reconcile_with_gh_before_mutation(mode, base, pr_numbers, || {})
 }
 
+/// Reconcile GitHub's native stack state and run `before_mutation` immediately
+/// before invoking a mutating `gh stack link` command.
+pub fn reconcile_with_gh_before_mutation(
+    mode: GithubStacksIntegration,
+    base: &str,
+    pr_numbers: &[u64],
+    before_mutation: impl FnMut(),
+) -> GithubStackReconcileOutcome {
+    reconcile_with_runner_before_mutation(&SystemGhRunner, mode, base, pr_numbers, before_mutation)
+}
+
+#[cfg(test)]
 fn reconcile_with_runner<R: GhCommandRunner>(
     runner: &R,
     mode: GithubStacksIntegration,
     base: &str,
     pr_numbers: &[u64],
+) -> GithubStackReconcileOutcome {
+    reconcile_with_runner_before_mutation(runner, mode, base, pr_numbers, || {})
+}
+
+fn reconcile_with_runner_before_mutation<R: GhCommandRunner>(
+    runner: &R,
+    mode: GithubStacksIntegration,
+    base: &str,
+    pr_numbers: &[u64],
+    mut before_mutation: impl FnMut(),
 ) -> GithubStackReconcileOutcome {
     if pr_numbers.is_empty() {
         return outcome(GithubStackSyncResult::skipped(
@@ -286,6 +301,7 @@ fn reconcile_with_runner<R: GhCommandRunner>(
         ReconcilePlan::Create => {
             let mut link_args = args(["stack", "link", "--base", base]);
             link_args.extend(pr_numbers.iter().map(ToString::to_string));
+            before_mutation();
             match run_link(runner, &link_args) {
                 Ok(()) => {
                     let confirmation = discover_stacks(runner, &pr_numbers[..1]);
@@ -328,6 +344,7 @@ fn reconcile_with_runner<R: GhCommandRunner>(
         } => {
             let mut link_args = args(["stack", "link", &stack_number.to_string()]);
             link_args.extend(delta.iter().map(ToString::to_string));
+            before_mutation();
             match run_link(runner, &link_args) {
                 Ok(()) => GithubStackReconcileOutcome {
                     result: GithubStackSyncResult {
@@ -534,8 +551,10 @@ fn output_message(output: &GhCommandOutput) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::Cell;
     use std::cell::RefCell;
     use std::collections::VecDeque;
+    use std::rc::Rc;
 
     const STACK_7: &str = r#"[{
   "number": 7,
@@ -594,6 +613,25 @@ mod tests {
                 .expect("unexpected gh command");
             assert_eq!(args, expected.args.as_slice());
             Ok(expected.output)
+        }
+    }
+
+    struct CallbackOrderRunner {
+        inner: FakeRunner,
+        callback_seen: Rc<Cell<bool>>,
+    }
+
+    impl GhCommandRunner for CallbackOrderRunner {
+        fn run(&self, args: &[String]) -> std::io::Result<GhCommandOutput> {
+            if args.first().map(String::as_str) == Some("stack")
+                && args.get(1).map(String::as_str) == Some("link")
+            {
+                assert!(
+                    self.callback_seen.get(),
+                    "pre-mutation callback must run before gh stack link"
+                );
+            }
+            self.inner.run(args)
         }
     }
 
@@ -961,6 +999,59 @@ mod tests {
     }
 
     #[test]
+    fn create_runs_pre_mutation_callback_before_stack_link() {
+        let callback_seen = Rc::new(Cell::new(false));
+        let runner = CallbackOrderRunner {
+            inner: FakeRunner::new([
+                response(
+                    &["stack", "--version"],
+                    true,
+                    "gh stack version 0.1.0\n",
+                    "",
+                ),
+                response(
+                    &["api", "repos/{owner}/{repo}/stacks?pull_request=41"],
+                    true,
+                    "[]",
+                    "",
+                ),
+                response(
+                    &["api", "repos/{owner}/{repo}/stacks?pull_request=42"],
+                    true,
+                    "[]",
+                    "",
+                ),
+                response(
+                    &["stack", "link", "--base", "main", "41", "42"],
+                    true,
+                    "",
+                    "",
+                ),
+                response(
+                    &["api", "repos/{owner}/{repo}/stacks?pull_request=41"],
+                    true,
+                    STACK_7_CREATED,
+                    "",
+                ),
+            ]),
+            callback_seen: Rc::clone(&callback_seen),
+        };
+
+        let outcome = reconcile_with_runner_before_mutation(
+            &runner,
+            GithubStacksIntegration::Auto,
+            "main",
+            &[41, 42],
+            || callback_seen.set(true),
+        );
+
+        assert_eq!(outcome.result.action, GithubStackAction::Created);
+        assert!(outcome.mutation_attempted);
+        assert!(callback_seen.get());
+        runner.inner.assert_exhausted();
+    }
+
+    #[test]
     fn append_uses_stack_number_and_delta_only() {
         let runner = FakeRunner::new([
             response(
@@ -1028,6 +1119,44 @@ mod tests {
         assert_eq!(outcome.result.action, GithubStackAction::Unchanged);
         assert_eq!(outcome.result.stack_number, Some(7));
         assert!(!outcome.mutation_attempted);
+        runner.assert_exhausted();
+    }
+
+    #[test]
+    fn unchanged_does_not_run_pre_mutation_callback() {
+        let callback_seen = Rc::new(Cell::new(false));
+        let runner = FakeRunner::new([
+            response(
+                &["stack", "--version"],
+                true,
+                "gh stack version 0.1.0\n",
+                "",
+            ),
+            response(
+                &["api", "repos/{owner}/{repo}/stacks?pull_request=41"],
+                true,
+                STACK_7_CREATED,
+                "",
+            ),
+            response(
+                &["api", "repos/{owner}/{repo}/stacks?pull_request=42"],
+                true,
+                STACK_7_CREATED,
+                "",
+            ),
+        ]);
+
+        let outcome = reconcile_with_runner_before_mutation(
+            &runner,
+            GithubStacksIntegration::Auto,
+            "main",
+            &[41, 42],
+            || callback_seen.set(true),
+        );
+
+        assert_eq!(outcome.result.action, GithubStackAction::Unchanged);
+        assert!(!outcome.mutation_attempted);
+        assert!(!callback_seen.get());
         runner.assert_exhausted();
     }
 

--- a/crates/gg-core/src/github_stacks.rs
+++ b/crates/gg-core/src/github_stacks.rs
@@ -1,4 +1,7 @@
-use serde::Serialize;
+use std::process::Command;
+
+use semver::Version;
+use serde::{Deserialize, Serialize};
 
 use crate::config::GithubStacksIntegration;
 
@@ -166,9 +169,433 @@ impl GithubStackSyncResult {
     }
 }
 
+const MIN_GH_STACK_VERSION: &str = "0.1.0";
+
+pub struct GithubStackReconcileOutcome {
+    pub result: GithubStackSyncResult,
+    pub mutation_attempted: bool,
+}
+
+struct GhCommandOutput {
+    success: bool,
+    stdout: String,
+    stderr: String,
+}
+
+trait GhCommandRunner {
+    fn run(&self, args: &[String]) -> std::io::Result<GhCommandOutput>;
+}
+
+struct SystemGhRunner;
+
+impl GhCommandRunner for SystemGhRunner {
+    fn run(&self, args: &[String]) -> std::io::Result<GhCommandOutput> {
+        let output = Command::new("gh").args(args).output()?;
+        Ok(GhCommandOutput {
+            success: output.status.success(),
+            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        })
+    }
+}
+
+#[derive(Deserialize)]
+struct GhStackJson {
+    number: u64,
+    pull_requests: Vec<GhStackPullRequestJson>,
+}
+
+#[derive(Deserialize)]
+struct GhStackPullRequestJson {
+    number: u64,
+    state: String,
+    draft: bool,
+    merged_at: Option<String>,
+}
+
+pub fn reconcile_with_gh(
+    mode: GithubStacksIntegration,
+    base: &str,
+    pr_numbers: &[u64],
+) -> GithubStackReconcileOutcome {
+    reconcile_with_runner(&SystemGhRunner, mode, base, pr_numbers)
+}
+
+fn reconcile_with_runner<R: GhCommandRunner>(
+    runner: &R,
+    mode: GithubStacksIntegration,
+    base: &str,
+    pr_numbers: &[u64],
+) -> GithubStackReconcileOutcome {
+    if mode == GithubStacksIntegration::Off {
+        return outcome(GithubStackSyncResult::skipped(
+            mode,
+            GithubStackReason::Disabled,
+            pr_numbers.to_vec(),
+        ));
+    }
+
+    let version_output = match runner.run(&args(["stack", "--version"])) {
+        Ok(output) => output,
+        Err(error) => return backend_warning(mode, pr_numbers, error.to_string()),
+    };
+    if !version_output.success {
+        return capability_outcome(
+            mode,
+            GithubStackReason::MissingExtension,
+            pr_numbers,
+            output_message(&version_output),
+        );
+    }
+    let version = match parse_gh_stack_version(&version_output.stdout) {
+        Ok(version) => version,
+        Err(message) => return backend_warning(mode, pr_numbers, message),
+    };
+    let minimum = Version::parse(MIN_GH_STACK_VERSION).expect("minimum version is valid");
+    if version < minimum {
+        return capability_outcome(
+            mode,
+            GithubStackReason::OutdatedExtension,
+            pr_numbers,
+            format!("gh-stack {version} is older than required {minimum}"),
+        );
+    }
+
+    let remote_stacks = match discover_stacks(runner, pr_numbers) {
+        Ok(stacks) => stacks,
+        Err(DiscoveryError::Unsupported(message)) => {
+            return capability_outcome(
+                mode,
+                GithubStackReason::UnsupportedRepository,
+                pr_numbers,
+                message,
+            );
+        }
+        Err(DiscoveryError::Backend(message)) => return backend_warning(mode, pr_numbers, message),
+    };
+
+    match plan_reconciliation(pr_numbers, &remote_stacks) {
+        ReconcilePlan::Create => {
+            let mut link_args = args(["stack", "link", "--base", base]);
+            link_args.extend(pr_numbers.iter().map(ToString::to_string));
+            match run_link(runner, &link_args) {
+                Ok(()) => {
+                    let confirmation = discover_stacks(runner, &pr_numbers[..1]);
+                    let (stack_number, message) = match confirmation {
+                        Ok(stacks) => (
+                            stacks
+                                .iter()
+                                .find(|stack| {
+                                    stack
+                                        .entries
+                                        .iter()
+                                        .any(|entry| entry.number == pr_numbers[0])
+                                })
+                                .map(|stack| stack.number),
+                            None,
+                        ),
+                        Err(error) => (None, Some(error.message())),
+                    };
+                    GithubStackReconcileOutcome {
+                        result: GithubStackSyncResult {
+                            mode,
+                            action: GithubStackAction::Created,
+                            reason: None,
+                            stack_number,
+                            pr_numbers: pr_numbers.to_vec(),
+                            message,
+                        },
+                        mutation_attempted: true,
+                    }
+                }
+                Err(message) => mutation_warning(mode, pr_numbers, message),
+            }
+        }
+        ReconcilePlan::Append {
+            stack_number,
+            delta,
+        } => {
+            let mut link_args = args(["stack", "link", &stack_number.to_string()]);
+            link_args.extend(delta.iter().map(ToString::to_string));
+            match run_link(runner, &link_args) {
+                Ok(()) => GithubStackReconcileOutcome {
+                    result: GithubStackSyncResult {
+                        mode,
+                        action: GithubStackAction::Appended,
+                        reason: None,
+                        stack_number: Some(stack_number),
+                        pr_numbers: pr_numbers.to_vec(),
+                        message: None,
+                    },
+                    mutation_attempted: true,
+                },
+                Err(message) => mutation_warning(mode, pr_numbers, message),
+            }
+        }
+        ReconcilePlan::Unchanged { stack_number } => GithubStackReconcileOutcome {
+            result: GithubStackSyncResult {
+                mode,
+                action: GithubStackAction::Unchanged,
+                reason: None,
+                stack_number: Some(stack_number),
+                pr_numbers: pr_numbers.to_vec(),
+                message: None,
+            },
+            mutation_attempted: false,
+        },
+        ReconcilePlan::Diverged { message } => GithubStackReconcileOutcome {
+            result: GithubStackSyncResult::warning(
+                mode,
+                GithubStackReason::Diverged,
+                pr_numbers.to_vec(),
+                message,
+            ),
+            mutation_attempted: false,
+        },
+    }
+}
+
+fn args<const N: usize>(items: [&str; N]) -> Vec<String> {
+    items.into_iter().map(ToString::to_string).collect()
+}
+
+fn outcome(result: GithubStackSyncResult) -> GithubStackReconcileOutcome {
+    GithubStackReconcileOutcome {
+        result,
+        mutation_attempted: false,
+    }
+}
+
+fn capability_outcome(
+    mode: GithubStacksIntegration,
+    reason: GithubStackReason,
+    pr_numbers: &[u64],
+    message: String,
+) -> GithubStackReconcileOutcome {
+    if mode == GithubStacksIntegration::Force {
+        outcome(GithubStackSyncResult::warning(
+            mode,
+            reason,
+            pr_numbers.to_vec(),
+            message,
+        ))
+    } else {
+        outcome(GithubStackSyncResult::skipped(
+            mode,
+            reason,
+            pr_numbers.to_vec(),
+        ))
+    }
+}
+
+fn backend_warning(
+    mode: GithubStacksIntegration,
+    pr_numbers: &[u64],
+    message: String,
+) -> GithubStackReconcileOutcome {
+    outcome(GithubStackSyncResult::warning(
+        mode,
+        GithubStackReason::BackendFailed,
+        pr_numbers.to_vec(),
+        message,
+    ))
+}
+
+fn mutation_warning(
+    mode: GithubStacksIntegration,
+    pr_numbers: &[u64],
+    message: String,
+) -> GithubStackReconcileOutcome {
+    GithubStackReconcileOutcome {
+        result: GithubStackSyncResult::warning(
+            mode,
+            GithubStackReason::BackendFailed,
+            pr_numbers.to_vec(),
+            message,
+        ),
+        mutation_attempted: true,
+    }
+}
+
+fn parse_gh_stack_version(output: &str) -> Result<Version, String> {
+    output
+        .split_whitespace()
+        .find_map(|token| Version::parse(token.trim_start_matches('v')).ok())
+        .ok_or_else(|| "Could not parse gh-stack version output".to_string())
+}
+
+fn parse_stack_list(output: &str) -> Result<Vec<RemoteStackSnapshot>, serde_json::Error> {
+    serde_json::from_str::<Vec<GhStackJson>>(output).map(|stacks| {
+        stacks
+            .into_iter()
+            .map(|stack| RemoteStackSnapshot {
+                number: stack.number,
+                entries: stack
+                    .pull_requests
+                    .into_iter()
+                    .map(|pull_request| RemoteStackEntry {
+                        number: pull_request.number,
+                        state: remote_state(pull_request),
+                    })
+                    .collect(),
+            })
+            .collect()
+    })
+}
+
+fn remote_state(pull_request: GhStackPullRequestJson) -> RemotePullRequestState {
+    if pull_request.merged_at.is_some() {
+        RemotePullRequestState::Merged
+    } else if pull_request.draft && pull_request.state.eq_ignore_ascii_case("open") {
+        RemotePullRequestState::Draft
+    } else if pull_request.state.eq_ignore_ascii_case("open") {
+        RemotePullRequestState::Open
+    } else {
+        RemotePullRequestState::Closed
+    }
+}
+
+enum DiscoveryError {
+    Unsupported(String),
+    Backend(String),
+}
+
+impl DiscoveryError {
+    fn message(self) -> String {
+        match self {
+            Self::Unsupported(message) | Self::Backend(message) => message,
+        }
+    }
+}
+
+fn discover_stacks<R: GhCommandRunner>(
+    runner: &R,
+    pr_numbers: &[u64],
+) -> Result<Vec<RemoteStackSnapshot>, DiscoveryError> {
+    let mut stacks = Vec::new();
+    for number in pr_numbers {
+        let endpoint = format!("repos/{{owner}}/{{repo}}/stacks?pull_request={number}");
+        let output = runner
+            .run(&args(["api", endpoint.as_str()]))
+            .map_err(|error| DiscoveryError::Backend(error.to_string()))?;
+        if !output.success {
+            let message = output_message(&output);
+            return if message.contains("HTTP 404") {
+                Err(DiscoveryError::Unsupported(message))
+            } else {
+                Err(DiscoveryError::Backend(message))
+            };
+        }
+        let response_stacks = parse_stack_list(&output.stdout)
+            .map_err(|error| DiscoveryError::Backend(error.to_string()))?;
+        for stack in response_stacks {
+            if !stacks
+                .iter()
+                .any(|existing: &RemoteStackSnapshot| existing.number == stack.number)
+            {
+                stacks.push(stack);
+            }
+        }
+    }
+    Ok(stacks)
+}
+
+fn run_link<R: GhCommandRunner>(runner: &R, args: &[String]) -> Result<(), String> {
+    let output = runner.run(args).map_err(|error| error.to_string())?;
+    if output.success {
+        Ok(())
+    } else {
+        Err(output_message(&output))
+    }
+}
+
+fn output_message(output: &GhCommandOutput) -> String {
+    let message = if !output.stderr.trim().is_empty() {
+        output.stderr.trim()
+    } else if !output.stdout.trim().is_empty() {
+        output.stdout.trim()
+    } else {
+        "gh command exited unsuccessfully"
+    };
+    message.to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::RefCell;
+    use std::collections::VecDeque;
+
+    const STACK_7: &str = r#"[{
+  "number": 7,
+  "pull_requests": [
+    {"number": 40, "state": "closed", "draft": false, "merged_at": "2026-07-01T00:00:00Z"},
+    {"number": 41, "state": "open", "draft": false, "merged_at": null}
+  ]
+}]"#;
+
+    const STACK_7_ACTIVE: &str = r#"[{
+  "number": 7,
+  "pull_requests": [
+    {"number": 40, "state": "closed", "draft": false, "merged_at": "2026-07-01T00:00:00Z"},
+    {"number": 41, "state": "open", "draft": false, "merged_at": null}
+  ]
+}]"#;
+
+    const STACK_7_CREATED: &str = r#"[{
+  "number": 7,
+  "pull_requests": [
+    {"number": 41, "state": "open", "draft": false, "merged_at": null},
+    {"number": 42, "state": "open", "draft": false, "merged_at": null}
+  ]
+}]"#;
+
+    struct ExpectedCommand {
+        args: Vec<String>,
+        output: GhCommandOutput,
+    }
+
+    struct FakeRunner {
+        commands: RefCell<VecDeque<ExpectedCommand>>,
+    }
+
+    impl FakeRunner {
+        fn new(commands: impl IntoIterator<Item = ExpectedCommand>) -> Self {
+            Self {
+                commands: RefCell::new(commands.into_iter().collect()),
+            }
+        }
+
+        fn assert_exhausted(&self) {
+            assert!(
+                self.commands.borrow().is_empty(),
+                "unexpected commands remain"
+            );
+        }
+    }
+
+    impl GhCommandRunner for FakeRunner {
+        fn run(&self, args: &[String]) -> std::io::Result<GhCommandOutput> {
+            let expected = self
+                .commands
+                .borrow_mut()
+                .pop_front()
+                .expect("unexpected gh command");
+            assert_eq!(args, expected.args.as_slice());
+            Ok(expected.output)
+        }
+    }
+
+    fn response(args: &[&str], success: bool, stdout: &str, stderr: &str) -> ExpectedCommand {
+        ExpectedCommand {
+            args: args.iter().map(ToString::to_string).collect(),
+            output: GhCommandOutput {
+                success,
+                stdout: stdout.to_string(),
+                stderr: stderr.to_string(),
+            },
+        }
+    }
 
     fn entry(number: u64, state: RemotePullRequestState) -> RemoteStackEntry {
         RemoteStackEntry { number, state }
@@ -332,5 +759,294 @@ mod tests {
         assert_eq!(result.action, GithubStackAction::Warning);
         assert_eq!(result.reason, Some(GithubStackReason::BackendFailed));
         assert_eq!(result.message.as_deref(), Some("GitHub extension failed"));
+    }
+
+    #[test]
+    fn accepts_minimum_gh_stack_version() {
+        assert_eq!(
+            parse_gh_stack_version("gh stack version 0.1.0\n").unwrap(),
+            semver::Version::new(0, 1, 0)
+        );
+    }
+
+    #[test]
+    fn rejects_outdated_gh_stack_version() {
+        let runner = FakeRunner::new([response(
+            &["stack", "--version"],
+            true,
+            "gh stack version 0.0.8\n",
+            "",
+        )]);
+        let outcome =
+            reconcile_with_runner(&runner, GithubStacksIntegration::Auto, "main", &[41, 42]);
+        assert_eq!(outcome.result.action, GithubStackAction::Skipped);
+        assert_eq!(
+            outcome.result.reason,
+            Some(GithubStackReason::OutdatedExtension)
+        );
+        assert!(!outcome.mutation_attempted);
+        runner.assert_exhausted();
+    }
+
+    #[test]
+    fn force_warns_when_gh_stack_version_is_outdated() {
+        let runner = FakeRunner::new([response(
+            &["stack", "--version"],
+            true,
+            "gh stack version 0.0.8\n",
+            "",
+        )]);
+        let outcome =
+            reconcile_with_runner(&runner, GithubStacksIntegration::Force, "main", &[41, 42]);
+        assert_eq!(outcome.result.action, GithubStackAction::Warning);
+        assert_eq!(
+            outcome.result.reason,
+            Some(GithubStackReason::OutdatedExtension)
+        );
+        assert!(!outcome.mutation_attempted);
+    }
+
+    #[test]
+    fn parses_merged_prefix_and_open_entry() {
+        let stacks = parse_stack_list(STACK_7).unwrap();
+        assert_eq!(stacks[0].entries[0].state, RemotePullRequestState::Merged);
+        assert_eq!(stacks[0].entries[1].state, RemotePullRequestState::Open);
+    }
+
+    #[test]
+    fn parses_draft_and_closed_entries() {
+        let stacks = parse_stack_list(
+            r#"[{"number":7,"pull_requests":[
+                {"number":41,"state":"open","draft":true,"merged_at":null},
+                {"number":42,"state":"closed","draft":false,"merged_at":null}
+            ]}]"#,
+        )
+        .unwrap();
+        assert_eq!(stacks[0].entries[0].state, RemotePullRequestState::Draft);
+        assert_eq!(stacks[0].entries[1].state, RemotePullRequestState::Closed);
+    }
+
+    #[test]
+    fn malformed_stack_api_response_warns_backend_failed() {
+        let runner = FakeRunner::new([
+            response(
+                &["stack", "--version"],
+                true,
+                "gh stack version 0.1.0\n",
+                "",
+            ),
+            response(
+                &["api", "repos/{owner}/{repo}/stacks?pull_request=41"],
+                true,
+                "not json",
+                "",
+            ),
+        ]);
+        let outcome = reconcile_with_runner(&runner, GithubStacksIntegration::Auto, "main", &[41]);
+        assert_eq!(outcome.result.action, GithubStackAction::Warning);
+        assert_eq!(
+            outcome.result.reason,
+            Some(GithubStackReason::BackendFailed)
+        );
+        assert!(!outcome.mutation_attempted);
+    }
+
+    #[test]
+    fn stack_api_404_marks_repository_unsupported() {
+        let runner = FakeRunner::new([
+            response(
+                &["stack", "--version"],
+                true,
+                "gh stack version 0.1.0\n",
+                "",
+            ),
+            response(
+                &["api", "repos/{owner}/{repo}/stacks?pull_request=41"],
+                false,
+                "",
+                "gh: HTTP 404: Not Found",
+            ),
+        ]);
+        let outcome = reconcile_with_runner(&runner, GithubStacksIntegration::Auto, "main", &[41]);
+        assert_eq!(outcome.result.action, GithubStackAction::Skipped);
+        assert_eq!(
+            outcome.result.reason,
+            Some(GithubStackReason::UnsupportedRepository)
+        );
+    }
+
+    #[test]
+    fn create_uses_base_and_numeric_prs_only() {
+        let runner = FakeRunner::new([
+            response(
+                &["stack", "--version"],
+                true,
+                "gh stack version 0.1.0\n",
+                "",
+            ),
+            response(
+                &["api", "repos/{owner}/{repo}/stacks?pull_request=41"],
+                true,
+                "[]",
+                "",
+            ),
+            response(
+                &["api", "repos/{owner}/{repo}/stacks?pull_request=42"],
+                true,
+                "[]",
+                "",
+            ),
+            response(
+                &["stack", "link", "--base", "main", "41", "42"],
+                true,
+                "Created stack\n",
+                "",
+            ),
+            response(
+                &["api", "repos/{owner}/{repo}/stacks?pull_request=41"],
+                true,
+                STACK_7_CREATED,
+                "",
+            ),
+        ]);
+        let outcome =
+            reconcile_with_runner(&runner, GithubStacksIntegration::Auto, "main", &[41, 42]);
+        assert_eq!(outcome.result.action, GithubStackAction::Created);
+        assert_eq!(outcome.result.stack_number, Some(7));
+        assert!(outcome.mutation_attempted);
+        runner.assert_exhausted();
+    }
+
+    #[test]
+    fn append_uses_stack_number_and_delta_only() {
+        let runner = FakeRunner::new([
+            response(
+                &["stack", "--version"],
+                true,
+                "gh stack version 0.1.0\n",
+                "",
+            ),
+            response(
+                &["api", "repos/{owner}/{repo}/stacks?pull_request=41"],
+                true,
+                STACK_7_ACTIVE,
+                "",
+            ),
+            response(
+                &["api", "repos/{owner}/{repo}/stacks?pull_request=42"],
+                true,
+                "[]",
+                "",
+            ),
+            response(
+                &["api", "repos/{owner}/{repo}/stacks?pull_request=43"],
+                true,
+                "[]",
+                "",
+            ),
+            response(&["stack", "link", "7", "42", "43"], true, "", ""),
+        ]);
+        let outcome = reconcile_with_runner(
+            &runner,
+            GithubStacksIntegration::Auto,
+            "main",
+            &[41, 42, 43],
+        );
+        assert_eq!(outcome.result.action, GithubStackAction::Appended);
+        assert_eq!(outcome.result.stack_number, Some(7));
+        assert!(outcome.mutation_attempted);
+        runner.assert_exhausted();
+    }
+
+    #[test]
+    fn unchanged_does_not_invoke_stack_link() {
+        let runner = FakeRunner::new([
+            response(
+                &["stack", "--version"],
+                true,
+                "gh stack version 0.1.0\n",
+                "",
+            ),
+            response(
+                &["api", "repos/{owner}/{repo}/stacks?pull_request=41"],
+                true,
+                STACK_7_CREATED,
+                "",
+            ),
+            response(
+                &["api", "repos/{owner}/{repo}/stacks?pull_request=42"],
+                true,
+                STACK_7_CREATED,
+                "",
+            ),
+        ]);
+        let outcome =
+            reconcile_with_runner(&runner, GithubStacksIntegration::Auto, "main", &[41, 42]);
+        assert_eq!(outcome.result.action, GithubStackAction::Unchanged);
+        assert_eq!(outcome.result.stack_number, Some(7));
+        assert!(!outcome.mutation_attempted);
+        runner.assert_exhausted();
+    }
+
+    #[test]
+    fn link_failure_warns_and_records_mutation_attempt() {
+        let runner = FakeRunner::new([
+            response(
+                &["stack", "--version"],
+                true,
+                "gh stack version 0.1.0\n",
+                "",
+            ),
+            response(
+                &["api", "repos/{owner}/{repo}/stacks?pull_request=41"],
+                true,
+                "[]",
+                "",
+            ),
+            response(
+                &["stack", "link", "--base", "main", "41"],
+                false,
+                "",
+                "link failed",
+            ),
+        ]);
+        let outcome = reconcile_with_runner(&runner, GithubStacksIntegration::Auto, "main", &[41]);
+        assert_eq!(outcome.result.action, GithubStackAction::Warning);
+        assert_eq!(
+            outcome.result.reason,
+            Some(GithubStackReason::BackendFailed)
+        );
+        assert!(outcome.mutation_attempted);
+        assert_eq!(outcome.result.message.as_deref(), Some("link failed"));
+    }
+
+    #[test]
+    fn create_confirmation_failure_preserves_created_result_with_diagnostic() {
+        let runner = FakeRunner::new([
+            response(
+                &["stack", "--version"],
+                true,
+                "gh stack version 0.1.0\n",
+                "",
+            ),
+            response(
+                &["api", "repos/{owner}/{repo}/stacks?pull_request=41"],
+                true,
+                "[]",
+                "",
+            ),
+            response(&["stack", "link", "--base", "main", "41"], true, "", ""),
+            response(
+                &["api", "repos/{owner}/{repo}/stacks?pull_request=41"],
+                false,
+                "",
+                "read failed",
+            ),
+        ]);
+        let outcome = reconcile_with_runner(&runner, GithubStacksIntegration::Auto, "main", &[41]);
+        assert_eq!(outcome.result.action, GithubStackAction::Created);
+        assert_eq!(outcome.result.stack_number, None);
+        assert!(outcome.mutation_attempted);
+        assert_eq!(outcome.result.message.as_deref(), Some("read failed"));
     }
 }

--- a/crates/gg-core/src/github_stacks.rs
+++ b/crates/gg-core/src/github_stacks.rs
@@ -1,0 +1,336 @@
+use serde::Serialize;
+
+use crate::config::GithubStacksIntegration;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RemotePullRequestState {
+    Open,
+    Draft,
+    Merged,
+    Closed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteStackEntry {
+    pub number: u64,
+    pub state: RemotePullRequestState,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteStackSnapshot {
+    pub number: u64,
+    pub entries: Vec<RemoteStackEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReconcilePlan {
+    Create,
+    Append { stack_number: u64, delta: Vec<u64> },
+    Unchanged { stack_number: u64 },
+    Diverged { message: String },
+}
+
+pub fn plan_reconciliation(
+    local_pr_numbers: &[u64],
+    remote_stacks: &[RemoteStackSnapshot],
+) -> ReconcilePlan {
+    let matching_stacks: Vec<_> = remote_stacks
+        .iter()
+        .filter(|stack| {
+            stack
+                .entries
+                .iter()
+                .any(|entry| local_pr_numbers.contains(&entry.number))
+        })
+        .collect();
+
+    let [stack] = matching_stacks.as_slice() else {
+        return match matching_stacks.len() {
+            0 => ReconcilePlan::Create,
+            _ => diverged("Local pull requests belong to multiple native stacks"),
+        };
+    };
+
+    let active_start = stack
+        .entries
+        .iter()
+        .position(|entry| entry.state != RemotePullRequestState::Merged)
+        .unwrap_or(stack.entries.len());
+
+    if stack.entries[..active_start]
+        .iter()
+        .any(|entry| entry.state != RemotePullRequestState::Merged)
+    {
+        return diverged("Native stack has an invalid merged prefix");
+    }
+
+    let active_entries = &stack.entries[active_start..];
+    if active_entries.iter().any(|entry| {
+        !matches!(
+            entry.state,
+            RemotePullRequestState::Open | RemotePullRequestState::Draft
+        )
+    }) {
+        return diverged("Native stack has a closed or merged entry after its active prefix");
+    }
+
+    let active_pr_numbers: Vec<_> = active_entries.iter().map(|entry| entry.number).collect();
+    if active_pr_numbers == local_pr_numbers {
+        ReconcilePlan::Unchanged {
+            stack_number: stack.number,
+        }
+    } else if local_pr_numbers.starts_with(&active_pr_numbers) {
+        ReconcilePlan::Append {
+            stack_number: stack.number,
+            delta: local_pr_numbers[active_pr_numbers.len()..].to_vec(),
+        }
+    } else {
+        diverged("Local pull requests do not match the native stack active sequence")
+    }
+}
+
+fn diverged(message: impl Into<String>) -> ReconcilePlan {
+    ReconcilePlan::Diverged {
+        message: message.into(),
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum GithubStackAction {
+    Created,
+    Appended,
+    Unchanged,
+    Skipped,
+    Warning,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum GithubStackReason {
+    Disabled,
+    PartialSync,
+    InsufficientPrs,
+    UnresolvedPrs,
+    MissingExtension,
+    OutdatedExtension,
+    UnsupportedRepository,
+    Diverged,
+    BackendFailed,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct GithubStackSyncResult {
+    pub mode: GithubStacksIntegration,
+    pub action: GithubStackAction,
+    pub reason: Option<GithubStackReason>,
+    pub stack_number: Option<u64>,
+    pub pr_numbers: Vec<u64>,
+    pub message: Option<String>,
+}
+
+impl GithubStackSyncResult {
+    pub fn skipped(
+        mode: GithubStacksIntegration,
+        reason: GithubStackReason,
+        pr_numbers: Vec<u64>,
+    ) -> Self {
+        Self {
+            mode,
+            action: GithubStackAction::Skipped,
+            reason: Some(reason),
+            stack_number: None,
+            pr_numbers,
+            message: None,
+        }
+    }
+
+    pub fn warning(
+        mode: GithubStacksIntegration,
+        reason: GithubStackReason,
+        pr_numbers: Vec<u64>,
+        message: String,
+    ) -> Self {
+        Self {
+            mode,
+            action: GithubStackAction::Warning,
+            reason: Some(reason),
+            stack_number: None,
+            pr_numbers,
+            message: Some(message),
+        }
+    }
+
+    pub fn is_warning(&self) -> bool {
+        self.action == GithubStackAction::Warning
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(number: u64, state: RemotePullRequestState) -> RemoteStackEntry {
+        RemoteStackEntry { number, state }
+    }
+
+    #[test]
+    fn plans_create_when_no_local_pr_is_stacked() {
+        assert_eq!(plan_reconciliation(&[41, 42], &[]), ReconcilePlan::Create);
+    }
+
+    #[test]
+    fn plans_unchanged_for_exact_active_sequence_after_merged_prefix() {
+        let remote = RemoteStackSnapshot {
+            number: 7,
+            entries: vec![
+                entry(40, RemotePullRequestState::Merged),
+                entry(41, RemotePullRequestState::Open),
+                entry(42, RemotePullRequestState::Draft),
+            ],
+        };
+        assert_eq!(
+            plan_reconciliation(&[41, 42], &[remote]),
+            ReconcilePlan::Unchanged { stack_number: 7 }
+        );
+    }
+
+    #[test]
+    fn plans_append_with_only_the_new_top_delta() {
+        let remote = RemoteStackSnapshot {
+            number: 7,
+            entries: vec![entry(41, RemotePullRequestState::Open)],
+        };
+        assert_eq!(
+            plan_reconciliation(&[41, 42, 43], &[remote]),
+            ReconcilePlan::Append {
+                stack_number: 7,
+                delta: vec![42, 43],
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_reordered_active_prs() {
+        let remote = RemoteStackSnapshot {
+            number: 7,
+            entries: vec![
+                entry(41, RemotePullRequestState::Open),
+                entry(42, RemotePullRequestState::Open),
+            ],
+        };
+        assert!(matches!(
+            plan_reconciliation(&[42, 41], &[remote]),
+            ReconcilePlan::Diverged { .. }
+        ));
+    }
+
+    #[test]
+    fn rejects_closed_unmerged_remote_entry() {
+        let remote = RemoteStackSnapshot {
+            number: 7,
+            entries: vec![
+                entry(41, RemotePullRequestState::Open),
+                entry(42, RemotePullRequestState::Closed),
+            ],
+        };
+        assert!(matches!(
+            plan_reconciliation(&[41, 43], &[remote]),
+            ReconcilePlan::Diverged { .. }
+        ));
+    }
+
+    #[test]
+    fn rejects_membership_in_multiple_native_stacks() {
+        let first = RemoteStackSnapshot {
+            number: 7,
+            entries: vec![entry(41, RemotePullRequestState::Open)],
+        };
+        let second = RemoteStackSnapshot {
+            number: 8,
+            entries: vec![entry(42, RemotePullRequestState::Open)],
+        };
+        assert!(matches!(
+            plan_reconciliation(&[41, 42], &[first, second]),
+            ReconcilePlan::Diverged { .. }
+        ));
+    }
+
+    #[test]
+    fn rejects_local_removal_from_active_suffix() {
+        let remote = RemoteStackSnapshot {
+            number: 7,
+            entries: vec![
+                entry(41, RemotePullRequestState::Open),
+                entry(42, RemotePullRequestState::Draft),
+            ],
+        };
+        assert!(matches!(
+            plan_reconciliation(&[41], &[remote]),
+            ReconcilePlan::Diverged { .. }
+        ));
+    }
+
+    #[test]
+    fn rejects_merged_entry_after_an_active_entry() {
+        let remote = RemoteStackSnapshot {
+            number: 7,
+            entries: vec![
+                entry(41, RemotePullRequestState::Open),
+                entry(42, RemotePullRequestState::Merged),
+            ],
+        };
+        assert!(matches!(
+            plan_reconciliation(&[41, 42], &[remote]),
+            ReconcilePlan::Diverged { .. }
+        ));
+    }
+
+    #[test]
+    fn plans_create_when_only_unrelated_prior_stack_is_fully_merged() {
+        let remote = RemoteStackSnapshot {
+            number: 7,
+            entries: vec![
+                entry(40, RemotePullRequestState::Merged),
+                entry(41, RemotePullRequestState::Merged),
+            ],
+        };
+        assert_eq!(
+            plan_reconciliation(&[42, 43], &[remote]),
+            ReconcilePlan::Create
+        );
+    }
+
+    #[test]
+    fn skipped_result_normalizes_skip_state() {
+        assert_eq!(
+            GithubStackSyncResult::skipped(
+                GithubStacksIntegration::Auto,
+                GithubStackReason::Disabled,
+                vec![41, 42],
+            ),
+            GithubStackSyncResult {
+                mode: GithubStacksIntegration::Auto,
+                action: GithubStackAction::Skipped,
+                reason: Some(GithubStackReason::Disabled),
+                stack_number: None,
+                pr_numbers: vec![41, 42],
+                message: None,
+            }
+        );
+    }
+
+    #[test]
+    fn warning_result_normalizes_warning_state() {
+        let result = GithubStackSyncResult::warning(
+            GithubStacksIntegration::Force,
+            GithubStackReason::BackendFailed,
+            vec![41, 42],
+            "GitHub extension failed".to_string(),
+        );
+        assert!(result.is_warning());
+        assert_eq!(result.action, GithubStackAction::Warning);
+        assert_eq!(result.reason, Some(GithubStackReason::BackendFailed));
+        assert_eq!(result.message.as_deref(), Some("GitHub extension failed"));
+    }
+}

--- a/crates/gg-core/src/github_stacks.rs
+++ b/crates/gg-core/src/github_stacks.rs
@@ -227,6 +227,14 @@ fn reconcile_with_runner<R: GhCommandRunner>(
     base: &str,
     pr_numbers: &[u64],
 ) -> GithubStackReconcileOutcome {
+    if pr_numbers.is_empty() {
+        return outcome(GithubStackSyncResult::skipped(
+            mode,
+            GithubStackReason::InsufficientPrs,
+            Vec::new(),
+        ));
+    }
+
     if mode == GithubStacksIntegration::Off {
         return outcome(GithubStackSyncResult::skipped(
             mode,
@@ -282,8 +290,8 @@ fn reconcile_with_runner<R: GhCommandRunner>(
                 Ok(()) => {
                     let confirmation = discover_stacks(runner, &pr_numbers[..1]);
                     let (stack_number, message) = match confirmation {
-                        Ok(stacks) => (
-                            stacks
+                        Ok(stacks) => {
+                            let stack_number = stacks
                                 .iter()
                                 .find(|stack| {
                                     stack
@@ -291,9 +299,12 @@ fn reconcile_with_runner<R: GhCommandRunner>(
                                         .iter()
                                         .any(|entry| entry.number == pr_numbers[0])
                                 })
-                                .map(|stack| stack.number),
-                            None,
-                        ),
+                                .map(|stack| stack.number);
+                            let message = stack_number
+                                .is_none()
+                                .then(|| "Created native stack could not be confirmed".to_string());
+                            (stack_number, message)
+                        }
                         Err(error) => (None, Some(error.message())),
                     };
                     GithubStackReconcileOutcome {
@@ -807,6 +818,38 @@ mod tests {
     }
 
     #[test]
+    fn force_warns_when_gh_stack_extension_is_missing() {
+        let runner = FakeRunner::new([response(
+            &["stack", "--version"],
+            false,
+            "",
+            "unknown command \"stack\"",
+        )]);
+        let outcome =
+            reconcile_with_runner(&runner, GithubStacksIntegration::Force, "main", &[41, 42]);
+        assert_eq!(outcome.result.action, GithubStackAction::Warning);
+        assert_eq!(
+            outcome.result.reason,
+            Some(GithubStackReason::MissingExtension)
+        );
+        assert!(!outcome.mutation_attempted);
+        runner.assert_exhausted();
+    }
+
+    #[test]
+    fn empty_pr_numbers_skip_without_running_gh() {
+        let runner = FakeRunner::new([]);
+        let outcome = reconcile_with_runner(&runner, GithubStacksIntegration::Auto, "main", &[]);
+        assert_eq!(outcome.result.action, GithubStackAction::Skipped);
+        assert_eq!(
+            outcome.result.reason,
+            Some(GithubStackReason::InsufficientPrs)
+        );
+        assert!(!outcome.mutation_attempted);
+        runner.assert_exhausted();
+    }
+
+    #[test]
     fn parses_merged_prefix_and_open_entry() {
         let stacks = parse_stack_list(STACK_7).unwrap();
         assert_eq!(stacks[0].entries[0].state, RemotePullRequestState::Merged);
@@ -1048,5 +1091,39 @@ mod tests {
         assert_eq!(outcome.result.stack_number, None);
         assert!(outcome.mutation_attempted);
         assert_eq!(outcome.result.message.as_deref(), Some("read failed"));
+    }
+
+    #[test]
+    fn create_confirmation_without_stack_records_diagnostic() {
+        let runner = FakeRunner::new([
+            response(
+                &["stack", "--version"],
+                true,
+                "gh stack version 0.1.0\n",
+                "",
+            ),
+            response(
+                &["api", "repos/{owner}/{repo}/stacks?pull_request=41"],
+                true,
+                "[]",
+                "",
+            ),
+            response(&["stack", "link", "--base", "main", "41"], true, "", ""),
+            response(
+                &["api", "repos/{owner}/{repo}/stacks?pull_request=41"],
+                true,
+                "[]",
+                "",
+            ),
+        ]);
+        let outcome = reconcile_with_runner(&runner, GithubStacksIntegration::Auto, "main", &[41]);
+        assert_eq!(outcome.result.action, GithubStackAction::Created);
+        assert_eq!(outcome.result.stack_number, None);
+        assert!(outcome.mutation_attempted);
+        assert_eq!(
+            outcome.result.message.as_deref(),
+            Some("Created native stack could not be confirmed")
+        );
+        runner.assert_exhausted();
     }
 }

--- a/crates/gg-core/src/lib.rs
+++ b/crates/gg-core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod context;
 pub mod error;
 pub mod gh;
 pub mod git;
+pub mod github_stacks;
 pub mod glab;
 pub mod immutability;
 pub mod managed_body;

--- a/crates/gg-core/src/output.rs
+++ b/crates/gg-core/src/output.rs
@@ -277,6 +277,7 @@ pub enum SyncStreamingEvent {
         base: String,
         rebased_before_sync: bool,
         warnings: Vec<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         github_stack: Option<GithubStackSyncResult>,
         metadata: SyncMetadataJson,
         entries: Vec<SyncEntryResultJson>,

--- a/crates/gg-core/src/output.rs
+++ b/crates/gg-core/src/output.rs
@@ -4,6 +4,8 @@ use std::io::{self, Write};
 
 use serde::{Serialize, Serializer};
 
+use crate::github_stacks::{GithubStackAction, GithubStackSyncResult};
+
 pub const OUTPUT_VERSION: u32 = 1;
 const STREAMING_ABORT_EXIT_CODE: i32 = 1;
 
@@ -195,6 +197,11 @@ impl Serialize for SyncStreamingResponse {
     {
         let status = match &self.event {
             SyncStreamingEvent::Error { .. } | SyncStreamingEvent::PushError { .. } => "error",
+            SyncStreamingEvent::GithubStack { result }
+                if result.action == GithubStackAction::Warning =>
+            {
+                "warning"
+            }
             _ => "ok",
         };
         let mut value = serde_json::to_value(&self.event).map_err(serde::ser::Error::custom)?;
@@ -258,6 +265,10 @@ pub enum SyncStreamingEvent {
         action: String,
         error: Option<String>,
     },
+    GithubStack {
+        #[serde(flatten)]
+        result: GithubStackSyncResult,
+    },
     Error {
         message: String,
     },
@@ -266,6 +277,7 @@ pub enum SyncStreamingEvent {
         base: String,
         rebased_before_sync: bool,
         warnings: Vec<String>,
+        github_stack: Option<GithubStackSyncResult>,
         metadata: SyncMetadataJson,
         entries: Vec<SyncEntryResultJson>,
     },
@@ -277,6 +289,7 @@ pub struct SyncResultJson {
     pub base: String,
     pub rebased_before_sync: bool,
     pub warnings: Vec<String>,
+    pub github_stack: Option<GithubStackSyncResult>,
     pub metadata: SyncMetadataJson,
     pub entries: Vec<SyncEntryResultJson>,
 }
@@ -505,6 +518,8 @@ pub struct InboxStackErrorJson {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::GithubStacksIntegration;
+    use crate::github_stacks::{GithubStackAction, GithubStackReason, GithubStackSyncResult};
     use std::io::{self, Write};
 
     struct BrokenPipeWriter;
@@ -904,6 +919,47 @@ mod tests {
         assert_eq!(v["total_entries"], 3);
     }
 
+    fn created_github_stack_result() -> GithubStackSyncResult {
+        GithubStackSyncResult {
+            mode: GithubStacksIntegration::Auto,
+            action: GithubStackAction::Created,
+            reason: None,
+            stack_number: Some(7),
+            pr_numbers: vec![41, 42],
+            message: None,
+        }
+    }
+
+    #[test]
+    fn sync_streaming_github_stack_event_is_flat_and_ok() {
+        let response = SyncStreamingResponse {
+            version: OUTPUT_VERSION,
+            command: "sync".to_string(),
+            event: SyncStreamingEvent::GithubStack {
+                result: created_github_stack_result(),
+            },
+        };
+        let value = serde_json::to_value(response).unwrap();
+        assert_eq!(value["event"], "github_stack");
+        assert_eq!(value["status"], "ok");
+        assert_eq!(value["action"], "created");
+        assert_eq!(value["stack_number"], 7);
+    }
+
+    #[test]
+    fn sync_streaming_github_stack_warning_has_warning_status() {
+        let mut result = created_github_stack_result();
+        result.action = GithubStackAction::Warning;
+        result.reason = Some(GithubStackReason::Diverged);
+        let response = SyncStreamingResponse {
+            version: OUTPUT_VERSION,
+            command: "sync".to_string(),
+            event: SyncStreamingEvent::GithubStack { result },
+        };
+        let value = serde_json::to_value(response).unwrap();
+        assert_eq!(value["status"], "warning");
+    }
+
     #[test]
     fn sync_streaming_summary_includes_entries() {
         let response = SyncStreamingResponse {
@@ -914,6 +970,7 @@ mod tests {
                 base: "main".to_string(),
                 rebased_before_sync: false,
                 warnings: vec!["w".to_string()],
+                github_stack: Some(created_github_stack_result()),
                 metadata: SyncMetadataJson {
                     gg_ids_added: 1,
                     gg_parents_updated: 2,
@@ -927,6 +984,7 @@ mod tests {
         assert_eq!(v["status"], "ok");
         assert_eq!(v["metadata"]["gg_ids_added"], 1);
         assert_eq!(v["warnings"][0], "w");
+        assert_eq!(v["github_stack"]["stack_number"], 7);
     }
 
     #[test]

--- a/docs/src/commands/setup.md
+++ b/docs/src/commands/setup.md
@@ -71,6 +71,16 @@ Full mode organizes all settings into logical groups:
 |-------|------|---------|-------------|
 | `worktree_base_path` | string | empty | Template for stack worktrees ({repo}, {stack}) |
 
+### GitHub (only shown if provider is GitHub)
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `github.stacks_integration` | select (`off`, `auto`, `force`) | auto | GitHub Stacked PRs public-preview integration. `auto` is best effort with the optional `gh stack` extension; `force` reports unavailable capabilities as warnings; `off` disables it. |
+
+The GitHub Stacked PRs selector appears only when GitHub is selected as the
+effective provider. GitLab setup does not prompt for it and preserves any
+existing GitHub setting.
+
 ### GitLab (only shown if provider is GitLab)
 
 | Field | Type | Default | Description |

--- a/docs/src/commands/sync.md
+++ b/docs/src/commands/sync.md
@@ -75,6 +75,85 @@ gg sync --no-verify
 
 When computing the target branch for each PR/MR, `gg sync` walks backwards through predecessor entries and skips any that are already merged or closed. If all predecessors have been merged, the target falls back to `stack.base`. This ensures downstream MRs are correctly retargeted after an upstream MR is merged — whether merged via `gg land` or directly in the provider UI.
 
+## GitHub Stacked PRs (public preview)
+
+For a full GitHub `gg sync` (without `--until`), git-gud collects the current
+stack's active open and draft PR numbers in bottom-to-top order. When there are
+at least two resolved PRs and `defaults.github.stacks_integration` is not
+`off`, it can reconcile GitHub's native Stacked PRs map through the optional
+official `gh stack` extension. This does not replace or change git-gud's local
+stack metadata, and GitLab sync never uses this integration.
+
+Install the extension yourself if you want the native UI:
+
+```sh
+gh extension install github/gh-stack
+```
+
+git-gud never installs or upgrades it automatically. The minimum supported
+extension version is `0.1.0`.
+
+### Eligibility and safe outcomes
+
+The integration is skipped when it is disabled, the sync is partial, fewer than
+two active PRs are available, or an active PR cannot be resolved. Full syncs
+create GitHub Stacked PRs when none of the active PRs is already associated,
+and append only new top PRs when the native active sequence is an exact ordered
+prefix of git-gud's sequence. Appending by stack number preserves a merged
+prefix; git-gud does not relink merged PRs or retarget a PR onto a merged
+branch.
+
+If the native and local sequences diverge, git-gud performs no mutation and
+returns a warning. Inspect the GitHub Stacked PRs map, explicitly unstack or
+repair it with GitHub's tools, then rerun `gg sync`. Version one never removes,
+reorders, unlinks, or recreates GitHub Stacked PRs.
+
+`auto` silently records a skipped result when the extension is missing or
+outdated, or the repository does not support the public preview. `force` uses
+the same create/append-only safety checks but surfaces those capability states
+as warnings. Divergence, malformed responses, authentication or network errors,
+and a failed `gh stack link` are warnings in both modes. Every native-integration
+failure is non-fatal to an otherwise successful `gg sync`.
+
+### JSON and JSONL output
+
+Atomic `gg sync --json` includes a `sync.github_stack` object for GitHub syncs
+(and `null` when the provider is not GitHub or provider detection did not
+complete). It always contains `mode`, `action`, `reason`, `stack_number`,
+`pr_numbers`, and `message`:
+
+```json
+{
+  "version": 1,
+  "sync": {
+    "stack": "feature",
+    "base": "main",
+    "github_stack": {
+      "mode": "auto",
+      "action": "created",
+      "reason": null,
+      "stack_number": 7,
+      "pr_numbers": [41, 42],
+      "message": null
+    }
+  }
+}
+```
+
+`action` is one of `created`, `appended`, `unchanged`, `skipped`, or `warning`.
+Stable reasons include `disabled`, `partial_sync`, `insufficient_prs`,
+`unresolved_prs`, `missing_extension`, `outdated_extension`,
+`unsupported_repository`, `diverged`, and `backend_failed`.
+
+`gg sync --jsonl` emits a line-delimited `github_stack` event immediately after
+reconciliation and repeats the same result in the deterministic final `summary`
+event. Its `status` is `ok` for created, appended, unchanged, and skipped
+results, and `warning` for warning results. For example, a divergence event is:
+
+```ndjson
+{"version":1,"command":"sync","status":"warning","event":"github_stack","mode":"auto","action":"warning","reason":"diverged","stack_number":null,"pr_numbers":[41,42],"message":"Local pull requests do not match the native stack active sequence"}
+```
+
 ## PR/MR Body Ownership
 
 When `gg sync` creates a new PR/MR, the generated description is wrapped in invisible HTML comment markers:
@@ -143,6 +222,7 @@ Event kinds:
 | `pr_updated` | `position`, `pr_number`, `action` | Existing PR/MR updated (`updated`/`recreated`) |
 | `pr_skipped_closed` | `position`, `pr_number` | Existing PR/MR is merged/closed and skipped |
 | `nav_comment` | `position`, `pr_number`, `action`, `error` | Managed nav comment reconciled (`created`/`updated`/`unchanged`/`deleted`/`error`/`skip`) |
+| `github_stack` | `mode`, `action`, `reason`, `stack_number`, `pr_numbers`, `message` | GitHub Stacked PRs reconciliation completed; `status` is `ok` or `warning` |
 | `error` | `message` | Fatal error before completion |
 | `summary` | same shape as `--json` `sync` object | Sync finished (success or partial failure) |
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -42,6 +42,9 @@ For global config, manually create `~/.config/gg/config.json` with your preferre
     "sync_update_descriptions": true,
     "sync_update_title": false,
     "worktree_base_path": "/tmp/gg-worktrees",
+    "github": {
+      "stacks_integration": "auto"
+    },
     "gitlab": {
       "auto_merge_on_land": false
     }
@@ -70,6 +73,7 @@ For global config, manually create `~/.config/gg/config.json` with your preferre
 | `sync_update_title` | `boolean` | Update PR/MR titles on re-sync | `false` |
 | `stack_nav_comments` | `boolean` | Post a managed navigation comment on each open PR/MR in a multi-entry stack, listing all entries with a 👉 marker on the current one. When set back to `false`, the next `gg sync` removes any previously-posted managed comments. Skipped for single-entry stacks and when `--until` limits a sync. | `false` |
 | `worktree_base_path` | `string` | Base directory for managed worktrees | Parent of repo |
+| `github.stacks_integration` | `off` \| `auto` \| `force` | GitHub Stacked PRs public-preview integration. `off` never inspects or updates it; `auto` attempts it when the optional `gh stack` extension and repository support are available; `force` uses the same safe behavior but reports unavailable capabilities as warnings. Ordinary GitHub sync works without the extension. | `auto` |
 | `gitlab.auto_merge_on_land` | `boolean` | Default GitLab auto-merge behavior for `gg land` | `false` |
 
 ## Global Config

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -28,6 +28,15 @@ Before using git-gud, make sure you have:
 - [GitHub CLI (`gh`)](https://cli.github.com/) for GitHub repositories
 - [GitLab CLI (`glab`)](https://gitlab.com/gitlab-org/cli) for GitLab repositories
 
+`gh` is required for GitHub PR creation and ordinary `gg sync`. The optional
+[`github/gh-stack`](https://github.com/github/gh-stack) extension adds the
+native GitHub Stacked PRs map and UI; it is not required for PR creation or
+ordinary sync.
+
+```sh
+gh extension install github/gh-stack
+```
+
 ## Authentication
 
 Authenticate with your provider CLI first:

--- a/docs/superpowers/plans/2026-08-01-github-stacks-integration.md
+++ b/docs/superpowers/plans/2026-08-01-github-stacks-integration.md
@@ -1,0 +1,1126 @@
+# Native GitHub Stacks Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make full `gg sync` runs create or append GitHub native Stacked PR associations through the official `github/gh-stack` extension while preserving git-gud ownership and non-fatal sync behavior.
+
+**Architecture:** Add a GitHub-specific configuration enum, then build a focused `github_stacks` module with a pure create/append reconciliation planner and an injectable `gh` command backend. `sync` supplies its ordered active PR numbers, records mutation attempts as remote touches, and maps the normalized result into human, JSON, and JSONL output without exposing extension subprocess output.
+
+**Tech Stack:** Rust 2021, serde/serde_json, semver, std::process::Command, clap/dialoguer configuration UI, Cargo unit and CLI integration tests, mdBook.
+
+## Global Constraints
+
+- The only mutation backend is the official `github/gh-stack` extension.
+- The minimum supported extension version is exactly `v0.1.0`.
+- `defaults.github.stacks_integration` accepts exactly `off`, `auto`, and `force`; the default is `auto`.
+- Version one may create a native stack or append new top PRs; it must never remove, reorder, unstack, or recreate a diverged native stack.
+- Every native-stack failure is non-fatal to an otherwise successful `gg sync`.
+- `auto` silently skips missing/outdated extension and unsupported repositories; `force` reports those capability states as warnings.
+- `force` never bypasses version, repository, or create/append-only safety checks.
+- Native integration runs only for GitHub and never mutates git-gud local stack tracking.
+- Partial `gg sync --until` runs and GitLab runs must not call the backend.
+- Only numeric PR arguments may be passed to `gh stack link`.
+- `--json` remains atomic; `--jsonl` emits an immediate `github_stack` event and a deterministic final summary.
+- Existing GitLab behavior, `GG-ID`/`GG-Parent` behavior, and current PR base chaining remain unchanged.
+- Do not update `skills/gg`; the CLI owns this decision and no agent authority boundary changes.
+- Every production change must have tests, `cargo fmt --all` must pass, Clippy must pass with `-D warnings`, and the full all-features test suite must pass.
+
+---
+
+## File Map
+
+- Modify `crates/gg-core/Cargo.toml`: add the direct `semver` dependency used for the extension version floor.
+- Modify `Cargo.lock`: record the direct workspace dependency relationship after Cargo updates the lockfile.
+- Modify `crates/gg-core/src/config.rs`: define `GithubDefaults` and `GithubStacksIntegration`, default/serde behavior, getter, and unit tests.
+- Modify `crates/gg-core/src/commands/setup.rs`: add the GitHub-only full-setup selector and pure selection helpers/tests.
+- Create `crates/gg-core/src/github_stacks.rs`: own remote models, normalized results, pure reconciliation planning, extension/API execution, and unit tests.
+- Modify `crates/gg-core/src/lib.rs`: export the focused `github_stacks` module.
+- Modify `crates/gg-core/src/output.rs`: add `github_stack` to atomic/summary output and the progressive event/status mapping.
+- Modify `crates/gg-core/src/commands/sync.rs`: collect active PRs, run or skip reconciliation, mark remote attempts, render results, and populate output.
+- Create `crates/gg-cli/tests/integration_tests/github_stacks.rs`: focused fake-`gh` command-contract and structured-output tests.
+- Modify `crates/gg-cli/tests/integration_tests/main.rs`: register the new integration-test module.
+- Modify `crates/gg-cli/tests/integration_tests/sync.rs`: opt unrelated multi-entry fake-`gh` fixtures out where their scripts intentionally do not model `gh-stack`.
+- Modify `README.md`: feature summary, prerequisite, sync behavior, and configuration table.
+- Modify `docs/src/configuration.md`: document the nested GitHub mode and default.
+- Modify `docs/src/commands/setup.md`: document the GitHub selector.
+- Modify `docs/src/commands/sync.md`: document eligibility, outcomes, recovery, JSON, and JSONL.
+- Modify `docs/src/getting-started.md`: document optional extension installation for the native UI.
+
+---
+
+### Task 1: Add GitHub Stacks Configuration and Setup Selection
+
+**Files:**
+- Modify: `crates/gg-core/src/config.rs`
+- Modify: `crates/gg-core/src/commands/setup.rs`
+
+**Interfaces:**
+- Produces: `GithubStacksIntegration::{Off, Auto, Force}` with lowercase serde names and `Default::default() == Auto`.
+- Produces: `GithubDefaults { pub stacks_integration: GithubStacksIntegration }`.
+- Produces: `Config::get_github_stacks_integration(&self) -> GithubStacksIntegration`.
+- Consumes later: Tasks 2-4 use the enum and getter; no task may parse mode strings independently.
+
+- [ ] **Step 1: Add failing configuration tests**
+
+Add tests beside the existing GitLab/default tests in `config.rs`:
+
+```rust
+#[test]
+fn test_github_stacks_integration_defaults_to_auto() {
+    let config: Config = serde_json::from_str(r#"{"defaults":{}}"#).unwrap();
+    assert_eq!(
+        config.get_github_stacks_integration(),
+        GithubStacksIntegration::Auto
+    );
+}
+
+#[test]
+fn test_github_stacks_integration_round_trips_all_modes() {
+    for mode in [
+        GithubStacksIntegration::Off,
+        GithubStacksIntegration::Auto,
+        GithubStacksIntegration::Force,
+    ] {
+        let mut config = Config::default();
+        config.defaults.github.stacks_integration = mode;
+        let json = serde_json::to_string(&config).unwrap();
+        let parsed: Config = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.get_github_stacks_integration(), mode);
+    }
+}
+
+#[test]
+fn test_github_stacks_integration_uses_lowercase_json() {
+    let config: Config = serde_json::from_str(
+        r#"{"defaults":{"github":{"stacks_integration":"force"}}}"#,
+    )
+    .unwrap();
+    assert_eq!(
+        config.get_github_stacks_integration(),
+        GithubStacksIntegration::Force
+    );
+}
+
+#[test]
+fn test_local_config_overrides_global_github_stacks_mode() {
+    let mut effective = Config::default();
+    effective.defaults.github.stacks_integration = GithubStacksIntegration::Force;
+    let mut local = Config::default();
+    local.defaults.github.stacks_integration = GithubStacksIntegration::Off;
+    effective.merge_local(local);
+    assert_eq!(
+        effective.get_github_stacks_integration(),
+        GithubStacksIntegration::Off
+    );
+}
+```
+
+- [ ] **Step 2: Run the config tests and verify the missing types fail compilation**
+
+Run:
+
+```sh
+cargo test -p gg-core config::tests::test_github_stacks_integration -- --nocapture
+```
+
+Expected: FAIL with unresolved `GithubStacksIntegration` and missing `Defaults::github`/getter errors.
+
+- [ ] **Step 3: Implement the configuration model and getter**
+
+Add the GitHub defaults next to `GitLabDefaults` and place `github` next to `gitlab` in `Defaults`:
+
+```rust
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum GithubStacksIntegration {
+    Off,
+    #[default]
+    Auto,
+    Force,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct GithubDefaults {
+    #[serde(default)]
+    pub stacks_integration: GithubStacksIntegration,
+}
+```
+
+Add `#[serde(default)] pub github: GithubDefaults` to `Defaults`, initialize it in `Defaults::default`, and add:
+
+```rust
+pub fn get_github_stacks_integration(&self) -> GithubStacksIntegration {
+    self.defaults.github.stacks_integration
+}
+```
+
+- [ ] **Step 4: Run focused configuration tests**
+
+Run:
+
+```sh
+cargo test -p gg-core config::tests::test_github_stacks_integration -- --nocapture
+```
+
+Expected: PASS for default, round-trip, and lowercase tests.
+
+- [ ] **Step 5: Add failing pure setup-selection tests**
+
+Extract selection helpers in `commands/setup.rs` and test them without opening an interactive terminal:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn github_stacks_prompt_is_github_only() {
+        assert!(should_prompt_github_stacks(Some("github")));
+        assert!(!should_prompt_github_stacks(Some("gitlab")));
+        assert!(!should_prompt_github_stacks(None));
+    }
+
+    #[test]
+    fn github_stacks_mode_indices_round_trip() {
+        for mode in [
+            GithubStacksIntegration::Auto,
+            GithubStacksIntegration::Off,
+            GithubStacksIntegration::Force,
+        ] {
+            assert_eq!(github_stacks_mode_from_index(github_stacks_mode_index(mode)), mode);
+        }
+    }
+
+    #[test]
+    fn gitlab_setup_preserves_existing_github_stacks_mode() {
+        let mut defaults = Defaults::default();
+        defaults.github.stacks_integration = GithubStacksIntegration::Force;
+        if should_prompt_github_stacks(Some("gitlab")) {
+            defaults.github.stacks_integration = GithubStacksIntegration::Off;
+        }
+        assert_eq!(
+            defaults.github.stacks_integration,
+            GithubStacksIntegration::Force
+        );
+    }
+}
+```
+
+- [ ] **Step 6: Run setup tests and verify helper names fail**
+
+Run:
+
+```sh
+cargo test -p gg-core commands::setup::tests::github_stacks -- --nocapture
+```
+
+Expected: FAIL with unresolved helper/import errors.
+
+- [ ] **Step 7: Implement the GitHub-only full-setup selector**
+
+Import `GithubStacksIntegration`, then add these helpers:
+
+```rust
+fn should_prompt_github_stacks(provider: Option<&str>) -> bool {
+    provider == Some("github")
+}
+
+fn github_stacks_mode_index(mode: GithubStacksIntegration) -> usize {
+    match mode {
+        GithubStacksIntegration::Auto => 0,
+        GithubStacksIntegration::Off => 1,
+        GithubStacksIntegration::Force => 2,
+    }
+}
+
+fn github_stacks_mode_from_index(index: usize) -> GithubStacksIntegration {
+    match index {
+        1 => GithubStacksIntegration::Off,
+        2 => GithubStacksIntegration::Force,
+        _ => GithubStacksIntegration::Auto,
+    }
+}
+```
+
+In `prompt_defaults_full`, after the Sync group and before Land, show a `GitHub` group only when the effective provider is GitHub:
+
+```rust
+if should_prompt_github_stacks(defaults.provider.as_deref()) {
+    print_group_header("GitHub");
+    let choices = [
+        "Auto (recommended)",
+        "Off",
+        "Force (warn when unavailable)",
+    ];
+    let selected = Select::with_theme(theme)
+        .with_prompt("Link synced PRs into GitHub's native Stacked PRs UI?")
+        .items(&choices)
+        .default(github_stacks_mode_index(existing.github.stacks_integration))
+        .interact()
+        .map_err(|e| GgError::Other(format!("Prompt failed: {}", e)))?;
+    defaults.github.stacks_integration = github_stacks_mode_from_index(selected);
+}
+```
+
+Because `defaults` starts as `existing.clone()`, GitLab full setup preserves the existing GitHub value.
+
+- [ ] **Step 8: Run focused and crate tests**
+
+Run:
+
+```sh
+cargo test -p gg-core config::tests::test_github_stacks_integration -- --nocapture
+cargo test -p gg-core commands::setup::tests::github_stacks -- --nocapture
+cargo test -p gg-core
+```
+
+Expected: all PASS.
+
+- [ ] **Step 9: Commit the configuration deliverable**
+
+```sh
+git add crates/gg-core/src/config.rs crates/gg-core/src/commands/setup.rs
+git commit -m "feat(config): add GitHub Stacks integration mode"
+```
+
+---
+
+### Task 2: Build the Pure Native-Stack Reconciliation Planner
+
+**Files:**
+- Create: `crates/gg-core/src/github_stacks.rs`
+- Modify: `crates/gg-core/src/lib.rs`
+
+**Interfaces:**
+- Consumes: `crate::config::GithubStacksIntegration` from Task 1.
+- Produces: `RemotePullRequestState`, `RemoteStackEntry`, and `RemoteStackSnapshot` as the backend-neutral remote model.
+- Produces: `ReconcilePlan::{Create, Append, Unchanged, Diverged}`.
+- Produces: `plan_reconciliation(local_pr_numbers: &[u64], remote_stacks: &[RemoteStackSnapshot]) -> ReconcilePlan`.
+- Produces: serialized `GithubStackAction`, `GithubStackReason`, and `GithubStackSyncResult` used by Tasks 3-4.
+
+- [ ] **Step 1: Register the empty focused module**
+
+Add `pub mod github_stacks;` to `lib.rs` and create `github_stacks.rs` with the imports and type declarations needed by the tests in the next step. Do not add subprocess execution in this task.
+
+- [ ] **Step 2: Add failing planner tests for create, unchanged, and append**
+
+Define a small test helper and concrete expectations:
+
+```rust
+fn entry(number: u64, state: RemotePullRequestState) -> RemoteStackEntry {
+    RemoteStackEntry { number, state }
+}
+
+#[test]
+fn plans_create_when_no_local_pr_is_stacked() {
+    assert_eq!(plan_reconciliation(&[41, 42], &[]), ReconcilePlan::Create);
+}
+
+#[test]
+fn plans_unchanged_for_exact_active_sequence_after_merged_prefix() {
+    let remote = RemoteStackSnapshot {
+        number: 7,
+        entries: vec![
+            entry(40, RemotePullRequestState::Merged),
+            entry(41, RemotePullRequestState::Open),
+            entry(42, RemotePullRequestState::Draft),
+        ],
+    };
+    assert_eq!(
+        plan_reconciliation(&[41, 42], &[remote]),
+        ReconcilePlan::Unchanged { stack_number: 7 }
+    );
+}
+
+#[test]
+fn plans_append_with_only_the_new_top_delta() {
+    let remote = RemoteStackSnapshot {
+        number: 7,
+        entries: vec![entry(41, RemotePullRequestState::Open)],
+    };
+    assert_eq!(
+        plan_reconciliation(&[41, 42, 43], &[remote]),
+        ReconcilePlan::Append {
+            stack_number: 7,
+            delta: vec![42, 43],
+        }
+    );
+}
+```
+
+- [ ] **Step 3: Add failing divergence tests**
+
+Cover each safety boundary with named tests:
+
+```rust
+#[test]
+fn rejects_reordered_active_prs() {
+    let remote = RemoteStackSnapshot {
+        number: 7,
+        entries: vec![
+            entry(41, RemotePullRequestState::Open),
+            entry(42, RemotePullRequestState::Open),
+        ],
+    };
+    assert!(matches!(
+        plan_reconciliation(&[42, 41], &[remote]),
+        ReconcilePlan::Diverged { .. }
+    ));
+}
+
+#[test]
+fn rejects_closed_unmerged_remote_entry() {
+    let remote = RemoteStackSnapshot {
+        number: 7,
+        entries: vec![
+            entry(41, RemotePullRequestState::Open),
+            entry(42, RemotePullRequestState::Closed),
+        ],
+    };
+    assert!(matches!(
+        plan_reconciliation(&[41, 43], &[remote]),
+        ReconcilePlan::Diverged { .. }
+    ));
+}
+
+#[test]
+fn rejects_membership_in_multiple_native_stacks() {
+    let first = RemoteStackSnapshot {
+        number: 7,
+        entries: vec![entry(41, RemotePullRequestState::Open)],
+    };
+    let second = RemoteStackSnapshot {
+        number: 8,
+        entries: vec![entry(42, RemotePullRequestState::Open)],
+    };
+    assert!(matches!(
+        plan_reconciliation(&[41, 42], &[first, second]),
+        ReconcilePlan::Diverged { .. }
+    ));
+}
+```
+
+Also add named tests for local removal, a merged entry after an active entry, and a fully merged unrelated prior stack yielding `Create` because no local active PR belongs to it.
+
+- [ ] **Step 4: Run planner tests and verify they fail**
+
+Run:
+
+```sh
+cargo test -p gg-core github_stacks::tests::plans -- --nocapture
+cargo test -p gg-core github_stacks::tests::rejects -- --nocapture
+```
+
+Expected: FAIL until `plan_reconciliation` implements the prefix rules.
+
+- [ ] **Step 5: Implement the remote model and pure planner**
+
+Use these exact public shapes:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RemotePullRequestState {
+    Open,
+    Draft,
+    Merged,
+    Closed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteStackEntry {
+    pub number: u64,
+    pub state: RemotePullRequestState,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteStackSnapshot {
+    pub number: u64,
+    pub entries: Vec<RemoteStackEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReconcilePlan {
+    Create,
+    Append { stack_number: u64, delta: Vec<u64> },
+    Unchanged { stack_number: u64 },
+    Diverged { message: String },
+}
+```
+
+`plan_reconciliation` must:
+
+1. Keep only remote stacks containing at least one local PR.
+2. Return `Create` when that set is empty.
+3. Return `Diverged` when more than one stack remains.
+4. Accept only a contiguous merged prefix.
+5. Reject `Closed` or later `Merged` entries in the retained active suffix.
+6. Compare the remote open/draft suffix with the local list.
+7. Return `Unchanged` for equality, `Append` when remote is a prefix, and `Diverged` otherwise.
+
+- [ ] **Step 6: Add the normalized serializable result model**
+
+Add:
+
+```rust
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum GithubStackAction {
+    Created,
+    Appended,
+    Unchanged,
+    Skipped,
+    Warning,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum GithubStackReason {
+    Disabled,
+    PartialSync,
+    InsufficientPrs,
+    UnresolvedPrs,
+    MissingExtension,
+    OutdatedExtension,
+    UnsupportedRepository,
+    Diverged,
+    BackendFailed,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct GithubStackSyncResult {
+    pub mode: GithubStacksIntegration,
+    pub action: GithubStackAction,
+    pub reason: Option<GithubStackReason>,
+    pub stack_number: Option<u64>,
+    pub pr_numbers: Vec<u64>,
+    pub message: Option<String>,
+}
+```
+
+Add constructors `skipped(mode, reason, pr_numbers)` and `warning(mode, reason, pr_numbers, message)`, plus `is_warning(&self) -> bool`.
+
+- [ ] **Step 7: Run focused and crate tests**
+
+Run:
+
+```sh
+cargo test -p gg-core github_stacks::tests -- --nocapture
+cargo test -p gg-core
+```
+
+Expected: all PASS without subprocess or network access.
+
+- [ ] **Step 8: Commit the planner deliverable**
+
+```sh
+git add crates/gg-core/src/lib.rs crates/gg-core/src/github_stacks.rs
+git commit -m "feat(github): plan native stack reconciliation"
+```
+
+---
+
+### Task 3: Implement the Official `gh-stack` Backend
+
+**Files:**
+- Modify: `crates/gg-core/Cargo.toml`
+- Modify: `Cargo.lock`
+- Modify: `crates/gg-core/src/github_stacks.rs`
+
+**Interfaces:**
+- Consumes: Task 2's `plan_reconciliation` and result types.
+- Produces: `GithubStackReconcileOutcome { pub result: GithubStackSyncResult, pub mutation_attempted: bool }`.
+- Produces: `reconcile_with_gh(mode: GithubStacksIntegration, base: &str, pr_numbers: &[u64]) -> GithubStackReconcileOutcome` for Task 4.
+- Keeps injectable internals: `GhCommandRunner::run(&self, args: &[String]) -> std::io::Result<GhCommandOutput>` and generic `reconcile_with_runner` for unit tests.
+
+- [ ] **Step 1: Add the direct semver dependency**
+
+Add `semver = "1"` under gg-core Utilities and run:
+
+```sh
+cargo check -p gg-core
+```
+
+Expected: PASS and `Cargo.lock` updated without a new semver version family.
+
+- [ ] **Step 2: Add failing version and capability tests**
+
+Create a scripted fake runner whose queue asserts exact argument vectors and returns `GhCommandOutput { success, stdout, stderr }`. Add tests:
+
+```rust
+#[test]
+fn accepts_minimum_gh_stack_version() {
+    assert_eq!(
+        parse_gh_stack_version("gh stack version 0.1.0\n").unwrap(),
+        semver::Version::new(0, 1, 0)
+    );
+}
+
+#[test]
+fn rejects_outdated_gh_stack_version() {
+    let runner = FakeRunner::new([response(
+        &["stack", "--version"],
+        true,
+        "gh stack version 0.0.8\n",
+        "",
+    )]);
+    let outcome = reconcile_with_runner(
+        &runner,
+        GithubStacksIntegration::Auto,
+        "main",
+        &[41, 42],
+    );
+    assert_eq!(outcome.result.action, GithubStackAction::Skipped);
+    assert_eq!(outcome.result.reason, Some(GithubStackReason::OutdatedExtension));
+    assert!(!outcome.mutation_attempted);
+}
+```
+
+Add a `Force` version of the missing/outdated test and assert `Warning` rather than `Skipped`.
+
+- [ ] **Step 3: Add failing API parsing and planner-input tests**
+
+Deserialize the documented stack resource shape. Use fixture JSON containing `number`, `state`, `draft`, and `merged_at`:
+
+```rust
+const STACK_7: &str = r#"[{
+  "number": 7,
+  "pull_requests": [
+    {"number": 40, "state": "closed", "draft": false, "merged_at": "2026-07-01T00:00:00Z"},
+    {"number": 41, "state": "open", "draft": false, "merged_at": null}
+  ]
+}]"#;
+
+#[test]
+fn parses_merged_prefix_and_open_entry() {
+    let stacks = parse_stack_list(STACK_7).unwrap();
+    assert_eq!(stacks[0].entries[0].state, RemotePullRequestState::Merged);
+    assert_eq!(stacks[0].entries[1].state, RemotePullRequestState::Open);
+}
+```
+
+Add tests mapping open drafts to `Draft`, closed/unmerged to `Closed`, malformed JSON to `BackendFailed`, and an API stderr containing `HTTP 404` to repository unsupported.
+
+- [ ] **Step 4: Run backend tests and verify missing implementation failures**
+
+Run:
+
+```sh
+cargo test -p gg-core github_stacks::tests::accepts_minimum -- --nocapture
+cargo test -p gg-core github_stacks::tests::rejects_outdated -- --nocapture
+cargo test -p gg-core github_stacks::tests::parses_ -- --nocapture
+```
+
+Expected: FAIL for missing parser, runner, and backend functions.
+
+- [ ] **Step 5: Implement command execution and capability checks**
+
+Add:
+
+```rust
+const MIN_GH_STACK_VERSION: &str = "0.1.0";
+
+pub struct GithubStackReconcileOutcome {
+    pub result: GithubStackSyncResult,
+    pub mutation_attempted: bool,
+}
+
+struct GhCommandOutput {
+    success: bool,
+    stdout: String,
+    stderr: String,
+}
+
+trait GhCommandRunner {
+    fn run(&self, args: &[String]) -> std::io::Result<GhCommandOutput>;
+}
+```
+
+`SystemGhRunner` executes `Command::new("gh").args(args).output()` and captures both streams. `parse_gh_stack_version` finds the first whitespace token accepted by `semver::Version::parse` after trimming an optional leading `v`.
+
+Before API reads, run exactly `gh stack --version`. A non-zero command is missing extension. A parse failure is `BackendFailed`; a parsed version below `0.1.0` is outdated.
+
+- [ ] **Step 6: Implement read-only native stack discovery**
+
+For every local PR number, run:
+
+```text
+gh api repos/{owner}/{repo}/stacks?pull_request=<number>
+```
+
+Pass the endpoint as one argument so `gh` substitutes `{owner}` and `{repo}` from the current repository. Parse each response as `Vec<GhStackJson>`, convert it to `RemoteStackSnapshot`, and deduplicate by stack number before calling `plan_reconciliation`.
+
+An `HTTP 404` from any membership query maps to `UnsupportedRepository`. Any
+other non-zero response or parse error maps to `BackendFailed`.
+
+- [ ] **Step 7: Add failing exact create/append command tests**
+
+Create test scripts with complete expected calls:
+
+```rust
+#[test]
+fn create_uses_base_and_numeric_prs_only() {
+    let runner = FakeRunner::new([
+        response(&["stack", "--version"], true, "gh stack version 0.1.0\n", ""),
+        response(&["api", "repos/{owner}/{repo}/stacks?pull_request=41"], true, "[]", ""),
+        response(&["api", "repos/{owner}/{repo}/stacks?pull_request=42"], true, "[]", ""),
+        response(&["stack", "link", "--base", "main", "41", "42"], true, "Created stack\n", ""),
+        response(&["api", "repos/{owner}/{repo}/stacks?pull_request=41"], true, STACK_7_CREATED, ""),
+    ]);
+    let outcome = reconcile_with_runner(&runner, GithubStacksIntegration::Auto, "main", &[41, 42]);
+    assert_eq!(outcome.result.action, GithubStackAction::Created);
+    assert_eq!(outcome.result.stack_number, Some(7));
+    assert!(outcome.mutation_attempted);
+    runner.assert_exhausted();
+}
+```
+
+Add an append test whose membership response contains merged PR 40 and active PR 41, then expect exactly:
+
+```text
+gh stack link 7 42 43
+```
+
+Add an unchanged test and assert no `stack link` call. Add a link-failure test and assert `Warning(BackendFailed)` with `mutation_attempted == true`.
+
+Add a create-confirmation failure test: the `stack link` call succeeds, the
+follow-up membership read fails, and the result remains `Created` with
+`stack_number == None`, `mutation_attempted == true`, and a diagnostic
+`message`.
+
+- [ ] **Step 8: Implement create, append, unchanged, and divergence execution**
+
+Map planner decisions as follows:
+
+- `Create`: set `mutation_attempted = true`, run `gh stack link --base <base> <all PRs>`, then reread the first PR to confirm the stack number.
+- `Append`: set `mutation_attempted = true`, run `gh stack link <stack-number> <delta>`.
+- `Unchanged`: return the known number without invoking link.
+- `Diverged`: return `Warning(Diverged)` without invoking link.
+
+Build each argument as its own `String`; never invoke a shell. Convert all non-zero link exits into a concise message using captured stderr first, stdout second, and the exit context last.
+
+- [ ] **Step 9: Run focused backend and crate tests**
+
+Run:
+
+```sh
+cargo test -p gg-core github_stacks::tests -- --nocapture
+cargo test -p gg-core
+cargo clippy -p gg-core --all-targets --all-features -- -D warnings
+```
+
+Expected: all PASS with no Clippy warnings.
+
+- [ ] **Step 10: Commit the backend deliverable**
+
+```sh
+git add crates/gg-core/Cargo.toml Cargo.lock crates/gg-core/src/github_stacks.rs
+git commit -m "feat(github): link PRs with gh-stack"
+```
+
+---
+
+### Task 4: Integrate Reconciliation into Sync and Structured Output
+
+**Files:**
+- Modify: `crates/gg-core/src/output.rs`
+- Modify: `crates/gg-core/src/commands/sync.rs`
+- Create: `crates/gg-cli/tests/integration_tests/github_stacks.rs`
+- Modify: `crates/gg-cli/tests/integration_tests/main.rs`
+- Modify: `crates/gg-cli/tests/integration_tests/sync.rs`
+
+**Interfaces:**
+- Consumes: `Config::get_github_stacks_integration` and `github_stacks::reconcile_with_gh`.
+- Consumes: `GithubStackReconcileOutcome::mutation_attempted` to protect operation history.
+- Produces: `SyncResultJson::github_stack: Option<GithubStackSyncResult>`.
+- Produces: `SyncStreamingEvent::GithubStack` and `Summary::github_stack`.
+- Preserves: output version `1`; the new fields/events are additive.
+
+- [ ] **Step 1: Add failing serialization tests**
+
+In `output.rs`, construct a result and require both atomic and progressive shapes:
+
+```rust
+fn created_github_stack_result() -> GithubStackSyncResult {
+    GithubStackSyncResult {
+        mode: GithubStacksIntegration::Auto,
+        action: GithubStackAction::Created,
+        reason: None,
+        stack_number: Some(7),
+        pr_numbers: vec![41, 42],
+        message: None,
+    }
+}
+
+#[test]
+fn sync_streaming_github_stack_event_is_flat_and_ok() {
+    let response = SyncStreamingResponse {
+        version: OUTPUT_VERSION,
+        command: "sync".to_string(),
+        event: SyncStreamingEvent::GithubStack {
+            result: created_github_stack_result(),
+        },
+    };
+    let value = serde_json::to_value(response).unwrap();
+    assert_eq!(value["event"], "github_stack");
+    assert_eq!(value["status"], "ok");
+    assert_eq!(value["action"], "created");
+    assert_eq!(value["stack_number"], 7);
+}
+
+#[test]
+fn sync_streaming_github_stack_warning_has_warning_status() {
+    let mut result = created_github_stack_result();
+    result.action = GithubStackAction::Warning;
+    result.reason = Some(GithubStackReason::Diverged);
+    let response = SyncStreamingResponse {
+        version: OUTPUT_VERSION,
+        command: "sync".to_string(),
+        event: SyncStreamingEvent::GithubStack { result },
+    };
+    let value = serde_json::to_value(response).unwrap();
+    assert_eq!(value["status"], "warning");
+}
+```
+
+Update the existing atomic response and summary tests to assert a `github_stack` field.
+
+- [ ] **Step 2: Run output tests and verify missing fields/variant fail**
+
+Run:
+
+```sh
+cargo test -p gg-core output::tests::sync_streaming_github_stack -- --nocapture
+cargo test -p gg-core commands::sync::tests::test_sync_json_response_structure -- --nocapture
+```
+
+Expected: FAIL for missing `GithubStack` event and `SyncResultJson::github_stack`.
+
+- [ ] **Step 3: Implement the additive output schema**
+
+Import `GithubStackAction` and `GithubStackSyncResult` into `output.rs`. Add:
+
+```rust
+GithubStack {
+    #[serde(flatten)]
+    result: GithubStackSyncResult,
+},
+```
+
+to `SyncStreamingEvent`. Add `github_stack: Option<GithubStackSyncResult>` to both `SyncResultJson` and the `Summary` variant.
+
+Update streaming `status` selection so only `GithubStackAction::Warning` yields `"warning"`; existing error events remain `"error"`, and all other events remain `"ok"`.
+
+Update every `SyncResultJson` and `Summary` constructor in `sync.rs` and its unit tests. Early exits before provider detection use `github_stack: None`.
+
+- [ ] **Step 4: Add a pure sync eligibility helper and failing tests**
+
+Inside `commands/sync.rs`, add a helper returning either a skipped result or `None` to proceed:
+
+```rust
+fn github_stack_preflight_skip(
+    mode: GithubStacksIntegration,
+    until: Option<&str>,
+    active_pr_numbers: &[u64],
+    has_unresolved_active_pr: bool,
+) -> Option<GithubStackSyncResult>
+```
+
+Add tests asserting precedence and reasons:
+
+```rust
+#[test]
+fn github_stack_preflight_off_is_disabled() {
+    let result = github_stack_preflight_skip(
+        GithubStacksIntegration::Off,
+        None,
+        &[41, 42],
+        false,
+    )
+    .unwrap();
+    assert_eq!(result.reason, Some(GithubStackReason::Disabled));
+}
+
+#[test]
+fn github_stack_preflight_partial_sync_skips_before_backend() {
+    let result = github_stack_preflight_skip(
+        GithubStacksIntegration::Auto,
+        Some("2"),
+        &[41, 42],
+        false,
+    )
+    .unwrap();
+    assert_eq!(result.reason, Some(GithubStackReason::PartialSync));
+}
+```
+
+Also test unresolved active PRs and fewer than two active PRs.
+
+- [ ] **Step 5: Implement sync orchestration before nav-comment reconciliation**
+
+Make the existing `warnings` binding mutable. After the entry loop finishes and the progress bar stops, derive active state by zipping `nav_snapshots` with `entry_is_closed`:
+
+```rust
+let active_pr_numbers: Vec<u64> = nav_snapshots
+    .iter()
+    .zip(&entry_is_closed)
+    .filter_map(|(snapshot, is_closed)| {
+        if *is_closed {
+            None
+        } else {
+            snapshot.as_ref().map(|value| value.pr_number)
+        }
+    })
+    .collect();
+let has_unresolved_active_pr = nav_snapshots
+    .iter()
+    .zip(&entry_is_closed)
+    .any(|(snapshot, is_closed)| !*is_closed && snapshot.is_none());
+```
+
+For `Provider::GitHub`, get the mode and either use `github_stack_preflight_skip` or call `reconcile_with_gh`. For GitLab, leave the result `None`.
+
+When `mutation_attempted` is true, immediately set `touched_remote = true` and call `guard.mark_touched_remote()` regardless of backend success.
+
+When the result is a warning, append its message to `warnings`. In human mode render the approved success/dim/warning line; suppress missing/outdated/unsupported `auto` skips. In JSONL mode emit the `GithubStack` event immediately. Store the same result for atomic output or final summary.
+
+- [ ] **Step 6: Add the focused CLI integration fixture**
+
+Register `mod github_stacks;` in `integration_tests/main.rs`. In the new file, build a two-entry GitHub stack with fixed GG-IDs and MR mappings, then install a fake executable `gh` in a prepended `PATH`.
+
+The fake must log every invocation and handle all normal sync calls before the new backend calls:
+
+```sh
+if [ "$1" = "--version" ]; then echo "gh version 2.97.0"; exit 0; fi
+if [ "$1" = "auth" ] && [ "$2" = "status" ]; then exit 0; fi
+if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  # Return OPEN JSON for mapped PR 41 or 42 with the expected headRefName.
+fi
+if [ "$1" = "pr" ] && [ "$2" = "edit" ]; then exit 0; fi
+if [ "$1" = "api" ] && printf '%s' "$*" | grep -q '/issues/'; then echo '[]'; exit 0; fi
+if [ "$1" = "stack" ] && [ "$2" = "--version" ]; then
+  echo "gh stack version ${GG_FAKE_STACK_VERSION:-0.1.0}"
+  exit "${GG_FAKE_STACK_VERSION_EXIT:-0}"
+fi
+```
+
+Handle Stacks API responses and link success/failure from environment-selected fixture files. The helper returns the repo path, fake log path, and environment vector so each test changes only its scenario.
+
+- [ ] **Step 7: Add CLI tests for create and JSONL append**
+
+Add:
+
+```rust
+#[test]
+fn sync_json_creates_native_stack_with_exact_pr_order() {
+    // Stacks queries return [] before link and stack #7 after link.
+    // Assert success, valid atomic JSON, action=created, stack_number=7,
+    // pr_numbers=[41,42], and log contains exactly:
+    // stack link --base main 41 42
+}
+
+#[test]
+fn sync_jsonl_appends_after_merged_prefix_and_repeats_result_in_summary() {
+    // Stack response is [merged #40, open #41]; local active list is [41,42].
+    // Assert one event=github_stack with action=appended and stack_number=7,
+    // the final summary contains the identical object, and the log contains:
+    // stack link 7 42
+}
+```
+
+Parse every JSONL line with `serde_json`, assert the event occurs before summary, and assert stderr is empty.
+
+- [ ] **Step 8: Add CLI tests for safety and non-fatal modes**
+
+Add named tests and exact assertions:
+
+- `sync_until_reports_partial_skip_without_stack_command`: `github_stack.reason == "partial_sync"`; fake log has no `stack --version` or `/stacks`.
+- `sync_off_reports_disabled_without_stack_command`: config mode `off`; no capability call.
+- `sync_auto_missing_extension_is_silent_and_non_fatal`: successful sync, `action == "skipped"`, `reason == "missing_extension"`, empty warnings/stderr.
+- `sync_force_missing_extension_is_warning_and_non_fatal`: successful sync, `action == "warning"`, `reason == "missing_extension"`, warning appears in summary.
+- `sync_divergence_warns_without_link`: reordered remote active list; no `stack link` call.
+- `sync_link_failure_warns_without_corrupting_json`: link exits non-zero with stderr; JSON remains one valid document and sync exits success.
+- `sync_gitlab_never_invokes_or_serializes_github_stacks`: use a fake `glab`,
+  assert no `gh` executable is needed, and assert `sync.github_stack` is null.
+
+- [ ] **Step 9: Update unrelated sync fixtures for default-auto compatibility**
+
+Search all multi-entry sync integration configs and fake `gh` scripts:
+
+```sh
+rg -n 'sync|fake_bin.join\("gh"\)|provider.*github' crates/gg-cli/tests/integration_tests/sync.rs
+```
+
+For tests unrelated to native stacks whose scripts intentionally reject unknown calls, add this nested config:
+
+```json
+"github": { "stacks_integration": "off" }
+```
+
+Do not weaken the dedicated GitHub Stacks tests. One-entry sync tests naturally skip before extension detection and need no fixture change.
+
+- [ ] **Step 10: Run focused sync/output/integration tests**
+
+Run:
+
+```sh
+cargo test -p gg-core output::tests::sync_streaming_github_stack -- --nocapture
+cargo test -p gg-core commands::sync::tests::github_stack_preflight -- --nocapture
+cargo test -p gg-cli --test integration_tests github_stacks -- --nocapture
+cargo test -p gg-cli --test integration_tests sync -- --nocapture
+```
+
+Expected: all PASS; structured stdout contains no raw extension output.
+
+- [ ] **Step 11: Run crate-wide checks and commit**
+
+Run:
+
+```sh
+cargo fmt --all
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-features
+```
+
+Expected: all PASS.
+
+Commit:
+
+```sh
+git add crates/gg-core/src/output.rs crates/gg-core/src/commands/sync.rs \
+  crates/gg-cli/tests/integration_tests/main.rs \
+  crates/gg-cli/tests/integration_tests/github_stacks.rs \
+  crates/gg-cli/tests/integration_tests/sync.rs
+git commit -m "feat(sync): reconcile native GitHub stacks"
+```
+
+---
+
+### Task 5: Document and Verify the Public Preview Integration
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/src/configuration.md`
+- Modify: `docs/src/commands/setup.md`
+- Modify: `docs/src/commands/sync.md`
+- Modify: `docs/src/getting-started.md`
+
+**Interfaces:**
+- Consumes: the exact configuration names, result fields, eligibility, and recovery behavior implemented in Tasks 1-4.
+- Produces: user guidance only; no code or agent-skill behavior changes.
+
+- [ ] **Step 1: Update README feature and prerequisite guidance**
+
+Add native GitHub Stacked PR UI integration to the feature overview, explain that it is a GitHub public preview, and give the optional installation command:
+
+```sh
+gh extension install github/gh-stack
+```
+
+Add `defaults.github.stacks_integration` to the configuration table with values `off`, `auto`, `force` and default `auto`. State that ordinary GitHub sync remains functional without the extension.
+
+- [ ] **Step 2: Update the mdBook configuration and setup reference**
+
+In `docs/src/configuration.md`, include the nested JSON example and a table row using the exact mode semantics. In `docs/src/commands/setup.md`, add the GitHub full-setup selector and state that it appears only when GitHub is selected.
+
+Use the product term `GitHub Stacked PRs` and command name `gh stack`; do not call git-gud's own stack metadata a GitHub Stack.
+
+- [ ] **Step 3: Update sync behavior and output contracts**
+
+In `docs/src/commands/sync.md`, add sections covering:
+
+- full GitHub sync eligibility and active open/draft PR collection
+- create and stack-number append behavior
+- merged-prefix preservation
+- create/append-only divergence warning and explicit recovery
+- `auto` versus `force` capability behavior
+- non-fatal failures
+- the atomic `sync.github_stack` object
+- the JSONL `github_stack` event and repeated summary result
+
+Include one JSON example with all fields and one JSONL event example whose `status` is `warning` for divergence.
+
+- [ ] **Step 4: Update getting-started guidance**
+
+In `docs/src/getting-started.md`, keep `gh` as the required GitHub client and list `github/gh-stack` as optional for the native stack map/UI. Do not imply the extension is required for PR creation or ordinary sync.
+
+- [ ] **Step 5: Build documentation and inspect links**
+
+Run:
+
+```sh
+mdbook build docs
+rg -n 'stacks_integration|gh extension install github/gh-stack|github_stack' \
+  README.md docs/src
+```
+
+Expected: mdBook build PASS; each public config/output term appears in the intended guide and reference pages.
+
+- [ ] **Step 6: Verify the official extension version in isolation**
+
+Use a narrowly scoped temporary config directory and perform no repository stack mutation:
+
+```sh
+gg_stack_tmp=$(mktemp -d)
+GH_CONFIG_DIR="$gg_stack_tmp" gh extension install github/gh-stack
+GH_CONFIG_DIR="$gg_stack_tmp" gh stack --version
+rm -rf "$gg_stack_tmp"
+```
+
+Expected: installation succeeds and version is `0.1.0` or later. The deletion target is the explicit directory returned by `mktemp -d`.
+
+- [ ] **Step 7: Run the complete project verification matrix**
+
+Run in this order:
+
+```sh
+cargo fmt --all
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-features
+mdbook build docs
+git diff --check
+```
+
+Expected: every command exits zero.
+
+- [ ] **Step 8: Review the final diff against the approved spec**
+
+Run:
+
+```sh
+git status --short
+git diff --stat HEAD~5
+git diff HEAD~5 -- crates/gg-core/src/github_stacks.rs \
+  crates/gg-core/src/commands/sync.rs crates/gg-core/src/output.rs
+```
+
+Confirm all of these directly in the diff:
+
+- no direct REST stack mutation
+- no automatic extension installation
+- no GitLab call path
+- no partial-sync backend call
+- only numeric `gh stack link` arguments
+- mutation attempt marks remote touch
+- JSON stays atomic and JSONL stays line-delimited
+- no `skills/gg` changes
+
+- [ ] **Step 9: Commit the documentation deliverable**
+
+```sh
+git add README.md docs/src/configuration.md docs/src/commands/setup.md \
+  docs/src/commands/sync.md docs/src/getting-started.md
+git commit -m "docs: document native GitHub Stacks integration"
+```
+
+- [ ] **Step 10: Record final evidence**
+
+Run:
+
+```sh
+git status --short --branch
+git log --oneline --decorate -7
+```
+
+Expected: clean worktree; the design commit, plan commit, and five
+implementation commits are visible on `nacho/gh-stacked`.

--- a/docs/superpowers/specs/2026-08-01-github-stacks-integration-design.md
+++ b/docs/superpowers/specs/2026-08-01-github-stacks-integration-design.md
@@ -1,0 +1,454 @@
+# Native GitHub Stacks Integration Design
+
+## Summary
+
+Add an optional GitHub-only post-pass to `gg sync` that links git-gud's
+existing pull request chain into GitHub's native Stacked PRs UI. The
+integration uses the official `github/gh-stack` extension as its only mutation
+backend and GitHub's documented read APIs to inspect current stack membership.
+
+The feature defaults to `auto`. It remains best-effort and non-fatal: normal
+GitHub sync continues to work without the extension or repository support, and
+GitLab behavior is unchanged. Version one creates native stacks and appends new
+top pull requests, but never removes or reorders existing native stack entries.
+
+## Problem
+
+Git-gud already creates the pull request graph required by GitHub Stacked PRs:
+
+- one branch per git-gud stack entry
+- the bottom pull request targets the configured stack base
+- each higher pull request targets the active branch below it
+- `gg sync` retargets pull requests after lower entries merge or close
+- stable `GG-ID` metadata maps local entries to provider pull requests
+
+Until now, GitHub did not expose a supported integration surface for telling it
+that those pull requests form a native stack. GitHub now ships the public
+preview `github/gh-stack` extension. Its `gh stack link` command is explicitly
+designed for tools that retain ownership of their own local stack metadata.
+
+Without integration, git-gud stacks remain structurally correct but do not gain
+GitHub's native stack map, stack-aware rules and CI evaluation, or native stack
+merge experience.
+
+## Goals
+
+- Link a fully synchronized GitHub pull request chain into a native GitHub
+  stack.
+- Append newly created top pull requests to a compatible existing native
+  stack.
+- Preserve merged lower pull requests already retained by GitHub.
+- Default to automatic best-effort behavior without making `gh-stack` a hard
+  dependency for ordinary GitHub usage.
+- Keep every integration failure non-fatal to `gg sync`.
+- Make the result explicit in human, atomic JSON, and streaming JSONL output.
+- Preserve git-gud's local stack model, `GG-ID` metadata, and provider
+  abstraction.
+- Keep GitLab and partial `--until` syncs unchanged.
+
+## Non-goals
+
+- Do not replace git-gud's branch, commit, or pull request management with
+  `gh-stack` local tracking.
+- Do not automatically install or upgrade the `github/gh-stack` extension.
+- Do not mutate GitHub Stacks through direct REST writes.
+- Do not remove, reorder, split, or recreate a diverged native stack.
+- Do not unstack merged, queued, closed, or open pull requests automatically.
+- Do not make native-stack integration a prerequisite for `gg sync` success.
+- Do not add equivalent behavior for GitLab.
+- Do not change `gg land` to use native stack merging in this version.
+
+## Configuration
+
+Add GitHub-specific defaults alongside the existing GitLab-specific defaults:
+
+```json
+{
+  "defaults": {
+    "github": {
+      "stacks_integration": "auto"
+    }
+  }
+}
+```
+
+`GithubDefaults` contains `stacks_integration:
+GithubStacksIntegration`. The enum serializes as lowercase and supports:
+
+- `off`: never inspect or mutate native GitHub Stacks
+- `auto`: attempt integration when the required extension and repository
+  support are available
+- `force`: perform the same safe reconciliation as `auto`, but surface missing
+  capabilities as visible warnings
+
+The serde and Rust defaults are `auto`. Missing `defaults.github` and missing
+`stacks_integration` fields therefore enable automatic best-effort behavior for
+existing configuration files.
+
+`gg setup` presents a three-value selection only when GitHub is the effective
+provider. GitLab setup preserves any existing GitHub setting without prompting
+for it.
+
+`force` does not bypass the create/append-only safety boundary, version checks,
+or GitHub validation. It controls observability of capability failures; it
+does not make the integration fatal.
+
+## Backend Requirements
+
+The mutation backend is the official `github/gh-stack` extension. The minimum
+supported version is `v0.1.0`, which includes stack-number append mode.
+
+The integration checks the installed extension and parses `gh stack
+--version`. It never installs or upgrades the extension. Users enable the
+backend with:
+
+```sh
+gh extension install github/gh-stack
+```
+
+GitHub's documented read APIs are used only to determine repository support,
+pull request membership, and remote stack composition. All stack creation and
+append mutations go through `gh stack link`.
+
+The repository capability probe uses the Stacks list endpoint. A `404` means
+the repository does not support native stacks; a successful response means the
+feature is available. Other failures are backend errors rather than unsupported
+capability.
+
+## Architecture
+
+Add a focused `github_stacks` module in `gg-core`. It owns the entire native
+integration boundary:
+
+- extension discovery and minimum-version validation
+- repository support probing
+- current pull request and native stack inspection
+- conversion of provider responses into a small remote-state model
+- pure create/append reconciliation planning
+- `gh stack link` command construction and execution
+- normalization of the final result for all output modes
+
+The module exposes a single reconciliation entry point to `sync`. The sync
+command supplies:
+
+- effective `GithubStacksIntegration` mode
+- configured stack base
+- active pull request numbers in bottom-to-top order
+
+The module does not load or modify git-gud configuration, commits, branches,
+or stack files. It does not render terminal output or serialize JSON.
+
+Command execution is injectable so unit tests can cover capability and backend
+behavior without a real extension or network. Reconciliation planning is pure
+and independently testable from subprocess execution.
+
+## Sync Eligibility
+
+`gg sync` evaluates native integration only after the normal per-entry push and
+pull request loop. It is eligible when all of these conditions hold:
+
+- the effective provider is GitHub
+- the mode is not `off`
+- the command is a full sync without `--until`
+- at least two active pull requests are available
+- every active entry has a resolved pull request number
+
+An active pull request is open or draft. Merged and closed pull requests are
+not supplied as local active entries because `gg sync` already chains around
+them when computing bases.
+
+`off`, GitLab, partial sync, insufficient active pull requests, or unresolved
+active mappings produce an explicit skipped result where structured output is
+available. They do not call GitHub or the extension.
+
+The integration runs before navigation-comment reconciliation and final output.
+The two post-passes remain independent: failure in one does not suppress the
+other.
+
+## Remote State Model
+
+For each active pull request, the module reads its native stack membership.
+Membership is either absent or contains a repository-scoped stack number and
+position.
+
+When any active pull request belongs to a native stack, the module fetches that
+stack's ordered pull requests. Remote entries retain enough state to distinguish:
+
+- merged immutable prefix entries
+- open or draft active entries
+- closed unmerged entries
+
+A compatible remote stack may have a contiguous merged prefix followed only by
+open or draft entries. A merged entry after an active entry, or a closed
+unmerged entry anywhere in the retained remote structure, is treated as
+divergence because version one cannot safely remove or reorder it.
+
+All already-stacked active pull requests must belong to the same native stack.
+Membership in multiple native stacks is divergence.
+
+## Reconciliation Algorithm
+
+The planner compares git-gud's local active pull request sequence with native
+remote state and produces one of these decisions.
+
+### Create
+
+When none of the active pull requests belongs to a native stack, create one:
+
+```sh
+gh stack link --base <stack-base> <bottom-pr> ... <top-pr>
+```
+
+Only numeric pull request arguments are used. The extension therefore cannot
+push a branch or create a missing pull request.
+
+### Unchanged
+
+When the active portion of one compatible native stack exactly matches the
+local active sequence, perform no mutation.
+
+The module may read the stack number for output, but does not invoke `gh stack
+link`.
+
+### Append
+
+When the native active sequence is an exact ordered prefix of the local active
+sequence, append only the delta:
+
+```sh
+gh stack link <stack-number> <first-new-pr> ... <new-top-pr>
+```
+
+Stack-number append mode preserves GitHub's merged immutable prefix without
+relisting it or retargeting the first active pull request back onto a merged
+branch.
+
+### Diverged
+
+Perform no mutation and return an actionable warning when:
+
+- local order differs from native order
+- the local sequence would remove a native active pull request
+- an active pull request belongs to another native stack
+- the native stack contains a closed unmerged middle entry
+- the native stack shape is otherwise not an ordered prefix
+
+The warning directs the user to inspect and explicitly unstack or repair the
+native stack before rerunning `gg sync`. Version one never invokes `gh stack
+unstack`.
+
+## Result Model
+
+Every evaluated integration produces a `GithubStackSyncResult` with:
+
+- `mode`: `off`, `auto`, or `force`
+- `action`: `created`, `appended`, `unchanged`, `skipped`, or `warning`
+- `reason`: optional stable machine-readable reason
+- `stack_number`: the native stack number when known
+- `pr_numbers`: the local active pull requests considered, bottom to top
+- `message`: optional human-readable detail for warnings
+
+Stable skipped or warning reasons include:
+
+- `disabled`
+- `partial_sync`
+- `insufficient_prs`
+- `unresolved_prs`
+- `missing_extension`
+- `outdated_extension`
+- `unsupported_repository`
+- `diverged`
+- `backend_failed`
+
+After successful creation, the module rereads the first active pull request's
+membership to obtain the new stack number. Failure of this confirmation does
+not turn successful creation into a sync failure; it returns `created` with an
+unknown stack number and a diagnostic message.
+
+## Human Output
+
+Human mode prints one concise line after native reconciliation:
+
+- creation: `OK Created GitHub stack #N`
+- append: `OK Added N PR(s) to GitHub stack #N`
+- unchanged: a dim `GitHub stack #N is already up to date`
+- divergence or backend failure: a yellow actionable warning
+
+Expected `auto` skips for a missing or outdated extension and unsupported
+repositories are silent. The structured result still records them.
+
+`force` prints those capability skips as warnings. `off`, partial sync, and
+insufficient pull requests do not print terminal noise in either mode.
+
+Captured stdout and stderr from `gh` and `gh stack` are never forwarded directly
+to command stdout, so atomic JSON and JSONL remain valid.
+
+## Structured Output
+
+Atomic `gg sync --json` adds `github_stack` to `sync`:
+
+```json
+{
+  "version": 1,
+  "sync": {
+    "stack": "feature",
+    "base": "main",
+    "github_stack": {
+      "mode": "auto",
+      "action": "created",
+      "reason": null,
+      "stack_number": 7,
+      "pr_numbers": [41, 42],
+      "message": null
+    }
+  }
+}
+```
+
+`github_stack` is `null` when the provider is not GitHub or sync exits before
+provider detection. GitHub syncs include an explicit result, including skipped
+outcomes.
+
+`gg sync --jsonl` emits a `github_stack` event immediately after reconciliation
+and repeats the result in the final summary. The event's standard `status` is:
+
+- `ok` for created, appended, unchanged, and skipped
+- `warning` for warning outcomes
+
+The atomic document remains a final snapshot. JSONL continues to flush each
+event immediately, and the final summary remains deterministic.
+
+Warnings that are visible in human mode are also appended to the existing
+summary `warnings` array. Expected silent `auto` skips are represented only by
+the structured result and are not summary warnings.
+
+## Failure Semantics
+
+Native integration never changes the exit status of an otherwise successful
+`gg sync`.
+
+Mode-specific capability behavior is:
+
+- `auto`: missing extension, outdated extension, or repository `404` becomes a
+  silent skipped result
+- `force`: the same conditions become visible warning results
+
+Safety or execution failures are warning results in both active modes:
+
+- incompatible remote shape
+- multiple native stack memberships
+- malformed API or extension output
+- authentication, network, or other API errors
+- non-zero `gh stack link` exit
+
+`force` never runs an unsafe plan and never bypasses extension or repository
+validation.
+
+## Operation History and Undo
+
+Create and append are remote mutations with no safe local inverse. Before
+invoking `gh stack link`, sync marks its operation guard as remotely touched.
+It remains marked even when the extension returns failure because the
+subprocess may have performed partial remote work before exiting.
+
+Unchanged and skipped decisions do not mark the operation as remotely touched.
+No new inverse `RemoteEffect` is recorded because version one does not attempt
+automatic native-stack rollback.
+
+## Testing
+
+### Configuration tests
+
+- `GithubStacksIntegration` defaults to `auto`
+- missing `defaults.github` loads as `auto`
+- `off`, `auto`, and `force` round-trip through JSON
+- local and global configuration merging preserves the GitHub setting
+- `gg setup` prompts only for an effective GitHub provider and preserves the
+  setting for GitLab
+
+### Pure planner tests
+
+- no membership plans create
+- exact active sequence plans unchanged
+- ordered remote prefix plans append with the correct delta
+- merged remote prefix is preserved during unchanged and append decisions
+- fully merged prior stack followed by unstacked active PRs plans a new create
+- local reorder plans divergence
+- local removal plans divergence
+- closed unmerged native entry plans divergence
+- PRs in multiple native stacks plan divergence
+- fewer than two active PRs plans skip
+
+### Backend tests
+
+- missing and outdated extension detection
+- minimum version `v0.1.0` acceptance and later version acceptance
+- repository `404` maps to unsupported capability
+- non-404 API failures map to backend failure
+- create command uses `--base` and only numeric PR arguments
+- append command uses the stack number and delta only
+- extension stdout and stderr are captured
+- successful creation confirms and returns the new stack number
+- non-zero extension exit maps to a warning result
+
+### Sync integration tests
+
+Integration tests use a fake `gh` executable and cover:
+
+- `off` performs no capability or mutation calls
+- GitLab performs no GitHub Stacks calls
+- `--until` performs no GitHub Stacks calls
+- insufficient and unresolved active PRs do not invoke the extension
+- `auto` silently skips missing, outdated, and unsupported capability
+- `force` reports the same capability states as warnings
+- supported create invokes the exact command once
+- merged-prefix append invokes stack-number mode with only the delta
+- divergence warns and performs no mutation
+- backend failure remains non-fatal
+- invoked create or append prevents local undo replay
+- human, JSON, and JSONL output remain isolated and truthful
+- JSONL emits one progressive `github_stack` event and includes the same result
+  in its final summary
+
+## Documentation
+
+Update:
+
+- README feature and configuration tables
+- `docs/src/configuration.md`
+- `docs/src/commands/setup.md`
+- `docs/src/commands/sync.md`
+- relevant getting-started guidance for installing `github/gh-stack`
+
+Documentation explains that GitHub Stacked PRs are in public preview, the
+extension is optional, `auto` is the default, integration is create/append
+only, and divergence requires explicit user recovery.
+
+The unified `skills/gg` agent skill remains unchanged. The CLI owns the
+capability and safety decisions, and this feature does not introduce a new
+agent authority boundary or multi-command workflow. The new JSON fields do not
+change what an agent is authorized to do.
+
+## Verification
+
+Before implementation is considered complete, run:
+
+```sh
+cargo fmt --all
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-features
+mdbook build docs
+```
+
+Also verify `gh stack --version` against an isolated installation of the latest
+official extension without mutating a real repository stack.
+
+## Future Work
+
+Potential later work, intentionally outside this design:
+
+- explicit native-stack repair or recreate commands
+- direct REST mutation fallback
+- native stack merge support in `gg land`
+- reconcile support after reorder, drop, split, or unstack operations
+- GitHub webhook or MCP exposure of native stack identifiers

--- a/skills/gg/references/syncing-and-reviews.md
+++ b/skills/gg/references/syncing-and-reviews.md
@@ -54,7 +54,7 @@
    `reason`, `message` when present, and the affected `pr_numbers`. Treat
    `"skipped"` as non-fatal and report the skip reason when it affects user
    expectations (`"disabled"`, `"partial_sync"`, `"unresolved_prs"`,
-   `"insufficient_prs"`, `"missing_extension"`, `"unsupported_repo"`, or
+   `"insufficient_prs"`, `"missing_extension"`, `"unsupported_repository"`, or
    `"outdated_extension"`). Do not infer review, CI, or mergeability from this
    result.
 9. Treat managed PR body blocks and stack-navigation comments as gg-owned; do

--- a/skills/gg/references/syncing-and-reviews.md
+++ b/skills/gg/references/syncing-and-reviews.md
@@ -31,9 +31,9 @@
 3. Prefer `gg sync --jsonl` for monitored agent execution. Use `gg sync --json`
    when only the final aggregate is needed.
 4. Consume the final summary event for publication results only: stack, base,
-   pre-sync rebase status, warnings, metadata normalization, and each entry's
-   source branch, push result, draft flag, PR or MR number, URL, error, and
-   action.
+   pre-sync rebase status, warnings, metadata normalization, GitHub native stack
+   reconciliation, and each entry's source branch, push result, draft flag, PR
+   or MR number, URL, error, and action.
 5. Use the exact publication action `"up_to_date"` when no publication change
    is needed.
    Other observed actions include `"created"`, `"updated"`, `"recreated"`,
@@ -47,9 +47,19 @@
    decisions. If the exact target branch is decision-critical, inspect it
    through the provider rather than inferring it from the sync summary.
 7. Surface branch-prefix warnings and `"recreated"` source-branch remaps.
-8. Treat managed PR body blocks and stack-navigation comments as gg-owned; do
+8. For GitHub syncs, read the optional `github_stack` result from the JSON
+   summary or the flat `github_stack` JSONL event. Report `"created"`,
+   `"appended"`, and `"unchanged"` as native GitHub Stacks outcomes alongside
+   normal PR publication. Treat `"warning"` as actionable: report the
+   `reason`, `message` when present, and the affected `pr_numbers`. Treat
+   `"skipped"` as non-fatal and report the skip reason when it affects user
+   expectations (`"disabled"`, `"partial_sync"`, `"unresolved_prs"`,
+   `"insufficient_prs"`, `"missing_extension"`, `"unsupported_repo"`, or
+   `"outdated_extension"`). Do not infer review, CI, or mergeability from this
+   result.
+9. Treat managed PR body blocks and stack-navigation comments as gg-owned; do
    not edit them manually.
-9. Keep GitHub and GitLab terminology provider-correct while accepting `pr_*`
+10. Keep GitHub and GitLab terminology provider-correct while accepting `pr_*`
    JSON fields for both.
 
 ## Stop conditions
@@ -68,5 +78,6 @@ fresh stack-tip versus `origin/<base>` merge-base check.
 ## Report
 
 Report created, updated, `up_to_date`, recreated, skipped-closed, or failed PRs
-or MRs; URLs; refreshed review and CI state; refreshed behind-base state;
+or MRs; URLs; GitHub native stack created/appended/unchanged/skipped/warning
+state when present; refreshed review and CI state; refreshed behind-base state;
 warnings; and every remaining non-terminal gate.


### PR DESCRIPTION
## Summary

- add `defaults.github.stacks_integration` with `off`, `auto`, and `force` modes
- reconcile full GitHub syncs with native GitHub Stacks using the official `gh-stack` extension
- report native stack reconciliation through JSON and JSONL output
- document setup, behavior, and safety boundaries

Closes #271

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `mdbook build docs`
- `git diff --check`