### PR TITLE
fix(land): release lock while waiting

### DIFF
--- a/crates/gg-cli/tests/integration_tests/land.rs
+++ b/crates/gg-cli/tests/integration_tests/land.rs
@@ -1,7 +1,298 @@
-use crate::helpers::{create_test_repo, run_gg};
+use crate::helpers::{create_test_repo, create_test_repo_with_remote, run_gg, run_git};
 
 use serde_json::Value;
+use std::ffi::OsString;
 use std::fs;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+#[cfg(unix)]
+fn write_waiting_fake_gh(path: &Path) {
+    fs::write(
+        path,
+        r#"#!/bin/sh
+set -eu
+
+if [ "$1" = "--version" ]; then
+  echo "gh version 2.97.0"
+  exit 0
+fi
+
+if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
+  exit 0
+fi
+
+if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  case "$*" in
+    *statusCheckRollup*)
+      touch "$GG_FAKE_POLLED"
+      calls=0
+      if [ -f "$GG_FAKE_CI_CALLS" ]; then calls=$(cat "$GG_FAKE_CI_CALLS"); fi
+      calls=$((calls + 1))
+      echo "$calls" > "$GG_FAKE_CI_CALLS"
+      if [ -f "$GG_FAKE_REGRESS" ] && [ "$calls" -eq 3 ]; then
+        echo PENDING
+      elif [ -f "$GG_FAKE_READY" ]; then
+        echo SUCCESS
+      else
+        echo PENDING
+      fi
+      exit 0
+      ;;
+    *"--jq .reviewDecision"*)
+      echo APPROVED
+      exit 0
+      ;;
+  esac
+
+  if [ -f "$GG_FAKE_MERGED" ]; then state=MERGED; else state=OPEN; fi
+  printf '{"number":41,"title":"Land entry","state":"%s","url":"https://github.com/test/repo/pull/41","headRefName":"testuser/land-wait--c-1111111","isDraft":false,"mergeable":"MERGEABLE","reviews":[],"reviewDecision":"APPROVED"}\n' "$state"
+  exit 0
+fi
+
+if [ "$1" = "pr" ] && [ "$2" = "merge" ]; then
+  touch "$GG_FAKE_MERGED"
+  exit 0
+fi
+
+echo "unexpected gh invocation: $*" >&2
+exit 1
+"#,
+    )
+    .expect("write fake gh");
+    let mut permissions = fs::metadata(path).expect("stat fake gh").permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).expect("make fake gh executable");
+}
+
+#[cfg(unix)]
+struct WaitingLandFixture {
+    _temp_dir: tempfile::TempDir,
+    repo_path: std::path::PathBuf,
+    other_worktree: std::path::PathBuf,
+    path: OsString,
+    polled: std::path::PathBuf,
+    ready: std::path::PathBuf,
+    merged: std::path::PathBuf,
+    ci_calls: std::path::PathBuf,
+    regress: std::path::PathBuf,
+    test_home: std::path::PathBuf,
+}
+
+#[cfg(unix)]
+impl WaitingLandFixture {
+    fn new() -> Self {
+        let (temp_dir, repo_path, _remote_path) = create_test_repo_with_remote();
+        let gg_dir = repo_path.join(".git/gg");
+        fs::create_dir_all(&gg_dir).expect("create gg dir");
+        fs::write(
+            gg_dir.join("config.json"),
+            r#"{
+  "defaults": {"branch_username":"testuser","provider":"github","base":"main"},
+  "stacks": {"land-wait":{"base":"main","mrs":{"c-1111111":41}}}
+}"#,
+        )
+        .expect("write config");
+
+        run_git(&repo_path, &["checkout", "-b", "testuser/land-wait"]);
+        fs::write(repo_path.join("land.txt"), "land\n").expect("write land entry");
+        run_git(&repo_path, &["add", "land.txt"]);
+        run_git(
+            &repo_path,
+            &["commit", "-m", "Land entry\n\nGG-ID: c-1111111"],
+        );
+
+        let other_worktree = repo_path.parent().unwrap().join("other-worktree");
+        let worktree_output = Command::new("git")
+            .args([
+                "worktree",
+                "add",
+                "-b",
+                "testuser/other",
+                other_worktree.to_str().unwrap(),
+                "main",
+            ])
+            .current_dir(&repo_path)
+            .output()
+            .expect("create other worktree");
+        assert!(worktree_output.status.success());
+
+        let fake_bin = repo_path.join("fake-bin-land-wait");
+        fs::create_dir_all(&fake_bin).expect("create fake bin");
+        write_waiting_fake_gh(&fake_bin.join("gh"));
+        let mut path = OsString::from(fake_bin.as_os_str());
+        path.push(":");
+        path.push(std::env::var_os("PATH").unwrap_or_default());
+
+        let polled = repo_path.join("fake-polled");
+        let ready = repo_path.join("fake-ready");
+        let merged = repo_path.join("fake-merged");
+        let ci_calls = repo_path.join("fake-ci-calls");
+        let regress = repo_path.join("fake-regress");
+        let test_home = repo_path.join(".test-home");
+        fs::create_dir_all(&test_home).expect("create test home");
+
+        Self {
+            _temp_dir: temp_dir,
+            repo_path,
+            other_worktree,
+            path,
+            polled,
+            ready,
+            merged,
+            ci_calls,
+            regress,
+            test_home,
+        }
+    }
+
+    fn start_land(&self) -> std::process::Child {
+        Command::new(env!("CARGO_BIN_EXE_gg"))
+            .args(["land", "--all", "--wait", "--no-clean"])
+            .current_dir(&self.repo_path)
+            .env("HOME", &self.test_home)
+            .env("PATH", &self.path)
+            .env("GG_FAKE_POLLED", &self.polled)
+            .env("GG_FAKE_READY", &self.ready)
+            .env("GG_FAKE_MERGED", &self.merged)
+            .env("GG_FAKE_CI_CALLS", &self.ci_calls)
+            .env("GG_FAKE_REGRESS", &self.regress)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("start waiting land")
+    }
+
+    fn wait_until_polling(&self) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !self.polled.exists() && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        assert!(self.polled.exists(), "land never started polling CI");
+    }
+
+    fn release_ci(&self) {
+        fs::write(&self.ready, "ready\n").expect("release fake CI");
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn test_land_wait_releases_operation_lock_for_sync_in_another_worktree() {
+    let fixture = WaitingLandFixture::new();
+    let land = fixture.start_land();
+    fixture.wait_until_polling();
+
+    let sync = Command::new(env!("CARGO_BIN_EXE_gg"))
+        .arg("sync")
+        .current_dir(&fixture.other_worktree)
+        .env("HOME", &fixture.test_home)
+        .output()
+        .expect("run sync in other worktree");
+    let config_path = fixture.repo_path.join(".git/gg/config.json");
+    let mut concurrent_config: Value =
+        serde_json::from_slice(&fs::read(&config_path).expect("read config after concurrent sync"))
+            .expect("parse config after concurrent sync");
+    concurrent_config["stacks"]["other"] = serde_json::json!({"base":"main"});
+    fs::write(
+        &config_path,
+        serde_json::to_vec_pretty(&concurrent_config).expect("serialize concurrent config"),
+    )
+    .expect("simulate unrelated stack config update");
+    fixture.release_ci();
+    let land_output = land.wait_with_output().expect("wait for land");
+    assert!(
+        sync.status.success(),
+        "sync should run while land is waiting: {}",
+        String::from_utf8_lossy(&sync.stderr)
+    );
+    assert!(
+        land_output.status.success(),
+        "land should finish: stdout={} stderr={}",
+        String::from_utf8_lossy(&land_output.stdout),
+        String::from_utf8_lossy(&land_output.stderr)
+    );
+    assert!(
+        fixture.merged.exists(),
+        "land should merge after CI becomes ready"
+    );
+    let final_config: Value =
+        serde_json::from_slice(&fs::read(&config_path).expect("read config after land"))
+            .expect("parse config after land");
+    assert_eq!(final_config["stacks"]["other"]["base"], "main");
+
+    let operations_dir = fixture.repo_path.join(".git/gg/operations");
+    for entry in fs::read_dir(operations_dir).expect("read operation records") {
+        let path = entry.expect("read operation record entry").path();
+        if path.extension().and_then(|extension| extension.to_str()) != Some("json") {
+            continue;
+        }
+        let record: Value = serde_json::from_slice(&fs::read(path).expect("read operation record"))
+            .expect("parse operation record");
+        assert_eq!(record["status"], "committed");
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn test_land_wait_aborts_when_target_stack_changes() {
+    let fixture = WaitingLandFixture::new();
+    let land = fixture.start_land();
+    fixture.wait_until_polling();
+
+    fs::write(fixture.repo_path.join("new.txt"), "new\n").expect("write new entry");
+    run_git(&fixture.repo_path, &["add", "new.txt"]);
+    run_git(
+        &fixture.repo_path,
+        &["commit", "-m", "New entry\n\nGG-ID: c-2222222"],
+    );
+
+    fixture.release_ci();
+    let output = land.wait_with_output().expect("wait for land");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "land should reject stale stack state"
+    );
+    assert!(
+        stderr.contains("Stack changed while gg land was waiting"),
+        "unexpected error: {stderr}"
+    );
+    assert!(
+        !fixture.merged.exists(),
+        "land must not merge after its target stack changes"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_land_wait_rechecks_readiness_after_reacquiring_lock() {
+    let fixture = WaitingLandFixture::new();
+    fixture.release_ci();
+    fs::write(&fixture.regress, "regress once\n").expect("enable readiness regression");
+
+    let land = fixture.start_land();
+    let output = land.wait_with_output().expect("wait for land");
+    assert!(
+        output.status.success(),
+        "land should resume waiting and finish: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let ci_calls: u32 = fs::read_to_string(&fixture.ci_calls)
+        .expect("read CI call count")
+        .trim()
+        .parse()
+        .expect("parse CI call count");
+    assert!(
+        ci_calls >= 4,
+        "land should recheck readiness and observe the regression; calls={ci_calls}"
+    );
+}
 
 #[test]
 fn test_gg_land_help_has_until() {

--- a/crates/gg-core/src/commands/land.rs
+++ b/crates/gg-core/src/commands/land.rs
@@ -909,6 +909,13 @@ pub fn run(opts: LandOptions) -> Result<()> {
                             break 'landing_loop;
                         }
                         guard = Some(begin_land_segment(&repo, &config, &args)?);
+                        // The MR merged while its train was being polled. Keep the
+                        // follow-up cleanup segment out of `gg undo`.
+                        touched_remote = true;
+                        guard
+                            .as_mut()
+                            .expect("land segment guard")
+                            .mark_touched_remote();
                         landed_count += 1;
                         cleanup_after_merge(
                             &mut config,

--- a/crates/gg-core/src/commands/land.rs
+++ b/crates/gg-core/src/commands/land.rs
@@ -78,6 +78,10 @@ fn interruptible_sleep(
     Ok(())
 }
 
+fn wait_timed_out(start_time: Instant, timeout: Duration) -> bool {
+    start_time.elapsed() > timeout
+}
+
 /// Polling interval (10 seconds)
 const POLL_INTERVAL_SECS: u64 = 10;
 
@@ -381,6 +385,80 @@ pub struct LandOptions {
     pub admin: bool,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+struct LandStackFingerprint {
+    name: String,
+    base: String,
+    entries: Vec<(git2::Oid, Option<String>, Option<u64>)>,
+}
+
+impl From<&Stack> for LandStackFingerprint {
+    fn from(stack: &Stack) -> Self {
+        Self {
+            name: stack.name.clone(),
+            base: stack.base.clone(),
+            entries: stack
+                .entries
+                .iter()
+                .map(|entry| (entry.oid, entry.gg_id.clone(), entry.mr_number))
+                .collect(),
+        }
+    }
+}
+
+fn stack_changed_while_waiting(expected: &LandStackFingerprint, stack: &Stack) -> Option<String> {
+    (expected != &LandStackFingerprint::from(stack)).then(|| {
+        "Stack changed while gg land was waiting; rerun gg land to use the latest stack state."
+            .to_string()
+    })
+}
+
+fn pr_is_still_ready(
+    provider: &Provider,
+    pr_num: u64,
+    skip_approval: bool,
+    merge_trains_enabled: bool,
+) -> bool {
+    if !matches!(provider.get_pr_ci_status(pr_num), Ok(CiStatus::Success)) {
+        return false;
+    }
+    (skip_approval && !merge_trains_enabled) || provider.check_pr_approved(pr_num).unwrap_or(false)
+}
+
+fn begin_land_segment(
+    repo: &git2::Repository,
+    config: &Config,
+    args: &[String],
+) -> Result<crate::operations::OperationGuard> {
+    git::begin_recorded_op(
+        repo,
+        config,
+        OperationKind::Land,
+        args.to_vec(),
+        None,
+        SnapshotScope::AllUserBranches,
+    )
+}
+
+fn finish_land_segment(
+    repo: &git2::Repository,
+    config: &Config,
+    guard: &mut Option<crate::operations::OperationGuard>,
+    remote_effects: &mut Vec<RemoteEffect>,
+    touched_remote: &mut bool,
+) -> Result<()> {
+    let Some(guard) = guard.take() else {
+        return Ok(());
+    };
+    guard.finalize_with_scope(
+        repo,
+        config,
+        SnapshotScope::AllUserBranches,
+        std::mem::take(remote_effects),
+        std::mem::take(touched_remote),
+    )
+}
+
 /// Run the land command
 pub fn run(opts: LandOptions) -> Result<()> {
     let LandOptions {
@@ -394,19 +472,15 @@ pub fn run(opts: LandOptions) -> Result<()> {
         admin,
     } = opts;
     let repo = git::open_repo()?;
-
     let git_dir = repo.commondir();
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let mut lock = Some(git::acquire_operation_lock(&repo, "land")?);
     let mut config = Config::load_with_global(git_dir)?;
-
-    // Acquire operation lock + record a Pending op for the undo log.
-    let (_lock, mut guard) = git::acquire_operation_lock_and_record(
-        &repo,
-        &config,
-        OperationKind::Land,
-        std::env::args().skip(1).collect(),
-        None,
-        SnapshotScope::AllUserBranches,
-    )?;
+    let mut guard = if wait {
+        None
+    } else {
+        Some(begin_land_segment(&repo, &config, &args)?)
+    };
 
     // Remote effects collected during landing. A successful merge adds a
     // `PrMerged`; auto-merge scheduling sets `touched_remote` without a
@@ -451,12 +525,12 @@ pub fn run(opts: LandOptions) -> Result<()> {
         } else {
             println!("{}", style("Stack is empty. Nothing to land.").dim());
         }
-        guard.finalize_with_scope(
+        finish_land_segment(
             &repo,
             &config,
-            SnapshotScope::AllUserBranches,
-            vec![],
-            false,
+            &mut guard,
+            &mut remote_effects,
+            &mut touched_remote,
         )?;
         return Ok(());
     }
@@ -583,7 +657,7 @@ pub fn run(opts: LandOptions) -> Result<()> {
             None => break 'landing_loop,
         };
 
-        let entry = &entries_to_land[entry_idx];
+        let entry = entries_to_land[entry_idx].clone();
         if let Some(ref flag) = interrupted {
             if flag.load(Ordering::SeqCst) {
                 land_error = Some("Interrupted by user".to_string());
@@ -592,7 +666,7 @@ pub fn run(opts: LandOptions) -> Result<()> {
         }
 
         let gg_id = match &entry.gg_id {
-            Some(id) => id,
+            Some(id) => id.clone(),
             None => {
                 land_error = Some(format!(
                     "Commit {} is missing GG-ID. Run `gg sync` first.",
@@ -685,27 +759,64 @@ pub fn run(opts: LandOptions) -> Result<()> {
             }
             PrState::Open => {
                 if wait {
-                    let timeout_minutes = config.get_land_wait_timeout_minutes();
-                    if let Err(e) = wait_for_pr_ready(
-                        &provider,
-                        pr_num,
-                        land_all || (admin && provider == Provider::GitHub),
-                        timeout_minutes,
-                        interrupted.as_ref(),
-                        &stack.base,
-                        json,
-                    ) {
-                        landed_entries.push(LandedEntryJson {
-                            position: entry.position,
-                            sha: entry.short_sha.clone(),
-                            title: entry.title.clone(),
-                            gg_id: gg_id.clone(),
-                            pr_number: pr_num,
-                            action: "error".to_string(),
-                            error: Some(e.to_string()),
-                        });
-                        land_error = Some(e.to_string());
-                        break 'landing_loop;
+                    let skip_approval = land_all || (admin && provider == Provider::GitHub);
+                    let wait_started = Instant::now();
+                    loop {
+                        let expected_stack = LandStackFingerprint::from(&stack);
+                        finish_land_segment(
+                            &repo,
+                            &config,
+                            &mut guard,
+                            &mut remote_effects,
+                            &mut touched_remote,
+                        )?;
+                        config.save(git_dir)?;
+                        drop(lock.take());
+                        let timeout_minutes = config.get_land_wait_timeout_minutes();
+                        let wait_result = wait_for_pr_ready(
+                            &provider,
+                            pr_num,
+                            skip_approval,
+                            wait_started,
+                            timeout_minutes,
+                            interrupted.as_ref(),
+                            &stack.base,
+                            json,
+                        );
+                        lock = Some(git::acquire_operation_lock(&repo, "land")?);
+                        config = Config::load_with_global(git_dir)?;
+                        stack = Stack::load(&repo, &config)?;
+                        if let Err(e) = wait_result {
+                            landed_entries.push(LandedEntryJson {
+                                position: entry.position,
+                                sha: entry.short_sha.clone(),
+                                title: entry.title.clone(),
+                                gg_id: gg_id.clone(),
+                                pr_number: pr_num,
+                                action: "error".to_string(),
+                                error: Some(e.to_string()),
+                            });
+                            land_error = Some(e.to_string());
+                            break 'landing_loop;
+                        }
+                        if let Some(error) = stack_changed_while_waiting(&expected_stack, &stack) {
+                            landed_entries.push(LandedEntryJson {
+                                position: entry.position,
+                                sha: entry.short_sha.clone(),
+                                title: entry.title.clone(),
+                                gg_id: gg_id.clone(),
+                                pr_number: pr_num,
+                                action: "error".to_string(),
+                                error: Some(error.clone()),
+                            });
+                            land_error = Some(error);
+                            break 'landing_loop;
+                        }
+                        if pr_is_still_ready(&provider, pr_num, skip_approval, merge_trains_enabled)
+                        {
+                            guard = Some(begin_land_segment(&repo, &config, &args)?);
+                            break;
+                        }
                     }
                 } else if !land_all && (!admin || provider != Provider::GitHub) {
                     let approved = provider.check_pr_approved(pr_num)?;
@@ -749,7 +860,10 @@ pub fn run(opts: LandOptions) -> Result<()> {
                     // the flag immediately so a mid-sequence failure still
                     // leaves a record the sweep will promote correctly.
                     touched_remote = true;
-                    guard.mark_touched_remote();
+                    guard
+                        .as_mut()
+                        .expect("land segment guard")
+                        .mark_touched_remote();
                     let action = match result {
                         AutoMergeResult::Queued => "queued",
                         AutoMergeResult::AlreadyQueued => "already_queued",
@@ -764,24 +878,43 @@ pub fn run(opts: LandOptions) -> Result<()> {
                         error: None,
                     });
                     if wait {
+                        let expected_stack = LandStackFingerprint::from(&stack);
+                        finish_land_segment(
+                            &repo,
+                            &config,
+                            &mut guard,
+                            &mut remote_effects,
+                            &mut touched_remote,
+                        )?;
+                        config.save(git_dir)?;
+                        drop(lock.take());
                         let timeout_minutes = config.get_land_wait_timeout_minutes();
-                        if let Err(e) = wait_for_merge_train_completion(
+                        let wait_result = wait_for_merge_train_completion(
                             &provider,
                             pr_num,
                             timeout_minutes,
                             interrupted.as_ref(),
                             &stack.base,
                             json,
-                        ) {
+                        );
+                        lock = Some(git::acquire_operation_lock(&repo, "land")?);
+                        config = Config::load_with_global(git_dir)?;
+                        stack = Stack::load(&repo, &config)?;
+                        if let Err(e) = wait_result {
                             land_error = Some(e.to_string());
                             break 'landing_loop;
                         }
+                        if let Some(error) = stack_changed_while_waiting(&expected_stack, &stack) {
+                            land_error = Some(error);
+                            break 'landing_loop;
+                        }
+                        guard = Some(begin_land_segment(&repo, &config, &args)?);
                         landed_count += 1;
                         cleanup_after_merge(
                             &mut config,
                             &stack,
                             &provider,
-                            gg_id,
+                            &gg_id,
                             pr_num,
                             land_multiple,
                             json,
@@ -835,7 +968,10 @@ pub fn run(opts: LandOptions) -> Result<()> {
                     // remote so `gg undo` refuses with a provider hint. Persist
                     // immediately for mid-sequence failure tolerance.
                     touched_remote = true;
-                    guard.mark_touched_remote();
+                    guard
+                        .as_mut()
+                        .expect("land segment guard")
+                        .mark_touched_remote();
                     landed_entries.push(LandedEntryJson {
                         position: entry.position,
                         sha: entry.short_sha.clone(),
@@ -887,7 +1023,10 @@ pub fn run(opts: LandOptions) -> Result<()> {
                     };
                     remote_effects.push(effect.clone());
                     touched_remote = true;
-                    guard.record_remote_effect(effect);
+                    guard
+                        .as_mut()
+                        .expect("land segment guard")
+                        .record_remote_effect(effect);
 
                     landed_entries.push(LandedEntryJson {
                         position: entry.position,
@@ -903,7 +1042,7 @@ pub fn run(opts: LandOptions) -> Result<()> {
                         &mut config,
                         &stack,
                         &provider,
-                        gg_id,
+                        &gg_id,
                         pr_num,
                         land_multiple,
                         json,
@@ -946,7 +1085,33 @@ pub fn run(opts: LandOptions) -> Result<()> {
         if !land_multiple {
             break 'landing_loop;
         }
-        std::thread::sleep(Duration::from_secs(2));
+        if wait {
+            let expected_stack = LandStackFingerprint::from(&stack);
+            finish_land_segment(
+                &repo,
+                &config,
+                &mut guard,
+                &mut remote_effects,
+                &mut touched_remote,
+            )?;
+            config.save(git_dir)?;
+            drop(lock.take());
+            let sleep_result =
+                interruptible_sleep(Duration::from_secs(2), interrupted.as_ref(), None);
+            lock = Some(git::acquire_operation_lock(&repo, "land")?);
+            config = Config::load_with_global(git_dir)?;
+            stack = Stack::load(&repo, &config)?;
+            if let Err(error) = sleep_result {
+                land_error = Some(error.to_string());
+                break 'landing_loop;
+            }
+            if let Some(error) = stack_changed_while_waiting(&expected_stack, &stack) {
+                land_error = Some(error);
+                break 'landing_loop;
+            }
+        } else {
+            std::thread::sleep(Duration::from_secs(2));
+        }
     }
 
     config.save(git_dir)?;
@@ -971,6 +1136,9 @@ pub fn run(opts: LandOptions) -> Result<()> {
         };
 
         if should_clean && !has_unsynced_commits_before_merge {
+            if guard.is_none() {
+                guard = Some(begin_land_segment(&repo, &config, &args)?);
+            }
             // After landing, the stack contains merged commits by definition.
             // Bypass the immutability guard since the rebase here is a
             // sanctioned cleanup step, not a user-driven history rewrite.
@@ -981,7 +1149,10 @@ pub fn run(opts: LandOptions) -> Result<()> {
                 &stack.name,
                 true,
                 &mut |effect| {
-                    guard.record_remote_effect(effect.clone());
+                    guard
+                        .as_mut()
+                        .expect("land segment guard")
+                        .record_remote_effect(effect.clone());
                     remote_effects.push(effect);
                     touched_remote = true;
                 },
@@ -1049,13 +1220,14 @@ pub fn run(opts: LandOptions) -> Result<()> {
     // on remote and can't be undone locally). Dropping the guard without
     // finalize would leave the record Pending and eventually get swept to
     // Interrupted — less accurate for `gg undo --list`.
-    guard.finalize_with_scope(
+    finish_land_segment(
         &repo,
         &config,
-        SnapshotScope::AllUserBranches,
-        remote_effects,
-        touched_remote,
+        &mut guard,
+        &mut remote_effects,
+        &mut touched_remote,
     )?;
+    drop(lock);
 
     // In JSON mode, the error is already included in the LandResponse payload.
     // Returning Err would cause gg-cli to emit a second JSON error object,
@@ -1071,16 +1243,17 @@ pub fn run(opts: LandOptions) -> Result<()> {
 
 /// Wait for a PR/MR to be ready to merge (CI passes, approvals met)
 /// Also monitors merge train status if merge trains are enabled
+#[allow(clippy::too_many_arguments)]
 fn wait_for_pr_ready(
     provider: &Provider,
     pr_num: u64,
     skip_approval: bool,
+    start_time: Instant,
     timeout_minutes: u64,
     interrupted: Option<&Arc<AtomicBool>>,
     target_branch: &str,
     json: bool,
 ) -> Result<()> {
-    let start_time = Instant::now();
     let timeout = Duration::from_secs(timeout_minutes * 60);
     let poll_interval = Duration::from_secs(POLL_INTERVAL_SECS);
     let mut consecutive_errors: u32 = 0;
@@ -1108,7 +1281,7 @@ fn wait_for_pr_ready(
 
     loop {
         // Check timeout
-        if start_time.elapsed() > timeout {
+        if wait_timed_out(start_time, timeout) {
             if let Some(ref spinner) = current_spinner {
                 spinner.finish_and_clear();
             }
@@ -1667,6 +1840,12 @@ mod tests {
     }
 
     #[test]
+    fn test_wait_timeout_uses_original_start_time() {
+        let started = Instant::now() - Duration::from_secs(61);
+        assert!(wait_timed_out(started, Duration::from_secs(60)));
+    }
+
+    #[test]
     fn test_config_remove_mr_for_entry_removes_single_entry() {
         // Create a config with multiple MR mappings
         let mut config = Config {
@@ -1919,6 +2098,7 @@ mod tests {
             &Provider,
             u64,
             bool,
+            Instant,
             u64,
             Option<&Arc<AtomicBool>>,
             &str,

--- a/docs/src/commands/land.md
+++ b/docs/src/commands/land.md
@@ -85,6 +85,17 @@ Error: MR !7621 CI failed
 
 This helps diagnose CI issues without having to open the GitLab UI. Failed job names and stages are fetched from the MR's head pipeline.
 
+## Concurrent commands while waiting
+
+`gg land --wait` releases the repository-wide `gg` lock while it polls CI,
+approvals, or merge-train state. You can run commands such as `gg sync` for a
+different stack in another worktree during that time. Landing reacquires the
+lock before every merge, rebase, push, cleanup, or config update.
+
+Do not change the stack being landed while it waits. If its commits, GG-IDs, or
+PR/MR mappings change, landing stops before the next merge and asks you to rerun
+the command with the latest stack state.
+
 ## JSON Output
 
 Example JSON response:

--- a/docs/src/guides/worktrees.md
+++ b/docs/src/guides/worktrees.md
@@ -34,6 +34,10 @@ gg co user-auth -w
 - Keep your main checkout untouched
 - Work on multiple stacks side by side
 - Avoid stashing/switching overhead
+- Run `gg` on another stack while `gg land --wait` polls in a different worktree
+
+Waiting does not reserve the stack being landed. If that stack changes before
+the next merge, `gg land --wait` stops and must be rerun.
 
 ## Default path behavior
 

--- a/skills/gg/references/landing-and-cleanup.md
+++ b/skills/gg/references/landing-and-cleanup.md
@@ -35,6 +35,11 @@
   there are no required checks or pipelines; stale or unavailable CI still
   blocks.
   Draft, behind-base, mergeability, and conflict gates always apply.
+- `gg land --wait` releases the clone-wide operation lock while polling. Other
+  worktrees may run `gg` commands on unrelated stacks, so do not treat a waiting
+  land process as a repository reservation. Do not mutate its target stack;
+  the command will stop before the next merge if local commits, GG-IDs, or
+  PR/MR mappings changed while it waited.
 - Treat a general request such as "finish this stack" as insufficient landing
   confirmation. Ask immediately before running `gg land`.
 - Immediately before landing, inspect the effective provider and `land_admin`


### PR DESCRIPTION
- Allow other worktrees to run gg during land polling\n- Revalidate stacks and readiness after reacquiring the lock\n- Document the concurrent wait behavior