### PR TITLE
feat(ls): add local-only stack snapshots

### DIFF
--- a/crates/gg-cli/src/main.rs
+++ b/crates/gg-cli/src/main.rs
@@ -82,7 +82,7 @@ enum Commands {
         refresh: bool,
 
         /// Skip refreshing PR/MR status from remote
-        #[arg(long, conflicts_with = "refresh")]
+        #[arg(long, conflicts_with_all = ["refresh", "remote"])]
         no_refresh: bool,
 
         /// List remote stacks (branches on origin not yet checked out locally)

--- a/crates/gg-cli/src/main.rs
+++ b/crates/gg-cli/src/main.rs
@@ -81,6 +81,10 @@ enum Commands {
         #[arg(short, long)]
         refresh: bool,
 
+        /// Skip refreshing PR/MR status from remote
+        #[arg(long, conflicts_with = "refresh")]
+        no_refresh: bool,
+
         /// List remote stacks (branches on origin not yet checked out locally)
         #[arg(long)]
         remote: bool,
@@ -571,7 +575,7 @@ fn main() {
     let (result, json_mode, jsonl) = match cli.command {
         // No command = show stacks (like `gg ls`)
         None => (
-            gg_core::commands::ls::run(false, false, false, false),
+            gg_core::commands::ls::run(false, false, false, false, false),
             false,
             false,
         ),
@@ -588,10 +592,11 @@ fn main() {
         Some(Commands::List {
             all,
             refresh,
+            no_refresh,
             remote,
             json,
         }) => (
-            gg_core::commands::ls::run(all, refresh, remote, json),
+            gg_core::commands::ls::run(all, refresh, remote, json, no_refresh),
             json,
             false,
         ),

--- a/crates/gg-cli/tests/integration_tests/ls.rs
+++ b/crates/gg-cli/tests/integration_tests/ls.rs
@@ -163,6 +163,18 @@ fn test_gg_ls_no_refresh_conflicts_with_refresh() {
 }
 
 #[test]
+fn test_gg_ls_no_refresh_conflicts_with_remote() {
+    let (_temp_dir, repo_path) = create_test_repo();
+    let (success, _, stderr) = run_gg(&repo_path, &["ls", "--remote", "--no-refresh"]);
+
+    assert!(!success);
+    assert!(
+        stderr.contains("cannot be used with") && stderr.contains("--no-refresh"),
+        "{stderr}"
+    );
+}
+
+#[test]
 fn test_gg_ls_json_reports_valid_interrupted_rebase_operation_id() {
     let (_temp_dir, repo_path) = create_test_repo();
     setup_json_stack(&repo_path, "paused-json-stack");

--- a/crates/gg-cli/tests/integration_tests/ls.rs
+++ b/crates/gg-cli/tests/integration_tests/ls.rs
@@ -137,6 +137,32 @@ fn test_gg_ls_json_current_stack() {
 }
 
 #[test]
+fn test_gg_ls_json_no_refresh_preserves_stack_output() {
+    let (_temp_dir, repo_path) = create_test_repo();
+    setup_json_stack(&repo_path, "local-json-stack");
+    fs::write(repo_path.join("local.txt"), "local").expect("Failed to write file");
+    run_git(&repo_path, &["add", "."]);
+    run_git(&repo_path, &["commit", "-m", "Add local file"]);
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["ls", "--json", "--no-refresh"]);
+    assert!(success, "gg ls --json --no-refresh failed: {stderr}");
+
+    let parsed: Value = serde_json::from_str(&stdout).expect("stdout must be valid JSON");
+    assert_eq!(parsed["version"], 1);
+    assert_eq!(parsed["stack"]["name"], "local-json-stack");
+    assert_eq!(parsed["stack"]["total_commits"], 1);
+}
+
+#[test]
+fn test_gg_ls_no_refresh_conflicts_with_refresh() {
+    let (_temp_dir, repo_path) = create_test_repo();
+    let (success, _, stderr) = run_gg(&repo_path, &["ls", "--json", "--refresh", "--no-refresh"]);
+
+    assert!(!success);
+    assert!(stderr.contains("cannot be used with"), "{stderr}");
+}
+
+#[test]
 fn test_gg_ls_json_reports_valid_interrupted_rebase_operation_id() {
     let (_temp_dir, repo_path) = create_test_repo();
     setup_json_stack(&repo_path, "paused-json-stack");

--- a/crates/gg-cli/tests/integration_tests/ls.rs
+++ b/crates/gg-cli/tests/integration_tests/ls.rs
@@ -4,6 +4,7 @@ use crate::helpers::{
 };
 
 use serde_json::Value;
+use std::ffi::OsStr;
 use std::fs;
 
 #[test]
@@ -171,6 +172,26 @@ fn test_gg_ls_no_refresh_conflicts_with_remote() {
     assert!(
         stderr.contains("cannot be used with") && stderr.contains("--no-refresh"),
         "{stderr}"
+    );
+}
+
+#[test]
+fn test_gg_ls_no_refresh_requires_configured_username_for_all_stacks() {
+    let (_temp_dir, repo_path) = create_test_repo();
+    let (success, stdout, stderr) = run_gg_with_env(
+        &repo_path,
+        &["ls", "--all", "--json", "--no-refresh"],
+        &[("PATH", OsStr::new(""))],
+    );
+
+    assert!(!success);
+    assert!(
+        stdout.contains("--no-refresh requires defaults.branch_username"),
+        "{stdout}"
+    );
+    assert!(
+        stderr.is_empty(),
+        "structured error should use stdout: {stderr}"
     );
 }
 

--- a/crates/gg-core/src/commands/ls.rs
+++ b/crates/gg-core/src/commands/ls.rs
@@ -14,7 +14,7 @@ use crate::provider::{CiStatus, PrState, Provider};
 use crate::stack::{self, Stack};
 
 /// Run the list command
-pub fn run(all: bool, refresh: bool, remote: bool, json: bool) -> Result<()> {
+pub fn run(all: bool, refresh: bool, remote: bool, json: bool, no_refresh: bool) -> Result<()> {
     let repo = git::open_repo()?;
     let git_dir = repo.commondir();
     let config = Config::load_with_global(git_dir)?;
@@ -43,7 +43,7 @@ pub fn run(all: bool, refresh: bool, remote: bool, json: bool) -> Result<()> {
                 }
             }
 
-            if should_refresh_mr_info(refresh, json) {
+            if should_refresh_mr_info(refresh, json, no_refresh) {
                 if refresh {
                     let provider = Provider::detect(&repo)?;
                     if !json {
@@ -757,8 +757,8 @@ fn ci_status_to_json(status: &CiStatus) -> String {
     }
 }
 
-fn should_refresh_mr_info(refresh: bool, json: bool) -> bool {
-    refresh || json
+fn should_refresh_mr_info(refresh: bool, json: bool, no_refresh: bool) -> bool {
+    refresh || (json && !no_refresh)
 }
 
 #[cfg(test)]
@@ -767,17 +767,22 @@ mod tests {
 
     #[test]
     fn json_output_auto_refreshes_mr_info() {
-        assert!(should_refresh_mr_info(false, true));
+        assert!(should_refresh_mr_info(false, true, false));
     }
 
     #[test]
     fn explicit_refresh_still_refreshes() {
-        assert!(should_refresh_mr_info(true, false));
+        assert!(should_refresh_mr_info(true, false, false));
+    }
+
+    #[test]
+    fn json_no_refresh_skips_mr_info() {
+        assert!(!should_refresh_mr_info(false, true, true));
     }
 
     #[test]
     fn no_refresh_for_human_output_without_flag() {
-        assert!(!should_refresh_mr_info(false, false));
+        assert!(!should_refresh_mr_info(false, false, false));
     }
 
     // ==========================================================================

--- a/crates/gg-core/src/commands/ls.rs
+++ b/crates/gg-core/src/commands/ls.rs
@@ -3,7 +3,7 @@
 use console::style;
 
 use crate::config::Config;
-use crate::error::Result;
+use crate::error::{GgError, Result};
 use crate::git;
 use crate::operations;
 use crate::output::{
@@ -29,7 +29,7 @@ pub fn run(all: bool, refresh: bool, remote: bool, json: bool, no_refresh: bool)
 
     match current_stack {
         None => {
-            list_all_stacks(&repo, &config, json)?;
+            list_all_stacks(&repo, &config, json, no_refresh)?;
         }
         Some(mut stack) if !all => {
             if !json {
@@ -61,7 +61,7 @@ pub fn run(all: bool, refresh: bool, remote: bool, json: bool, no_refresh: bool)
             show_stack(&stack, json)?;
         }
         Some(_) => {
-            list_all_stacks(&repo, &config, json)?;
+            list_all_stacks(&repo, &config, json, no_refresh)?;
         }
     }
 
@@ -69,7 +69,17 @@ pub fn run(all: bool, refresh: bool, remote: bool, json: bool, no_refresh: bool)
 }
 
 /// List all available stacks with their commits in a tree view
-fn list_all_stacks(repo: &git2::Repository, config: &Config, json: bool) -> Result<()> {
+fn list_all_stacks(
+    repo: &git2::Repository,
+    config: &Config,
+    json: bool,
+    no_refresh: bool,
+) -> Result<()> {
+    if no_refresh && config.defaults.branch_username.is_none() {
+        return Err(GgError::Other(
+            "--no-refresh requires defaults.branch_username when listing all stacks".to_string(),
+        ));
+    }
     let username = config
         .defaults
         .branch_username

--- a/docs/src/commands/ls.md
+++ b/docs/src/commands/ls.md
@@ -18,7 +18,7 @@ gg ls [OPTIONS]
 
 - `-a, --all`: Show all local stacks
 - `-r, --refresh`: Refresh PR/MR status from remote
-- `--no-refresh`: Skip the provider API and return local stack data immediately. Conflicts with `--refresh` and `--remote`; intended for local-only JSON consumers.
+- `--no-refresh`: Skip the provider API and return local stack data immediately. Conflicts with `--refresh` and `--remote`; listing all stacks also requires `defaults.branch_username` to be configured. Intended for local-only JSON consumers.
 - `--remote`: List remote stacks not checked out locally. Stacks whose PRs/MRs are all merged are shown in a separate "Landed" section at the bottom with a `✓` marker
 - `--json`: Print structured JSON output (for scripts and automation). Automatically performs a best-effort refresh of PR/MR state from the provider API, so `pr_state` and `ci_status` fields are populated without needing `--refresh`.
 

--- a/docs/src/commands/ls.md
+++ b/docs/src/commands/ls.md
@@ -18,7 +18,7 @@ gg ls [OPTIONS]
 
 - `-a, --all`: Show all local stacks
 - `-r, --refresh`: Refresh PR/MR status from remote
-- `--no-refresh`: Skip the provider API and return local stack data immediately. Conflicts with `--refresh`; intended for local-only JSON consumers.
+- `--no-refresh`: Skip the provider API and return local stack data immediately. Conflicts with `--refresh` and `--remote`; intended for local-only JSON consumers.
 - `--remote`: List remote stacks not checked out locally. Stacks whose PRs/MRs are all merged are shown in a separate "Landed" section at the bottom with a `✓` marker
 - `--json`: Print structured JSON output (for scripts and automation). Automatically performs a best-effort refresh of PR/MR state from the provider API, so `pr_state` and `ci_status` fields are populated without needing `--refresh`.
 

--- a/docs/src/commands/ls.md
+++ b/docs/src/commands/ls.md
@@ -18,6 +18,7 @@ gg ls [OPTIONS]
 
 - `-a, --all`: Show all local stacks
 - `-r, --refresh`: Refresh PR/MR status from remote
+- `--no-refresh`: Skip the provider API and return local stack data immediately. Conflicts with `--refresh`; intended for local-only JSON consumers.
 - `--remote`: List remote stacks not checked out locally. Stacks whose PRs/MRs are all merged are shown in a separate "Landed" section at the bottom with a `✓` marker
 - `--json`: Print structured JSON output (for scripts and automation). Automatically performs a best-effort refresh of PR/MR state from the provider API, so `pr_state` and `ci_status` fields are populated without needing `--refresh`.
 
@@ -40,6 +41,9 @@ gg ls --refresh
 gg ls --json
 gg ls --all --json
 gg ls --remote --json
+
+# Local-only JSON without waiting for the provider API
+gg ls --json --no-refresh
 ```
 
 ## Un-integrated commits at HEAD


### PR DESCRIPTION
## Summary
- add `gg ls --json --no-refresh` for local-only stack snapshots
- preserve the existing JSON auto-refresh behavior by default
- reject `--refresh` combined with `--no-refresh`

## Verification
- `cargo test --workspace`
- `cargo fmt --all --check`
- `git diff --check`