### PR TITLE
feat(land): add JSONL output

### DIFF
--- a/crates/gg-cli/src/main.rs
+++ b/crates/gg-cli/src/main.rs
@@ -326,6 +326,10 @@ enum Commands {
         #[arg(long)]
         json: bool,
 
+        /// Output streaming NDJSON (one event per line; flushed after each)
+        #[arg(long = "jsonl", conflicts_with = "json")]
+        jsonl: bool,
+
         /// (GitLab only) Request auto-merge ("merge when pipeline succeeds") instead of merging immediately
         #[arg(long)]
         auto_merge: bool,
@@ -745,6 +749,7 @@ fn main() {
         Some(Commands::Land {
             all,
             json,
+            jsonl,
             auto_merge,
             no_squash,
             wait,
@@ -753,6 +758,10 @@ fn main() {
             no_clean,
             admin,
         }) => {
+            if jsonl {
+                streaming_command = Some("land");
+            }
+
             // Load config once for resolving defaults
             let land_cfg = gg_core::git::open_repo()
                 .and_then(|repo| gg_core::config::Config::load_with_global(repo.commondir()))
@@ -774,6 +783,7 @@ fn main() {
                 gg_core::commands::land::run(gg_core::commands::land::LandOptions {
                     land_all: all,
                     json,
+                    jsonl,
                     squash: !no_squash,
                     wait,
                     auto_clean,
@@ -781,8 +791,8 @@ fn main() {
                     until,
                     admin,
                 }),
-                json,
-                false,
+                json || jsonl,
+                jsonl,
             )
         }
         Some(Commands::Clean { all, json }) => {

--- a/crates/gg-cli/tests/integration_tests/land.rs
+++ b/crates/gg-cli/tests/integration_tests/land.rs
@@ -327,6 +327,19 @@ fn test_land_jsonl_clean_does_not_prompt_for_a_configured_worktree() {
             .all(|line| serde_json::from_str::<Value>(line).is_ok()),
         "every JSONL line must parse: {stdout}"
     );
+    let summary: Value = serde_json::from_str(stdout.lines().last().expect("summary event"))
+        .expect("parse summary event");
+    assert_eq!(summary["cleaned"], false);
+    assert!(
+        summary["warnings"]
+            .as_array()
+            .expect("warnings must be an array")
+            .iter()
+            .any(|warning| warning
+                .as_str()
+                .is_some_and(|warning| warning.contains("worktree"))),
+        "summary should explain why cleanup was skipped: {summary}"
+    );
 }
 
 #[cfg(unix)]

--- a/crates/gg-cli/tests/integration_tests/land.rs
+++ b/crates/gg-cli/tests/integration_tests/land.rs
@@ -528,6 +528,11 @@ fn test_land_jsonl_default_scope_reports_one_total_entry() {
         serde_json::from_str(stdout.lines().next().expect("start event")).expect("parse start");
     assert_eq!(start["event"], "start");
     assert_eq!(start["total_entries"], 1);
+
+    let summary: Value = serde_json::from_str(stdout.lines().last().expect("summary event"))
+        .expect("parse summary event");
+    assert_eq!(summary["event"], "summary");
+    assert_eq!(summary["remaining"], 1);
 }
 
 #[cfg(unix)]

--- a/crates/gg-cli/tests/integration_tests/land.rs
+++ b/crates/gg-cli/tests/integration_tests/land.rs
@@ -269,6 +269,68 @@ fn test_land_jsonl_streams_wait_entry_and_summary() {
 
 #[cfg(unix)]
 #[test]
+fn test_land_jsonl_admin_emits_no_human_warning() {
+    let fixture = WaitingLandFixture::new();
+    fixture.release_ci();
+
+    let output = fixture
+        .start_land_with_args(&["land", "--jsonl", "--admin", "--no-clean"])
+        .wait_with_output()
+        .expect("wait for land");
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    assert!(output.status.success(), "land failed: {stderr}");
+    assert!(stderr.trim().is_empty(), "unexpected stderr: {stderr}");
+    assert!(
+        stdout
+            .lines()
+            .all(|line| serde_json::from_str::<Value>(line).is_ok()),
+        "every JSONL line must parse: {stdout}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_land_jsonl_clean_does_not_prompt_for_a_configured_worktree() {
+    let fixture = WaitingLandFixture::new();
+    fixture.release_ci();
+    let config_path = fixture.repo_path.join(".git/gg/config.json");
+    let mut config: Value = serde_json::from_slice(&fs::read(&config_path).expect("read config"))
+        .expect("parse config");
+    config["stacks"]["land-wait"]["worktree_path"] = Value::String(
+        fixture
+            .repo_path
+            .join("configured-worktree")
+            .display()
+            .to_string(),
+    );
+    fs::write(
+        &config_path,
+        serde_json::to_vec_pretty(&config).expect("serialize config"),
+    )
+    .expect("write config");
+
+    let output = fixture
+        .start_land_with_args(&["land", "--jsonl", "--clean"])
+        .wait_with_output()
+        .expect("wait for land");
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    assert!(
+        output.status.success(),
+        "land failed: stdout={stdout} stderr={stderr}"
+    );
+    assert!(stderr.trim().is_empty(), "unexpected stderr: {stderr}");
+    assert!(
+        stdout
+            .lines()
+            .all(|line| serde_json::from_str::<Value>(line).is_ok()),
+        "every JSONL line must parse: {stdout}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
 fn test_land_wait_releases_operation_lock_for_sync_in_another_worktree() {
     let fixture = WaitingLandFixture::new();
     let land = fixture.start_land();

--- a/crates/gg-cli/tests/integration_tests/land.rs
+++ b/crates/gg-cli/tests/integration_tests/land.rs
@@ -717,6 +717,11 @@ fn test_land_gitlab_auto_merge_jsonl_reports_single_entry_total() {
         serde_json::from_str(stdout.lines().next().expect("start event")).expect("parse start");
     assert_eq!(start["event"], "start");
     assert_eq!(start["total_entries"], 1);
+
+    let summary: Value = serde_json::from_str(stdout.lines().last().expect("summary event"))
+        .expect("parse summary event");
+    assert_eq!(summary["event"], "summary");
+    assert_eq!(summary["remaining"], 2);
 }
 
 #[cfg(unix)]

--- a/crates/gg-cli/tests/integration_tests/land.rs
+++ b/crates/gg-cli/tests/integration_tests/land.rs
@@ -3,6 +3,7 @@ use crate::helpers::{create_test_repo, create_test_repo_with_remote, run_gg, run
 use serde_json::Value;
 use std::ffi::OsString;
 use std::fs;
+use std::io::{BufRead, BufReader, Read};
 use std::path::Path;
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
@@ -151,8 +152,12 @@ impl WaitingLandFixture {
     }
 
     fn start_land(&self) -> std::process::Child {
+        self.start_land_with_args(&["land", "--all", "--wait", "--no-clean"])
+    }
+
+    fn start_land_with_args(&self, args: &[&str]) -> std::process::Child {
         Command::new(env!("CARGO_BIN_EXE_gg"))
-            .args(["land", "--all", "--wait", "--no-clean"])
+            .args(args)
             .current_dir(&self.repo_path)
             .env("HOME", &self.test_home)
             .env("PATH", &self.path)
@@ -178,6 +183,88 @@ impl WaitingLandFixture {
     fn release_ci(&self) {
         fs::write(&self.ready, "ready\n").expect("release fake CI");
     }
+}
+
+#[cfg(unix)]
+#[test]
+fn test_land_jsonl_streams_wait_entry_and_summary() {
+    let fixture = WaitingLandFixture::new();
+    let mut land = fixture.start_land_with_args(&["land", "--wait", "--no-clean", "--jsonl"]);
+    let stdout = land.stdout.take().expect("capture land stdout");
+    let (sender, receiver) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let mut reader = BufReader::new(stdout);
+        let mut events = Vec::new();
+        loop {
+            let mut line = String::new();
+            assert!(
+                reader.read_line(&mut line).expect("read JSONL event") > 0,
+                "land exited before emitting a wait heartbeat"
+            );
+            let event: Value = serde_json::from_str(line.trim_end()).expect("parse JSONL event");
+            let is_wait = event["event"] == "wait";
+            events.push(event);
+            if is_wait {
+                sender.send((reader, events)).expect("return JSONL reader");
+                break;
+            }
+        }
+    });
+    let (mut reader, mut events) = match receiver.recv_timeout(Duration::from_secs(20)) {
+        Ok(result) => result,
+        Err(error) => {
+            let _ = land.kill();
+            panic!("land did not flush a wait heartbeat: {error}");
+        }
+    };
+
+    // The command cannot finish until this file exists, so observing the wait
+    // event first proves StreamingJson flushed the heartbeat immediately.
+    fixture.release_ci();
+    let mut remaining_stdout = String::new();
+    reader
+        .read_to_string(&mut remaining_stdout)
+        .expect("read remaining JSONL events");
+
+    let output = land.wait_with_output().expect("wait for land");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    assert!(
+        output.status.success(),
+        "land --jsonl failed: stdout={remaining_stdout} stderr={stderr}"
+    );
+    assert!(stderr.trim().is_empty(), "unexpected stderr: {stderr}");
+
+    events.extend(
+        remaining_stdout
+            .lines()
+            .map(|line| serde_json::from_str(line).expect("every JSONL line must parse")),
+    );
+    assert_eq!(events.first().unwrap()["event"], "start");
+    assert_eq!(events.first().unwrap()["total_entries"], 1);
+
+    let wait = events
+        .iter()
+        .find(|event| event["event"] == "wait")
+        .expect("pending CI should emit a wait heartbeat");
+    assert_eq!(wait["phase"], "readiness");
+    assert_eq!(wait["position"], 1);
+    assert_eq!(wait["pr_number"], 41);
+    assert_eq!(wait["poll"], 1);
+    assert_eq!(wait["ci_status"], "pending");
+    assert_eq!(wait["approved"], true);
+    assert!(wait["elapsed_seconds"].is_number());
+
+    let entry = events
+        .iter()
+        .find(|event| event["event"] == "entry")
+        .expect("merge should emit an entry event");
+    assert_eq!(entry["action"], "merged");
+    assert_eq!(entry["pr_number"], 41);
+
+    let summary = events.last().unwrap();
+    assert_eq!(summary["event"], "summary");
+    assert_eq!(summary["landed"][0]["action"], "merged");
+    assert_eq!(summary["remaining"], 0);
 }
 
 #[cfg(unix)]
@@ -313,6 +400,24 @@ fn test_gg_land_json_help() {
 }
 
 #[test]
+fn test_gg_land_jsonl_help() {
+    let (_temp_dir, repo_path) = create_test_repo();
+    let (success, stdout, _stderr) = run_gg(&repo_path, &["land", "--help"]);
+
+    assert!(success);
+    assert!(stdout.contains("--jsonl"), "help should mention --jsonl");
+}
+
+#[test]
+fn test_gg_land_rejects_json_and_jsonl_together() {
+    let (_temp_dir, repo_path) = create_test_repo();
+    let (success, _stdout, stderr) = run_gg(&repo_path, &["land", "--json", "--jsonl"]);
+
+    assert!(!success, "--json and --jsonl should conflict");
+    assert!(stderr.contains("cannot be used with"));
+}
+
+#[test]
 fn test_gg_land_json_error_without_provider() {
     let (_temp_dir, repo_path) = create_test_repo();
 
@@ -337,6 +442,38 @@ fn test_gg_land_json_error_without_provider() {
     let parsed: Value = serde_json::from_str(&stdout).expect("stdout must be valid JSON");
     assert_eq!(parsed["version"], 1);
     assert!(parsed["error"].is_string(), "error field must be string");
+}
+
+#[test]
+fn test_gg_land_jsonl_error_without_provider() {
+    let (_temp_dir, repo_path) = create_test_repo();
+
+    let gg_dir = repo_path.join(".git/gg");
+    fs::create_dir_all(&gg_dir).expect("Failed to create gg dir");
+    fs::write(
+        gg_dir.join("config.json"),
+        r#"{"defaults":{"branch_username":"testuser"}}"#,
+    )
+    .expect("Failed to write config");
+
+    let (success, _stdout, stderr) = run_gg(&repo_path, &["co", "jsonl-land-error"]);
+    assert!(success, "Failed to create stack: {stderr}");
+
+    let (success, stdout, stderr) = run_gg(&repo_path, &["land", "--jsonl"]);
+    assert!(!success, "land --jsonl should fail without provider");
+    assert!(
+        stderr.trim().is_empty(),
+        "stderr should be empty in JSONL mode: {stderr}"
+    );
+
+    let lines: Vec<_> = stdout.lines().collect();
+    assert_eq!(lines.len(), 1, "fatal error should emit one event");
+    let event: Value = serde_json::from_str(lines[0]).expect("error line must be valid JSON");
+    assert_eq!(event["version"], 1);
+    assert_eq!(event["command"], "land");
+    assert_eq!(event["status"], "error");
+    assert_eq!(event["event"], "error");
+    assert!(event["message"].is_string());
 }
 
 #[test]

--- a/crates/gg-cli/tests/integration_tests/land.rs
+++ b/crates/gg-cli/tests/integration_tests/land.rs
@@ -644,6 +644,35 @@ fn test_land_jsonl_reports_downstream_push_failure_warning() {
 
 #[cfg(unix)]
 #[test]
+fn test_land_jsonl_reports_provider_scan_failure() {
+    let fixture = WaitingLandFixture::new();
+    fixture.add_second_entry();
+    fixture.fail_cleanup_provider_after_first_view();
+    fs::write(&fixture.merged, "already merged\n").expect("mark first PR merged");
+
+    let output = fixture
+        .start_land_with_args(&["land", "--all", "--jsonl", "--no-clean"])
+        .wait_with_output()
+        .expect("wait for land");
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    assert!(output.status.success(), "land failed: {stderr}");
+    assert!(stderr.trim().is_empty(), "unexpected stderr: {stderr}");
+
+    let summary: Value = serde_json::from_str(stdout.lines().last().expect("summary event"))
+        .expect("parse summary event");
+    assert_eq!(summary["event"], "summary");
+    assert_eq!(summary["status"], "error");
+    assert!(
+        summary["error"]
+            .as_str()
+            .is_some_and(|error| error.contains("Failed to fetch PR #")),
+        "summary should include provider scan failure: {summary}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
 fn test_land_gitlab_jsonl_admin_emits_no_human_warning() {
     let fixture = WaitingLandFixture::new();
     fixture.use_gitlab_provider();

--- a/crates/gg-cli/tests/integration_tests/land.rs
+++ b/crates/gg-cli/tests/integration_tests/land.rs
@@ -532,6 +532,37 @@ fn test_land_jsonl_default_scope_reports_one_total_entry() {
 
 #[cfg(unix)]
 #[test]
+fn test_land_jsonl_default_scope_counts_terminal_prefix_entries() {
+    let fixture = WaitingLandFixture::new();
+    fixture.add_second_entry();
+    fs::write(&fixture.merged, "already merged\n").expect("mark fake PR merged");
+
+    let output = fixture
+        .start_land_with_args(&["land", "--jsonl", "--admin", "--no-clean"])
+        .wait_with_output()
+        .expect("wait for land");
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    assert!(output.status.success(), "land failed: {stderr}");
+    assert!(stderr.trim().is_empty(), "unexpected stderr: {stderr}");
+
+    let events = stdout
+        .lines()
+        .map(|line| serde_json::from_str::<Value>(line).expect("parse JSONL event"))
+        .collect::<Vec<_>>();
+    assert_eq!(events.first().unwrap()["event"], "start");
+    assert_eq!(events.first().unwrap()["total_entries"], 2);
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| event["event"] == "entry")
+            .count(),
+        2
+    );
+}
+
+#[cfg(unix)]
+#[test]
 fn test_land_jsonl_reports_retarget_failure_warning() {
     let fixture = WaitingLandFixture::new();
     fixture.add_second_entry();

--- a/crates/gg-cli/tests/integration_tests/land.rs
+++ b/crates/gg-cli/tests/integration_tests/land.rs
@@ -71,6 +71,49 @@ exit 1
 }
 
 #[cfg(unix)]
+fn write_fake_land_glab(path: &Path) {
+    fs::write(
+        path,
+        r#"#!/bin/sh
+set -eu
+
+if [ "$1" = "--version" ]; then
+  echo "glab version 1.0.0"
+  exit 0
+fi
+
+if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
+  exit 0
+fi
+
+if [ "$1" = "api" ] && [ "$2" = "projects/:id" ]; then
+  echo '{"merge_trains_enabled":false}'
+  exit 0
+fi
+
+if [ "$1" = "mr" ] && [ "$2" = "view" ]; then
+  if [ -f "$GG_FAKE_MERGED" ]; then state=merged; else state=opened; fi
+  printf '{"iid":41,"title":"Land entry","state":"%s","web_url":"https://gitlab.example/test/repo/-/merge_requests/41","source_branch":"testuser/land-wait/c-1111111","draft":false,"work_in_progress":false,"detailed_merge_status":"mergeable","head_pipeline":{"status":"success"}}\n' "$state"
+  exit 0
+fi
+
+if [ "$1" = "mr" ] && [ "$2" = "merge" ]; then
+  touch "$GG_FAKE_MERGED"
+  touch "$GG_FAKE_MERGED.glab"
+  exit 0
+fi
+
+echo "unexpected glab invocation: $*" >&2
+exit 1
+"#,
+    )
+    .expect("write fake glab");
+    let mut permissions = fs::metadata(path).expect("stat fake glab").permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).expect("make fake glab executable");
+}
+
+#[cfg(unix)]
 struct WaitingLandFixture {
     _temp_dir: tempfile::TempDir,
     repo_path: std::path::PathBuf,
@@ -183,6 +226,20 @@ impl WaitingLandFixture {
     fn release_ci(&self) {
         fs::write(&self.ready, "ready\n").expect("release fake CI");
     }
+
+    fn use_gitlab_provider(&self) {
+        let config_path = self.repo_path.join(".git/gg/config.json");
+        let mut config: Value =
+            serde_json::from_slice(&fs::read(&config_path).expect("read config"))
+                .expect("parse config");
+        config["defaults"]["provider"] = Value::String("gitlab".to_string());
+        fs::write(
+            &config_path,
+            serde_json::to_vec_pretty(&config).expect("serialize config"),
+        )
+        .expect("write config");
+        write_fake_land_glab(&self.repo_path.join("fake-bin-land-wait").join("glab"));
+    }
 }
 
 #[cfg(unix)]
@@ -280,6 +337,32 @@ fn test_land_jsonl_admin_emits_no_human_warning() {
     let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
     let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
     assert!(output.status.success(), "land failed: {stderr}");
+    assert!(stderr.trim().is_empty(), "unexpected stderr: {stderr}");
+    assert!(
+        stdout
+            .lines()
+            .all(|line| serde_json::from_str::<Value>(line).is_ok()),
+        "every JSONL line must parse: {stdout}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_land_gitlab_jsonl_admin_emits_no_human_warning() {
+    let fixture = WaitingLandFixture::new();
+    fixture.use_gitlab_provider();
+
+    let output = fixture
+        .start_land_with_args(&["land", "--all", "--jsonl", "--admin", "--no-clean"])
+        .wait_with_output()
+        .expect("wait for land");
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    assert!(output.status.success(), "land failed: {stderr}");
+    assert!(
+        fixture.merged.with_extension("glab").exists(),
+        "fake GitLab MR should be merged"
+    );
     assert!(stderr.trim().is_empty(), "unexpected stderr: {stderr}");
     assert!(
         stdout

--- a/crates/gg-cli/tests/integration_tests/land.rs
+++ b/crates/gg-cli/tests/integration_tests/land.rs
@@ -28,6 +28,14 @@ if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
 fi
 
 if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  calls=0
+  if [ -f "$GG_FAKE_PR_VIEW_CALLS" ]; then calls=$(cat "$GG_FAKE_PR_VIEW_CALLS"); fi
+  calls=$((calls + 1))
+  echo "$calls" > "$GG_FAKE_PR_VIEW_CALLS"
+  if [ -f "$GG_FAKE_CLEAN_PROVIDER_FAIL" ] && [ "$calls" -gt 1 ]; then
+    echo "provider unavailable" >&2
+    exit 1
+  fi
   case "$*" in
     *statusCheckRollup*)
       touch "$GG_FAKE_POLLED"
@@ -179,6 +187,8 @@ struct WaitingLandFixture {
     auth_network_fail: std::path::PathBuf,
     queued: std::path::PathBuf,
     retarget_fail: std::path::PathBuf,
+    clean_provider_fail: std::path::PathBuf,
+    pr_view_calls: std::path::PathBuf,
     test_home: std::path::PathBuf,
 }
 
@@ -236,6 +246,8 @@ impl WaitingLandFixture {
         let auth_network_fail = repo_path.join("fake-auth-network-fail");
         let queued = repo_path.join("fake-queued");
         let retarget_fail = repo_path.join("fake-retarget-fail");
+        let clean_provider_fail = repo_path.join("fake-clean-provider-fail");
+        let pr_view_calls = repo_path.join("fake-pr-view-calls");
         let test_home = repo_path.join(".test-home");
         fs::create_dir_all(&test_home).expect("create test home");
 
@@ -253,6 +265,8 @@ impl WaitingLandFixture {
             auth_network_fail,
             queued,
             retarget_fail,
+            clean_provider_fail,
+            pr_view_calls,
             test_home,
         }
     }
@@ -276,6 +290,8 @@ impl WaitingLandFixture {
             .env("GG_FAKE_AUTH_NETWORK_FAIL", &self.auth_network_fail)
             .env("GG_FAKE_QUEUED", &self.queued)
             .env("GG_FAKE_RETARGET_FAIL", &self.retarget_fail)
+            .env("GG_FAKE_CLEAN_PROVIDER_FAIL", &self.clean_provider_fail)
+            .env("GG_FAKE_PR_VIEW_CALLS", &self.pr_view_calls)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()
@@ -338,6 +354,29 @@ impl WaitingLandFixture {
 
     fn fail_retargeting(&self) {
         fs::write(&self.retarget_fail, "fail\n").expect("enable fake retarget failure");
+    }
+
+    fn fail_cleanup_provider_after_first_view(&self) {
+        fs::write(&self.clean_provider_fail, "fail\n")
+            .expect("enable fake cleanup provider failure");
+    }
+
+    fn fail_downstream_push(&self) {
+        fs::write(
+            self.repo_path.join("fake-bin-land-wait").join("git"),
+            r#"#!/bin/sh
+if [ "$1" = "push" ] && [ "$2" = "--force-with-lease" ]; then
+  echo "force-with-lease rejected" >&2
+  exit 1
+fi
+exec /usr/bin/git "$@"
+"#,
+        )
+        .expect("write fake git");
+        let path = self.repo_path.join("fake-bin-land-wait").join("git");
+        let mut permissions = fs::metadata(&path).expect("stat fake git").permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(path, permissions).expect("make fake git executable");
     }
 }
 
@@ -525,6 +564,42 @@ fn test_land_jsonl_reports_retarget_failure_warning() {
 
 #[cfg(unix)]
 #[test]
+fn test_land_jsonl_reports_downstream_push_failure_warning() {
+    let fixture = WaitingLandFixture::new();
+    fixture.add_second_entry();
+    fixture.release_ci();
+    fixture.fail_downstream_push();
+    run_git(
+        &fixture.repo_path,
+        &["branch", "testuser/land-wait--c-2222222"],
+    );
+
+    let output = fixture
+        .start_land_with_args(&["land", "--all", "--jsonl", "--admin", "--no-clean"])
+        .wait_with_output()
+        .expect("wait for land");
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    assert!(output.status.success(), "land failed: {stderr}");
+    assert!(stderr.trim().is_empty(), "unexpected stderr: {stderr}");
+
+    let summary: Value = serde_json::from_str(stdout.lines().last().expect("summary event"))
+        .expect("parse summary event");
+    assert_eq!(summary["event"], "summary");
+    assert!(
+        summary["warnings"]
+            .as_array()
+            .expect("warnings must be an array")
+            .iter()
+            .any(|warning| warning.as_str().is_some_and(
+                |warning| warning.contains("Failed to push testuser/land-wait--c-2222222")
+            )),
+        "summary should include downstream push failure warning: {summary}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
 fn test_land_gitlab_jsonl_admin_emits_no_human_warning() {
     let fixture = WaitingLandFixture::new();
     fixture.use_gitlab_provider();
@@ -540,6 +615,29 @@ fn test_land_gitlab_jsonl_admin_emits_no_human_warning() {
         fixture.merged.with_extension("glab").exists(),
         "fake GitLab MR should be merged"
     );
+    assert!(stderr.trim().is_empty(), "unexpected stderr: {stderr}");
+    assert!(
+        stdout
+            .lines()
+            .all(|line| serde_json::from_str::<Value>(line).is_ok()),
+        "every JSONL line must parse: {stdout}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_land_jsonl_clean_silences_provider_lookup_debug() {
+    let fixture = WaitingLandFixture::new();
+    fs::write(&fixture.merged, "already merged\n").expect("mark fake PR merged");
+    fixture.fail_cleanup_provider_after_first_view();
+
+    let output = fixture
+        .start_land_with_args(&["land", "--all", "--jsonl", "--clean"])
+        .wait_with_output()
+        .expect("wait for land");
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    assert!(output.status.success(), "land failed: {stderr}");
     assert!(stderr.trim().is_empty(), "unexpected stderr: {stderr}");
     assert!(
         stdout

--- a/crates/gg-cli/tests/integration_tests/land.rs
+++ b/crates/gg-cli/tests/integration_tests/land.rs
@@ -227,6 +227,26 @@ impl WaitingLandFixture {
         fs::write(&self.ready, "ready\n").expect("release fake CI");
     }
 
+    fn add_second_entry(&self) {
+        fs::write(self.repo_path.join("second.txt"), "second\n").expect("write second entry");
+        run_git(&self.repo_path, &["add", "second.txt"]);
+        run_git(
+            &self.repo_path,
+            &["commit", "-m", "Second entry\n\nGG-ID: c-2222222"],
+        );
+
+        let config_path = self.repo_path.join(".git/gg/config.json");
+        let mut config: Value =
+            serde_json::from_slice(&fs::read(&config_path).expect("read config"))
+                .expect("parse config");
+        config["stacks"]["land-wait"]["mrs"]["c-2222222"] = Value::from(42);
+        fs::write(
+            &config_path,
+            serde_json::to_vec_pretty(&config).expect("serialize config"),
+        )
+        .expect("write config");
+    }
+
     fn use_gitlab_provider(&self) {
         let config_path = self.repo_path.join(".git/gg/config.json");
         let mut config: Value =
@@ -344,6 +364,27 @@ fn test_land_jsonl_admin_emits_no_human_warning() {
             .all(|line| serde_json::from_str::<Value>(line).is_ok()),
         "every JSONL line must parse: {stdout}"
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_land_jsonl_default_scope_reports_one_total_entry() {
+    let fixture = WaitingLandFixture::new();
+    fixture.add_second_entry();
+    fixture.release_ci();
+
+    let output = fixture
+        .start_land_with_args(&["land", "--jsonl", "--admin", "--no-clean"])
+        .wait_with_output()
+        .expect("wait for land");
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    assert!(output.status.success(), "land failed: {stderr}");
+
+    let start: Value =
+        serde_json::from_str(stdout.lines().next().expect("start event")).expect("parse start");
+    assert_eq!(start["event"], "start");
+    assert_eq!(start["total_entries"], 1);
 }
 
 #[cfg(unix)]

--- a/crates/gg-cli/tests/integration_tests/land.rs
+++ b/crates/gg-cli/tests/integration_tests/land.rs
@@ -365,6 +365,15 @@ impl WaitingLandFixture {
         .expect("write config");
     }
 
+    fn add_unsynced_entry(&self) {
+        fs::write(self.repo_path.join("unsynced.txt"), "unsynced\n").expect("write unsynced entry");
+        run_git(&self.repo_path, &["add", "unsynced.txt"]);
+        run_git(
+            &self.repo_path,
+            &["commit", "-m", "Unsynced entry\n\nGG-ID: c-2222222"],
+        );
+    }
+
     fn use_gitlab_provider(&self) {
         let config_path = self.repo_path.join(".git/gg/config.json");
         let mut config: Value =
@@ -585,6 +594,36 @@ fn test_land_jsonl_default_scope_reports_one_total_entry() {
         .expect("parse summary event");
     assert_eq!(summary["event"], "summary");
     assert_eq!(summary["remaining"], 1);
+}
+
+#[cfg(unix)]
+#[test]
+fn test_land_jsonl_summary_reports_unsynced_remaining_entry() {
+    let fixture = WaitingLandFixture::new();
+    fixture.add_unsynced_entry();
+    fixture.release_ci();
+
+    let output = fixture
+        .start_land_with_args(&["land", "--jsonl", "--admin", "--no-clean"])
+        .wait_with_output()
+        .expect("wait for land");
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    assert!(output.status.success(), "land failed: {stderr}");
+    assert!(stderr.trim().is_empty(), "unexpected stderr: {stderr}");
+
+    let summary: Value = serde_json::from_str(stdout.lines().last().expect("summary event"))
+        .expect("parse summary event");
+    assert_eq!(summary["event"], "summary");
+    assert_eq!(summary["status"], "warning");
+    assert_eq!(summary["remaining"], 1);
+    assert!(summary["warnings"]
+        .as_array()
+        .expect("warnings must be an array")
+        .iter()
+        .any(|warning| warning
+            .as_str()
+            .is_some_and(|warning| warning.contains("gg sync"))));
 }
 
 #[cfg(unix)]

--- a/crates/gg-cli/tests/integration_tests/land.rs
+++ b/crates/gg-cli/tests/integration_tests/land.rs
@@ -54,7 +54,7 @@ if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
       exit 0
       ;;
     *"--jq .reviewDecision"*)
-      echo APPROVED
+      if [ -f "$GG_FAKE_UNAPPROVED" ]; then echo REVIEW_REQUIRED; else echo APPROVED; fi
       exit 0
       ;;
   esac
@@ -65,7 +65,7 @@ if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
     exit 0
   fi
 
-  if [ -f "$GG_FAKE_MERGED" ] || { [ -f "$GG_FAKE_FIRST_TERMINAL_AFTER_REFRESH" ] && [ "$calls" -gt 2 ]; }; then state=MERGED; else state=OPEN; fi
+  if [ -f "$GG_FAKE_CLOSED" ]; then state=CLOSED; elif [ -f "$GG_FAKE_MERGED" ] || { [ -f "$GG_FAKE_FIRST_TERMINAL_AFTER_REFRESH" ] && [ "$calls" -gt 2 ]; }; then state=MERGED; else state=OPEN; fi
   printf '{"number":41,"title":"Land entry","state":"%s","url":"https://github.com/test/repo/pull/41","headRefName":"testuser/land-wait--c-1111111","isDraft":false,"mergeable":"MERGEABLE","reviews":[],"reviewDecision":"APPROVED"}\n' "$state"
   exit 0
 fi
@@ -188,6 +188,8 @@ struct WaitingLandFixture {
     polled: std::path::PathBuf,
     ready: std::path::PathBuf,
     merged: std::path::PathBuf,
+    closed: std::path::PathBuf,
+    unapproved: std::path::PathBuf,
     ci_calls: std::path::PathBuf,
     regress: std::path::PathBuf,
     merge_trains: std::path::PathBuf,
@@ -248,6 +250,8 @@ impl WaitingLandFixture {
         let polled = repo_path.join("fake-polled");
         let ready = repo_path.join("fake-ready");
         let merged = repo_path.join("fake-merged");
+        let closed = repo_path.join("fake-closed");
+        let unapproved = repo_path.join("fake-unapproved");
         let ci_calls = repo_path.join("fake-ci-calls");
         let regress = repo_path.join("fake-regress");
         let merge_trains = repo_path.join("fake-merge-trains");
@@ -268,6 +272,8 @@ impl WaitingLandFixture {
             polled,
             ready,
             merged,
+            closed,
+            unapproved,
             ci_calls,
             regress,
             merge_trains,
@@ -294,6 +300,8 @@ impl WaitingLandFixture {
             .env("GG_FAKE_POLLED", &self.polled)
             .env("GG_FAKE_READY", &self.ready)
             .env("GG_FAKE_MERGED", &self.merged)
+            .env("GG_FAKE_CLOSED", &self.closed)
+            .env("GG_FAKE_UNAPPROVED", &self.unapproved)
             .env("GG_FAKE_CI_CALLS", &self.ci_calls)
             .env("GG_FAKE_REGRESS", &self.regress)
             .env("GG_FAKE_MERGE_TRAINS", &self.merge_trains)
@@ -386,6 +394,14 @@ impl WaitingLandFixture {
     fn make_first_entry_terminal_after_refresh(&self) {
         fs::write(&self.first_terminal_after_refresh, "enabled\n")
             .expect("enable fake terminal race");
+    }
+
+    fn mark_closed(&self) {
+        fs::write(&self.closed, "closed\n").expect("mark fake PR closed");
+    }
+
+    fn mark_unapproved(&self) {
+        fs::write(&self.unapproved, "unapproved\n").expect("mark fake PR unapproved");
     }
 
     fn fail_downstream_push(&self) {
@@ -625,6 +641,74 @@ fn test_land_jsonl_default_scope_uses_refreshed_state_for_selection() {
     );
     assert_eq!(entries[0]["action"], "merged");
     assert_eq!(entries[0]["pr_number"], 41);
+}
+
+#[cfg(unix)]
+#[test]
+fn test_land_jsonl_unapproved_entry_emits_error_outcome() {
+    let fixture = WaitingLandFixture::new();
+    fixture.mark_unapproved();
+
+    let output = fixture
+        .start_land_with_args(&["land", "--jsonl", "--no-clean"])
+        .wait_with_output()
+        .expect("wait for land");
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    assert!(output.status.success(), "land failed: {stderr}");
+    assert!(stderr.trim().is_empty(), "unexpected stderr: {stderr}");
+
+    let events = stdout
+        .lines()
+        .map(|line| serde_json::from_str::<Value>(line).expect("parse JSONL event"))
+        .collect::<Vec<_>>();
+    let entry = events
+        .iter()
+        .find(|event| event["event"] == "entry")
+        .expect("unapproved PR should emit an entry outcome");
+    assert_eq!(entry["status"], "error");
+    assert_eq!(entry["action"], "error");
+    assert!(entry["error"]
+        .as_str()
+        .is_some_and(|error| error.contains("is not approved")));
+    assert_eq!(events.last().unwrap()["status"], "error");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_land_jsonl_closed_entry_marks_warning_status() {
+    let fixture = WaitingLandFixture::new();
+    fixture.mark_closed();
+
+    let output = fixture
+        .start_land_with_args(&["land", "--jsonl", "--admin", "--no-clean"])
+        .wait_with_output()
+        .expect("wait for land");
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    assert!(output.status.success(), "land failed: {stderr}");
+    assert!(stderr.trim().is_empty(), "unexpected stderr: {stderr}");
+
+    let events = stdout
+        .lines()
+        .map(|line| serde_json::from_str::<Value>(line).expect("parse JSONL event"))
+        .collect::<Vec<_>>();
+    let entry = events
+        .iter()
+        .find(|event| event["event"] == "entry")
+        .expect("closed PR should emit an entry outcome");
+    assert_eq!(entry["status"], "warning");
+    assert_eq!(entry["action"], "skipped_closed");
+
+    let summary = events.last().unwrap();
+    assert_eq!(summary["status"], "warning");
+    assert!(summary["warnings"]
+        .as_array()
+        .expect("warnings must be an array")
+        .iter()
+        .any(|warning| warning
+            .as_str()
+            .is_some_and(|warning| warning.contains("is closed"))));
 }
 
 #[cfg(unix)]

--- a/crates/gg-cli/tests/integration_tests/land.rs
+++ b/crates/gg-cli/tests/integration_tests/land.rs
@@ -83,12 +83,55 @@ if [ "$1" = "--version" ]; then
 fi
 
 if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
+  if [ -f "$GG_FAKE_AUTH_NETWORK_FAIL" ]; then
+    echo "Could not resolve host: gitlab.com" >&2
+    exit 1
+  fi
   exit 0
 fi
 
 if [ "$1" = "api" ] && [ "$2" = "projects/:id" ]; then
-  echo '{"merge_trains_enabled":false}'
+  if [ -f "$GG_FAKE_MERGE_TRAINS" ]; then
+    echo '{"merge_trains_enabled":true}'
+  else
+    echo '{"merge_trains_enabled":false}'
+  fi
   exit 0
+fi
+
+if [ "$1" = "api" ] && [ "$2" = "-X" ] && [ "$3" = "POST" ]; then
+  touch "$GG_FAKE_QUEUED"
+  exit 0
+fi
+
+if [ "$1" = "api" ]; then
+  case "$2" in
+    projects/:id/merge_requests/*/approvals)
+      echo '{"approved":true}'
+      exit 0
+      ;;
+    projects/:id/merge_trains/*scope=active*)
+      if [ ! -f "$GG_FAKE_QUEUED" ]; then
+        echo '[]'
+        exit 0
+      fi
+      touch "$GG_FAKE_POLLED"
+      if [ -f "$GG_FAKE_MERGED" ]; then
+        echo '[]'
+      else
+        echo '[{"merge_request":{"iid":41},"status":"fresh","pipeline":{"status":"success"}}]'
+      fi
+      exit 0
+      ;;
+    projects/:id/merge_trains/*scope=complete*)
+      if [ -f "$GG_FAKE_MERGED" ]; then
+        echo '[{"merge_request":{"iid":41},"status":"merged","pipeline":{"status":"success"}}]'
+      else
+        echo '[]'
+      fi
+      exit 0
+      ;;
+  esac
 fi
 
 if [ "$1" = "mr" ] && [ "$2" = "view" ]; then
@@ -124,6 +167,9 @@ struct WaitingLandFixture {
     merged: std::path::PathBuf,
     ci_calls: std::path::PathBuf,
     regress: std::path::PathBuf,
+    merge_trains: std::path::PathBuf,
+    auth_network_fail: std::path::PathBuf,
+    queued: std::path::PathBuf,
     test_home: std::path::PathBuf,
 }
 
@@ -177,6 +223,9 @@ impl WaitingLandFixture {
         let merged = repo_path.join("fake-merged");
         let ci_calls = repo_path.join("fake-ci-calls");
         let regress = repo_path.join("fake-regress");
+        let merge_trains = repo_path.join("fake-merge-trains");
+        let auth_network_fail = repo_path.join("fake-auth-network-fail");
+        let queued = repo_path.join("fake-queued");
         let test_home = repo_path.join(".test-home");
         fs::create_dir_all(&test_home).expect("create test home");
 
@@ -190,6 +239,9 @@ impl WaitingLandFixture {
             merged,
             ci_calls,
             regress,
+            merge_trains,
+            auth_network_fail,
+            queued,
             test_home,
         }
     }
@@ -209,6 +261,9 @@ impl WaitingLandFixture {
             .env("GG_FAKE_MERGED", &self.merged)
             .env("GG_FAKE_CI_CALLS", &self.ci_calls)
             .env("GG_FAKE_REGRESS", &self.regress)
+            .env("GG_FAKE_MERGE_TRAINS", &self.merge_trains)
+            .env("GG_FAKE_AUTH_NETWORK_FAIL", &self.auth_network_fail)
+            .env("GG_FAKE_QUEUED", &self.queued)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()
@@ -259,6 +314,14 @@ impl WaitingLandFixture {
         )
         .expect("write config");
         write_fake_land_glab(&self.repo_path.join("fake-bin-land-wait").join("glab"));
+    }
+
+    fn enable_gitlab_merge_trains(&self) {
+        fs::write(&self.merge_trains, "enabled\n").expect("enable fake merge trains");
+    }
+
+    fn fail_auth_with_network_error(&self) {
+        fs::write(&self.auth_network_fail, "fail\n").expect("enable fake auth failure");
     }
 }
 
@@ -410,6 +473,78 @@ fn test_land_gitlab_jsonl_admin_emits_no_human_warning() {
             .lines()
             .all(|line| serde_json::from_str::<Value>(line).is_ok()),
         "every JSONL line must parse: {stdout}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_land_gitlab_jsonl_network_auth_fallback_emits_no_human_warning() {
+    let fixture = WaitingLandFixture::new();
+    fixture.use_gitlab_provider();
+    fixture.fail_auth_with_network_error();
+
+    let output = fixture
+        .start_land_with_args(&["land", "--all", "--jsonl", "--admin", "--no-clean"])
+        .wait_with_output()
+        .expect("wait for land");
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    assert!(output.status.success(), "land failed: {stderr}");
+    assert!(stderr.trim().is_empty(), "unexpected stderr: {stderr}");
+    assert!(
+        stdout
+            .lines()
+            .all(|line| serde_json::from_str::<Value>(line).is_ok()),
+        "every JSONL line must parse: {stdout}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_land_gitlab_jsonl_records_merge_train_merge_before_stale_stack_error() {
+    let fixture = WaitingLandFixture::new();
+    fixture.use_gitlab_provider();
+    fixture.enable_gitlab_merge_trains();
+
+    let land = fixture.start_land_with_args(&["land", "--all", "--wait", "--jsonl", "--no-clean"]);
+    fixture.wait_until_polling();
+
+    fs::write(fixture.repo_path.join("new.txt"), "new\n").expect("write new entry");
+    run_git(&fixture.repo_path, &["add", "new.txt"]);
+    run_git(
+        &fixture.repo_path,
+        &["commit", "-m", "New entry\n\nGG-ID: c-2222222"],
+    );
+    fs::write(&fixture.merged, "merged\n").expect("complete fake merge train");
+
+    let output = land.wait_with_output().expect("wait for land");
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    assert!(
+        output.status.success(),
+        "structured land reports the error in JSONL: stderr={stderr}"
+    );
+    assert!(stderr.trim().is_empty(), "unexpected stderr: {stderr}");
+
+    let events: Vec<Value> = stdout
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("every JSONL line must parse"))
+        .collect();
+    assert!(
+        events.iter().any(|event| event["event"] == "entry"
+            && event["pr_number"] == 41
+            && event["action"] == "merged"),
+        "merged entry should be emitted before stale-stack error: {stdout}"
+    );
+    let summary = events.last().expect("summary event");
+    assert_eq!(summary["event"], "summary");
+    assert_eq!(summary["landed"][0]["action"], "merged");
+    assert_eq!(summary["remaining"], 0);
+    assert!(
+        summary["error"]
+            .as_str()
+            .is_some_and(|error| error.contains("Stack changed while gg land was waiting")),
+        "summary should still report the stale-stack error: {summary}"
     );
 }
 

--- a/crates/gg-cli/tests/integration_tests/land.rs
+++ b/crates/gg-cli/tests/integration_tests/land.rs
@@ -299,11 +299,19 @@ impl WaitingLandFixture {
     }
 
     fn wait_until_polling(&self) {
-        let deadline = Instant::now() + Duration::from_secs(5);
+        let deadline = Instant::now() + Duration::from_secs(30);
         while !self.polled.exists() && Instant::now() < deadline {
             std::thread::sleep(Duration::from_millis(25));
         }
         assert!(self.polled.exists(), "land never started polling CI");
+    }
+
+    fn wait_until_queued(&self) {
+        let deadline = Instant::now() + Duration::from_secs(30);
+        while !self.queued.exists() && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        assert!(self.queued.exists(), "land never queued the MR");
     }
 
     fn release_ci(&self) {
@@ -714,6 +722,7 @@ fn test_land_gitlab_jsonl_records_merge_train_merge_before_stale_stack_error() {
     fixture.enable_gitlab_merge_trains();
 
     let land = fixture.start_land_with_args(&["land", "--all", "--wait", "--jsonl", "--no-clean"]);
+    fixture.wait_until_queued();
     fixture.wait_until_polling();
 
     fs::write(fixture.repo_path.join("new.txt"), "new\n").expect("write new entry");

--- a/crates/gg-cli/tests/integration_tests/land.rs
+++ b/crates/gg-cli/tests/integration_tests/land.rs
@@ -28,6 +28,7 @@ if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
 fi
 
 if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  num="${3:-41}"
   calls=0
   if [ -f "$GG_FAKE_PR_VIEW_CALLS" ]; then calls=$(cat "$GG_FAKE_PR_VIEW_CALLS"); fi
   calls=$((calls + 1))
@@ -58,7 +59,13 @@ if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
       ;;
   esac
 
-  if [ -f "$GG_FAKE_MERGED" ]; then state=MERGED; else state=OPEN; fi
+  if [ "$num" = "42" ]; then
+    if [ -f "$GG_FAKE_MERGED" ]; then state=MERGED; else state=OPEN; fi
+    printf '{"number":42,"title":"Second entry","state":"%s","url":"https://github.com/test/repo/pull/42","headRefName":"testuser/land-wait--c-2222222","isDraft":false,"mergeable":"MERGEABLE","reviews":[],"reviewDecision":"APPROVED"}\n' "$state"
+    exit 0
+  fi
+
+  if [ -f "$GG_FAKE_MERGED" ] || { [ -f "$GG_FAKE_FIRST_TERMINAL_AFTER_REFRESH" ] && [ "$calls" -gt 2 ]; }; then state=MERGED; else state=OPEN; fi
   printf '{"number":41,"title":"Land entry","state":"%s","url":"https://github.com/test/repo/pull/41","headRefName":"testuser/land-wait--c-1111111","isDraft":false,"mergeable":"MERGEABLE","reviews":[],"reviewDecision":"APPROVED"}\n' "$state"
   exit 0
 fi
@@ -189,6 +196,7 @@ struct WaitingLandFixture {
     retarget_fail: std::path::PathBuf,
     clean_provider_fail: std::path::PathBuf,
     pr_view_calls: std::path::PathBuf,
+    first_terminal_after_refresh: std::path::PathBuf,
     test_home: std::path::PathBuf,
 }
 
@@ -248,6 +256,7 @@ impl WaitingLandFixture {
         let retarget_fail = repo_path.join("fake-retarget-fail");
         let clean_provider_fail = repo_path.join("fake-clean-provider-fail");
         let pr_view_calls = repo_path.join("fake-pr-view-calls");
+        let first_terminal_after_refresh = repo_path.join("fake-first-terminal-after-refresh");
         let test_home = repo_path.join(".test-home");
         fs::create_dir_all(&test_home).expect("create test home");
 
@@ -267,6 +276,7 @@ impl WaitingLandFixture {
             retarget_fail,
             clean_provider_fail,
             pr_view_calls,
+            first_terminal_after_refresh,
             test_home,
         }
     }
@@ -292,6 +302,10 @@ impl WaitingLandFixture {
             .env("GG_FAKE_RETARGET_FAIL", &self.retarget_fail)
             .env("GG_FAKE_CLEAN_PROVIDER_FAIL", &self.clean_provider_fail)
             .env("GG_FAKE_PR_VIEW_CALLS", &self.pr_view_calls)
+            .env(
+                "GG_FAKE_FIRST_TERMINAL_AFTER_REFRESH",
+                &self.first_terminal_after_refresh,
+            )
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()
@@ -367,6 +381,11 @@ impl WaitingLandFixture {
     fn fail_cleanup_provider_after_first_view(&self) {
         fs::write(&self.clean_provider_fail, "fail\n")
             .expect("enable fake cleanup provider failure");
+    }
+
+    fn make_first_entry_terminal_after_refresh(&self) {
+        fs::write(&self.first_terminal_after_refresh, "enabled\n")
+            .expect("enable fake terminal race");
     }
 
     fn fail_downstream_push(&self) {
@@ -572,6 +591,46 @@ fn test_land_jsonl_default_scope_counts_terminal_prefix_entries() {
             .count(),
         2
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_land_jsonl_advances_when_selected_entry_becomes_terminal() {
+    let fixture = WaitingLandFixture::new();
+    fixture.add_second_entry();
+    fixture.make_first_entry_terminal_after_refresh();
+
+    let mut land =
+        fixture.start_land_with_args(&["land", "--all", "--jsonl", "--admin", "--no-clean"]);
+    let deadline = Instant::now() + Duration::from_secs(20);
+    while land.try_wait().expect("poll land").is_none() && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    if land.try_wait().expect("poll land").is_none() {
+        let _ = land.kill();
+        panic!("land did not advance past the terminal first entry");
+    }
+
+    let output = land.wait_with_output().expect("wait for land");
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    assert!(output.status.success(), "land failed: {stderr}");
+    assert!(stderr.trim().is_empty(), "unexpected stderr: {stderr}");
+
+    let events = stdout
+        .lines()
+        .map(|line| serde_json::from_str::<Value>(line).expect("parse JSONL event"))
+        .collect::<Vec<_>>();
+    let entries = events
+        .iter()
+        .filter(|event| event["event"] == "entry")
+        .collect::<Vec<_>>();
+    assert_eq!(entries.len(), 2, "expected both entries to emit: {stdout}");
+    assert_eq!(entries[0]["action"], "already_merged");
+    assert_eq!(entries[0]["pr_number"], 41);
+    assert_eq!(entries[1]["action"], "merged");
+    assert_eq!(entries[1]["pr_number"], 42);
+    assert_eq!(events.last().unwrap()["remaining"], 0);
 }
 
 #[cfg(unix)]

--- a/crates/gg-cli/tests/integration_tests/land.rs
+++ b/crates/gg-cli/tests/integration_tests/land.rs
@@ -66,7 +66,8 @@ if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
   fi
 
   if [ -f "$GG_FAKE_CLOSED" ]; then state=CLOSED; elif [ -f "$GG_FAKE_MERGED" ] || { [ -f "$GG_FAKE_FIRST_TERMINAL_AFTER_REFRESH" ] && [ "$calls" -gt 2 ]; }; then state=MERGED; else state=OPEN; fi
-  printf '{"number":41,"title":"Land entry","state":"%s","url":"https://github.com/test/repo/pull/41","headRefName":"testuser/land-wait--c-1111111","isDraft":false,"mergeable":"MERGEABLE","reviews":[],"reviewDecision":"APPROVED"}\n' "$state"
+  if [ -f "$GG_FAKE_DRAFT" ]; then draft=true; else draft=false; fi
+  printf '{"number":41,"title":"Land entry","state":"%s","url":"https://github.com/test/repo/pull/41","headRefName":"testuser/land-wait--c-1111111","isDraft":%s,"mergeable":"MERGEABLE","reviews":[],"reviewDecision":"APPROVED"}\n' "$state" "$draft"
   exit 0
 fi
 
@@ -189,6 +190,7 @@ struct WaitingLandFixture {
     ready: std::path::PathBuf,
     merged: std::path::PathBuf,
     closed: std::path::PathBuf,
+    draft: std::path::PathBuf,
     unapproved: std::path::PathBuf,
     ci_calls: std::path::PathBuf,
     regress: std::path::PathBuf,
@@ -251,6 +253,7 @@ impl WaitingLandFixture {
         let ready = repo_path.join("fake-ready");
         let merged = repo_path.join("fake-merged");
         let closed = repo_path.join("fake-closed");
+        let draft = repo_path.join("fake-draft");
         let unapproved = repo_path.join("fake-unapproved");
         let ci_calls = repo_path.join("fake-ci-calls");
         let regress = repo_path.join("fake-regress");
@@ -273,6 +276,7 @@ impl WaitingLandFixture {
             ready,
             merged,
             closed,
+            draft,
             unapproved,
             ci_calls,
             regress,
@@ -301,6 +305,7 @@ impl WaitingLandFixture {
             .env("GG_FAKE_READY", &self.ready)
             .env("GG_FAKE_MERGED", &self.merged)
             .env("GG_FAKE_CLOSED", &self.closed)
+            .env("GG_FAKE_DRAFT", &self.draft)
             .env("GG_FAKE_UNAPPROVED", &self.unapproved)
             .env("GG_FAKE_CI_CALLS", &self.ci_calls)
             .env("GG_FAKE_REGRESS", &self.regress)
@@ -398,6 +403,10 @@ impl WaitingLandFixture {
 
     fn mark_closed(&self) {
         fs::write(&self.closed, "closed\n").expect("mark fake PR closed");
+    }
+
+    fn mark_draft(&self) {
+        fs::write(&self.draft, "draft\n").expect("mark fake PR draft");
     }
 
     fn mark_unapproved(&self) {
@@ -676,6 +685,36 @@ fn test_land_jsonl_unapproved_entry_emits_error_outcome() {
 
 #[cfg(unix)]
 #[test]
+fn test_land_jsonl_draft_entry_emits_error_status() {
+    let fixture = WaitingLandFixture::new();
+    fixture.mark_draft();
+
+    let output = fixture
+        .start_land_with_args(&["land", "--jsonl", "--admin", "--no-clean"])
+        .wait_with_output()
+        .expect("wait for land");
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    assert!(output.status.success(), "land failed: {stderr}");
+    assert!(stderr.trim().is_empty(), "unexpected stderr: {stderr}");
+
+    let events = stdout
+        .lines()
+        .map(|line| serde_json::from_str::<Value>(line).expect("parse JSONL event"))
+        .collect::<Vec<_>>();
+    let entry = events
+        .iter()
+        .find(|event| event["event"] == "entry")
+        .expect("draft PR should emit an entry outcome");
+    assert_eq!(entry["status"], "error");
+    assert_eq!(entry["action"], "skipped_draft");
+    assert!(entry["error"]
+        .as_str()
+        .is_some_and(|error| error.contains("is a draft")));
+}
+
+#[cfg(unix)]
+#[test]
 fn test_land_jsonl_closed_entry_marks_warning_status() {
     let fixture = WaitingLandFixture::new();
     fixture.mark_closed();
@@ -805,6 +844,13 @@ fn test_land_jsonl_reports_provider_scan_failure() {
             .as_str()
             .is_some_and(|error| error.contains("Failed to fetch PR #")),
         "summary should include provider scan failure: {summary}"
+    );
+    assert!(
+        stdout.lines().any(|line| {
+            let event: Value = serde_json::from_str(line).expect("parse JSONL event");
+            event["event"] == "entry" && event["status"] == "error" && event["pr_number"] == 42
+        }),
+        "provider scan failure should emit an entry outcome: {stdout}"
     );
 }
 

--- a/crates/gg-cli/tests/integration_tests/land.rs
+++ b/crates/gg-cli/tests/integration_tests/land.rs
@@ -699,6 +699,28 @@ fn test_land_gitlab_jsonl_admin_emits_no_human_warning() {
 
 #[cfg(unix)]
 #[test]
+fn test_land_gitlab_auto_merge_jsonl_reports_single_entry_total() {
+    let fixture = WaitingLandFixture::new();
+    fixture.use_gitlab_provider();
+    fixture.add_second_entry();
+
+    let output = fixture
+        .start_land_with_args(&["land", "--all", "--jsonl", "--auto-merge", "--no-clean"])
+        .wait_with_output()
+        .expect("wait for land");
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    assert!(output.status.success(), "land failed: {stderr}");
+    assert!(stderr.trim().is_empty(), "unexpected stderr: {stderr}");
+
+    let start: Value =
+        serde_json::from_str(stdout.lines().next().expect("start event")).expect("parse start");
+    assert_eq!(start["event"], "start");
+    assert_eq!(start["total_entries"], 1);
+}
+
+#[cfg(unix)]
+#[test]
 fn test_land_jsonl_clean_silences_provider_lookup_debug() {
     let fixture = WaitingLandFixture::new();
     fs::write(&fixture.merged, "already merged\n").expect("mark fake PR merged");

--- a/crates/gg-cli/tests/integration_tests/land.rs
+++ b/crates/gg-cli/tests/integration_tests/land.rs
@@ -447,6 +447,31 @@ fn test_land_jsonl_admin_emits_no_human_warning() {
 
 #[cfg(unix)]
 #[test]
+fn test_land_jsonl_index_lock_wait_emits_no_human_warning() {
+    let fixture = WaitingLandFixture::new();
+    fixture.release_ci();
+    let index_lock = fixture.repo_path.join(".git/index.lock");
+    fs::write(&index_lock, "locked\n").expect("create index lock");
+
+    let land = fixture.start_land_with_args(&["land", "--jsonl", "--admin", "--no-clean"]);
+    std::thread::sleep(Duration::from_millis(250));
+    fs::remove_file(&index_lock).expect("release index lock");
+
+    let output = land.wait_with_output().expect("wait for land");
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    assert!(output.status.success(), "land failed: {stderr}");
+    assert!(stderr.trim().is_empty(), "unexpected stderr: {stderr}");
+    assert!(
+        stdout
+            .lines()
+            .all(|line| serde_json::from_str::<Value>(line).is_ok()),
+        "every JSONL line must parse: {stdout}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
 fn test_land_jsonl_default_scope_reports_one_total_entry() {
     let fixture = WaitingLandFixture::new();
     fixture.add_second_entry();

--- a/crates/gg-cli/tests/integration_tests/land.rs
+++ b/crates/gg-cli/tests/integration_tests/land.rs
@@ -595,23 +595,15 @@ fn test_land_jsonl_default_scope_counts_terminal_prefix_entries() {
 
 #[cfg(unix)]
 #[test]
-fn test_land_jsonl_advances_when_selected_entry_becomes_terminal() {
+fn test_land_jsonl_default_scope_uses_refreshed_state_for_selection() {
     let fixture = WaitingLandFixture::new();
     fixture.add_second_entry();
     fixture.make_first_entry_terminal_after_refresh();
 
-    let mut land =
-        fixture.start_land_with_args(&["land", "--all", "--jsonl", "--admin", "--no-clean"]);
-    let deadline = Instant::now() + Duration::from_secs(20);
-    while land.try_wait().expect("poll land").is_none() && Instant::now() < deadline {
-        std::thread::sleep(Duration::from_millis(25));
-    }
-    if land.try_wait().expect("poll land").is_none() {
-        let _ = land.kill();
-        panic!("land did not advance past the terminal first entry");
-    }
-
-    let output = land.wait_with_output().expect("wait for land");
+    let output = fixture
+        .start_land_with_args(&["land", "--jsonl", "--admin", "--no-clean"])
+        .wait_with_output()
+        .expect("wait for land");
     let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
     let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
     assert!(output.status.success(), "land failed: {stderr}");
@@ -625,12 +617,14 @@ fn test_land_jsonl_advances_when_selected_entry_becomes_terminal() {
         .iter()
         .filter(|event| event["event"] == "entry")
         .collect::<Vec<_>>();
-    assert_eq!(entries.len(), 2, "expected both entries to emit: {stdout}");
-    assert_eq!(entries[0]["action"], "already_merged");
+    assert_eq!(events.first().unwrap()["total_entries"], 1);
+    assert_eq!(
+        entries.len(),
+        1,
+        "default land emitted too many entries: {stdout}"
+    );
+    assert_eq!(entries[0]["action"], "merged");
     assert_eq!(entries[0]["pr_number"], 41);
-    assert_eq!(entries[1]["action"], "merged");
-    assert_eq!(entries[1]["pr_number"], 42);
-    assert_eq!(events.last().unwrap()["remaining"], 0);
 }
 
 #[cfg(unix)]
@@ -765,6 +759,34 @@ fn test_land_gitlab_auto_merge_jsonl_reports_single_entry_total() {
 
     let output = fixture
         .start_land_with_args(&["land", "--all", "--jsonl", "--auto-merge", "--no-clean"])
+        .wait_with_output()
+        .expect("wait for land");
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    assert!(output.status.success(), "land failed: {stderr}");
+    assert!(stderr.trim().is_empty(), "unexpected stderr: {stderr}");
+
+    let start: Value =
+        serde_json::from_str(stdout.lines().next().expect("start event")).expect("parse start");
+    assert_eq!(start["event"], "start");
+    assert_eq!(start["total_entries"], 1);
+
+    let summary: Value = serde_json::from_str(stdout.lines().last().expect("summary event"))
+        .expect("parse summary event");
+    assert_eq!(summary["event"], "summary");
+    assert_eq!(summary["remaining"], 2);
+}
+
+#[cfg(unix)]
+#[test]
+fn test_land_gitlab_merge_train_jsonl_reports_single_entry_total_without_wait() {
+    let fixture = WaitingLandFixture::new();
+    fixture.use_gitlab_provider();
+    fixture.enable_gitlab_merge_trains();
+    fixture.add_second_entry();
+
+    let output = fixture
+        .start_land_with_args(&["land", "--all", "--jsonl", "--no-clean"])
         .wait_with_output()
         .expect("wait for land");
     let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");

--- a/crates/gg-cli/tests/integration_tests/land.rs
+++ b/crates/gg-cli/tests/integration_tests/land.rs
@@ -60,6 +60,14 @@ if [ "$1" = "pr" ] && [ "$2" = "merge" ]; then
   exit 0
 fi
 
+if [ "$1" = "pr" ] && [ "$2" = "edit" ]; then
+  if [ -f "$GG_FAKE_RETARGET_FAIL" ]; then
+    echo "retarget failed" >&2
+    exit 1
+  fi
+  exit 0
+fi
+
 echo "unexpected gh invocation: $*" >&2
 exit 1
 "#,
@@ -170,6 +178,7 @@ struct WaitingLandFixture {
     merge_trains: std::path::PathBuf,
     auth_network_fail: std::path::PathBuf,
     queued: std::path::PathBuf,
+    retarget_fail: std::path::PathBuf,
     test_home: std::path::PathBuf,
 }
 
@@ -226,6 +235,7 @@ impl WaitingLandFixture {
         let merge_trains = repo_path.join("fake-merge-trains");
         let auth_network_fail = repo_path.join("fake-auth-network-fail");
         let queued = repo_path.join("fake-queued");
+        let retarget_fail = repo_path.join("fake-retarget-fail");
         let test_home = repo_path.join(".test-home");
         fs::create_dir_all(&test_home).expect("create test home");
 
@@ -242,6 +252,7 @@ impl WaitingLandFixture {
             merge_trains,
             auth_network_fail,
             queued,
+            retarget_fail,
             test_home,
         }
     }
@@ -264,6 +275,7 @@ impl WaitingLandFixture {
             .env("GG_FAKE_MERGE_TRAINS", &self.merge_trains)
             .env("GG_FAKE_AUTH_NETWORK_FAIL", &self.auth_network_fail)
             .env("GG_FAKE_QUEUED", &self.queued)
+            .env("GG_FAKE_RETARGET_FAIL", &self.retarget_fail)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()
@@ -322,6 +334,10 @@ impl WaitingLandFixture {
 
     fn fail_auth_with_network_error(&self) {
         fs::write(&self.auth_network_fail, "fail\n").expect("enable fake auth failure");
+    }
+
+    fn fail_retargeting(&self) {
+        fs::write(&self.retarget_fail, "fail\n").expect("enable fake retarget failure");
     }
 }
 
@@ -448,6 +464,38 @@ fn test_land_jsonl_default_scope_reports_one_total_entry() {
         serde_json::from_str(stdout.lines().next().expect("start event")).expect("parse start");
     assert_eq!(start["event"], "start");
     assert_eq!(start["total_entries"], 1);
+}
+
+#[cfg(unix)]
+#[test]
+fn test_land_jsonl_reports_retarget_failure_warning() {
+    let fixture = WaitingLandFixture::new();
+    fixture.add_second_entry();
+    fixture.fail_retargeting();
+    fixture.release_ci();
+
+    let output = fixture
+        .start_land_with_args(&["land", "--jsonl", "--admin", "--no-clean"])
+        .wait_with_output()
+        .expect("wait for land");
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    assert!(output.status.success(), "land failed: {stderr}");
+    assert!(stderr.trim().is_empty(), "unexpected stderr: {stderr}");
+
+    let summary: Value = serde_json::from_str(stdout.lines().last().expect("summary event"))
+        .expect("parse summary event");
+    assert_eq!(summary["event"], "summary");
+    assert!(
+        summary["warnings"]
+            .as_array()
+            .expect("warnings must be an array")
+            .iter()
+            .any(|warning| warning
+                .as_str()
+                .is_some_and(|warning| warning.contains("Failed to update PR #42 base"))),
+        "summary should include retarget failure warning: {summary}"
+    );
 }
 
 #[cfg(unix)]

--- a/crates/gg-core/src/commands/clean.rs
+++ b/crates/gg-core/src/commands/clean.rs
@@ -47,7 +47,7 @@ pub fn run_for_stack(stack_name: &str, force: bool) -> Result<()> {
 
 /// Run clean for a stack with an already-open repository (no lock acquisition)
 pub fn run_for_stack_with_repo(repo: &Repository, stack_name: &str, force: bool) -> Result<()> {
-    run_for_stack_with_repo_options(repo, stack_name, force, false, false, &mut |_| {})
+    run_for_stack_with_repo_options(repo, stack_name, force, false, false, &mut |_| {}).map(|_| ())
 }
 
 /// Run clean after `gg land` has already verified that every PR/MR in the stack
@@ -64,14 +64,7 @@ pub(crate) fn run_for_stack_with_repo_after_verified_land(
     silent: bool,
     record_remote_effect: &mut dyn FnMut(RemoteEffect),
 ) -> Result<bool> {
-    let git_dir = repo.commondir();
-    let mut config = Config::load_with_global(git_dir)?;
-    if !maybe_remove_configured_worktree(repo, &mut config, stack_name, silent)? {
-        return Ok(false);
-    }
-    config.save(git_dir)?;
-    run_for_stack_with_repo_options(repo, stack_name, force, true, silent, record_remote_effect)?;
-    Ok(true)
+    run_for_stack_with_repo_options(repo, stack_name, force, true, silent, record_remote_effect)
 }
 
 fn run_for_stack_with_repo_options(
@@ -81,7 +74,7 @@ fn run_for_stack_with_repo_options(
     merge_verified_by_land: bool,
     silent: bool,
     record_remote_effect: &mut dyn FnMut(RemoteEffect),
-) -> Result<()> {
+) -> Result<bool> {
     let git_dir = repo.commondir();
     let mut config = Config::load_with_global(git_dir)?;
 
@@ -111,7 +104,9 @@ fn run_for_stack_with_repo_options(
         )));
     }
 
-    let _ = maybe_remove_configured_worktree(repo, &mut config, stack_name, silent)?;
+    if !maybe_remove_configured_worktree(repo, &mut config, stack_name, silent)? {
+        return Ok(false);
+    }
 
     // Delete local branch
     if let Ok(mut branch) = repo.find_branch(&branch_name, BranchType::Local) {
@@ -209,7 +204,7 @@ fn run_for_stack_with_repo_options(
     // Save updated config
     config.save(git_dir)?;
 
-    Ok(())
+    Ok(true)
 }
 
 /// Run the clean command
@@ -1073,5 +1068,97 @@ mod tests {
             },
             true,
         ));
+    }
+
+    #[test]
+    fn verified_land_validates_before_removing_configured_worktree() {
+        let temp = tempfile::tempdir().expect("create temp dir");
+        let repo_path = temp.path().join("repo");
+        std::fs::create_dir(&repo_path).expect("create repo dir");
+
+        let init = std::process::Command::new("git")
+            .args(["init", "-b", "main"])
+            .current_dir(&repo_path)
+            .output()
+            .expect("git init");
+        assert!(
+            init.status.success(),
+            "git init failed: {}",
+            String::from_utf8_lossy(&init.stderr)
+        );
+
+        std::process::Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(&repo_path)
+            .output()
+            .expect("git config email");
+        std::process::Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(&repo_path)
+            .output()
+            .expect("git config name");
+        std::fs::write(repo_path.join("README.md"), "test\n").expect("write readme");
+        std::process::Command::new("git")
+            .args(["add", "README.md"])
+            .current_dir(&repo_path)
+            .output()
+            .expect("git add");
+        let commit = std::process::Command::new("git")
+            .args(["commit", "-m", "init"])
+            .current_dir(&repo_path)
+            .output()
+            .expect("git commit");
+        assert!(
+            commit.status.success(),
+            "git commit failed: {}",
+            String::from_utf8_lossy(&commit.stderr)
+        );
+
+        let worktree_path = temp.path().join("configured-worktree");
+        let worktree = std::process::Command::new("git")
+            .args([
+                "worktree",
+                "add",
+                "--detach",
+                worktree_path.to_str().unwrap(),
+                "HEAD",
+            ])
+            .current_dir(&repo_path)
+            .output()
+            .expect("git worktree add");
+        assert!(
+            worktree.status.success(),
+            "git worktree add failed: {}",
+            String::from_utf8_lossy(&worktree.stderr)
+        );
+
+        let gg_dir = repo_path.join(".git/gg");
+        std::fs::create_dir_all(&gg_dir).expect("create gg dir");
+        std::fs::write(
+            gg_dir.join("config.json"),
+            serde_json::json!({
+                "defaults": {"branch_username": "bad/name", "base": "main"},
+                "stacks": {"cleanup": {"worktree_path": worktree_path.display().to_string()}}
+            })
+            .to_string(),
+        )
+        .expect("write config");
+
+        let repo = Repository::open(&repo_path).expect("open repo");
+        let result =
+            run_for_stack_with_repo_after_verified_land(&repo, "cleanup", true, false, &mut |_| {});
+
+        assert!(result.is_err(), "invalid username should fail validation");
+        assert!(
+            worktree_path.exists(),
+            "configured worktree must not be removed before validation"
+        );
+        let config = Config::load_with_global(repo.commondir()).expect("reload config");
+        assert_eq!(
+            config
+                .get_stack("cleanup")
+                .and_then(|stack| stack.worktree_path.as_deref()),
+            Some(worktree_path.to_str().unwrap())
+        );
     }
 }

--- a/crates/gg-core/src/commands/clean.rs
+++ b/crates/gg-core/src/commands/clean.rs
@@ -95,7 +95,14 @@ fn run_for_stack_with_repo_options(
     let branch_name = git::format_stack_branch(&username, stack_name);
 
     // Check if stack is fully merged
-    let merge_status = check_stack_merged(repo, &config, stack_name, &username, provider.as_ref())?;
+    let merge_status = check_stack_merged(
+        repo,
+        &config,
+        stack_name,
+        &username,
+        provider.as_ref(),
+        silent,
+    )?;
 
     if !merge_status.merged && !force {
         return Err(GgError::Other(format!(
@@ -295,8 +302,14 @@ pub fn run(clean_all: bool, json: bool) -> Result<()> {
         }
 
         // Load the stack to check MR status
-        let merge_status =
-            check_stack_merged(&repo, &config, stack_name, &username, provider.as_ref())?;
+        let merge_status = check_stack_merged(
+            &repo,
+            &config,
+            stack_name,
+            &username,
+            provider.as_ref(),
+            json,
+        )?;
 
         if merge_status.merged {
             if !clean_all && !json {
@@ -558,6 +571,7 @@ fn check_stack_merged(
     stack_name: &str,
     username: &str,
     provider: Option<&Provider>,
+    silent: bool,
 ) -> Result<MergeStatus> {
     // Track whether any provider API call failed - if so, we cannot trust
     // verification and must be conservative about remote branch deletion.
@@ -607,13 +621,15 @@ fn check_stack_merged(
                         Err(e) => {
                             // PR/MR might be deleted or inaccessible.
                             // Log the error for debugging but continue checking other MRs.
-                            eprintln!(
-                                "{} Could not fetch MR #{} ({}): {}",
-                                console::style("Debug:").dim(),
-                                mr_num,
-                                gg_id,
-                                e
-                            );
+                            if !silent {
+                                eprintln!(
+                                    "{} Could not fetch MR #{} ({}): {}",
+                                    console::style("Debug:").dim(),
+                                    mr_num,
+                                    gg_id,
+                                    e
+                                );
+                            }
                             had_provider_error = true;
                             provider_was_consulted = true; // We tried, it failed
                         }

--- a/crates/gg-core/src/commands/clean.rs
+++ b/crates/gg-core/src/commands/clean.rs
@@ -196,6 +196,7 @@ fn run_for_stack_with_repo_options(
     if !maybe_remove_configured_worktree(repo, &mut config, stack_name, silent)? {
         return Ok(false);
     }
+    config.save(git_dir)?;
 
     let allow_remote_delete = should_delete_remote_branches(merge_status, merge_verified_by_land);
     if !allow_remote_delete && !silent {
@@ -348,6 +349,7 @@ pub fn run(clean_all: bool, json: bool) -> Result<()> {
 
             let removed_or_not_configured =
                 maybe_remove_configured_worktree(&repo, &mut config, stack_name, json)?;
+            config.save(git_dir)?;
             if json && !removed_or_not_configured {
                 skipped.push(format!(
                     "{} (worktree not removed: confirmation defaults to false in --json mode)",

--- a/crates/gg-core/src/commands/clean.rs
+++ b/crates/gg-core/src/commands/clean.rs
@@ -214,7 +214,7 @@ fn run_for_stack_with_repo_options(
         /*delete_remote=*/ allow_remote_delete,
         /*silent=*/ silent,
         record_remote_effect,
-    );
+    )?;
 
     // Remove from config
     config.remove_stack(stack_name);
@@ -306,7 +306,7 @@ pub fn run(clean_all: bool, json: bool) -> Result<()> {
                 /*delete_remote=*/ false,
                 /*silent=*/ json,
                 &mut |_| {},
-            );
+            )?;
             config.remove_stack(stack_name);
             cleaned.push(stack_name.clone());
             continue;
@@ -434,7 +434,7 @@ pub fn run(clean_all: bool, json: bool) -> Result<()> {
                     guard.record_remote_effect(effect.clone());
                     remote_effects.push(effect);
                 },
-            );
+            )?;
 
             // Remove from config
             config.remove_stack(stack_name);
@@ -958,7 +958,7 @@ fn delete_entry_branches(
     delete_remote: bool,
     silent: bool,
     record_remote_effect: &mut dyn FnMut(RemoteEffect),
-) {
+) -> Result<()> {
     // First, delete entry branches from config (if any)
     if let Some(stack_config) = config.get_stack(stack_name) {
         for entry_id in stack_config.mrs.keys() {
@@ -991,7 +991,7 @@ fn delete_entry_branches(
             }
             // Delete remote entry branch
             if delete_remote {
-                if let Some(effect) = delete_remote_branch(repo, &entry_branch) {
+                if let Some(effect) = delete_remote_branch(repo, &entry_branch)? {
                     record_remote_effect(effect);
                 }
             }
@@ -1034,22 +1034,22 @@ fn delete_entry_branches(
         }
         // Also try to delete from remote
         if delete_remote {
-            if let Some(effect) = delete_remote_branch(repo, &branch_name) {
+            if let Some(effect) = delete_remote_branch(repo, &branch_name)? {
                 record_remote_effect(effect);
             }
         }
     }
+    Ok(())
 }
 
-fn delete_remote_branch(repo: &Repository, branch: &str) -> Option<RemoteEffect> {
-    git::delete_remote_branch(repo, branch)
-        .ok()
-        .flatten()
-        .map(|prior_oid| RemoteEffect::BranchDeleted {
+fn delete_remote_branch(repo: &Repository, branch: &str) -> Result<Option<RemoteEffect>> {
+    git::delete_remote_branch(repo, branch).map(|prior_oid| {
+        prior_oid.map(|prior_oid| RemoteEffect::BranchDeleted {
             remote: "origin".to_string(),
             branch: branch.to_string(),
             prior_oid: Some(prior_oid.to_string()),
         })
+    })
 }
 
 #[cfg(test)]
@@ -1095,6 +1095,19 @@ mod tests {
             },
             true,
         ));
+    }
+
+    #[test]
+    fn delete_remote_branch_reports_git_errors() {
+        let temp = tempfile::tempdir().expect("create temp dir");
+        let repo = Repository::init(temp.path()).expect("init repo");
+
+        let error = delete_remote_branch(&repo, "u/cleanup--c-1111111").unwrap_err();
+
+        assert!(
+            error.to_string().contains("git ls-remote failed"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]

--- a/crates/gg-core/src/commands/clean.rs
+++ b/crates/gg-core/src/commands/clean.rs
@@ -393,9 +393,25 @@ pub fn run(clean_all: bool, json: bool) -> Result<()> {
                 continue;
             }
 
-            if !delete_stack_branch(&repo, &config, stack_name, &branch_name, json)? {
-                skipped.push(format!("{stack_name} (branch cleanup could not complete)"));
-                continue;
+            match delete_stack_branch(&repo, &config, stack_name, &branch_name, json) {
+                Ok(true) => {}
+                Ok(false) => {
+                    skipped.push(format!("{stack_name} (branch cleanup could not complete)"));
+                    continue;
+                }
+                Err(error) => {
+                    if !json {
+                        println!(
+                            "{} Could not delete stack branch for '{}': {}",
+                            style("Warning:").yellow(),
+                            stack_name,
+                            error
+                        );
+                    }
+                    cleanup_error.get_or_insert_with(|| error.to_string());
+                    skipped.push(format!("{stack_name} ({error})"));
+                    continue;
+                }
             }
 
             // Remove from config

--- a/crates/gg-core/src/commands/clean.rs
+++ b/crates/gg-core/src/commands/clean.rs
@@ -165,7 +165,17 @@ fn run_for_stack_with_repo_options(
                         wt_name
                     );
                 }
-                let _ = git::remove_worktree(&wt_name);
+                if let Err(e) = git::remove_worktree(&wt_name) {
+                    if !silent {
+                        println!(
+                            "{} Could not remove worktree '{}': {}",
+                            style("Warning:").yellow(),
+                            wt_name,
+                            e
+                        );
+                    }
+                    return Ok(false);
+                }
             }
         }
 
@@ -182,6 +192,7 @@ fn run_for_stack_with_repo_options(
                     "  You may need to manually remove the worktree first: git worktree remove <path>"
                 );
             }
+            return Ok(false);
         }
     }
 
@@ -1175,6 +1186,107 @@ mod tests {
                 .get_stack("cleanup")
                 .and_then(|stack| stack.worktree_path.as_deref()),
             Some(worktree_path.to_str().unwrap())
+        );
+    }
+
+    #[test]
+    fn verified_land_reports_incomplete_branch_cleanup() {
+        let temp = tempfile::tempdir().expect("create temp dir");
+        let repo_path = temp.path().join("repo");
+        std::fs::create_dir(&repo_path).expect("create repo dir");
+
+        let init = std::process::Command::new("git")
+            .args(["init", "-b", "main"])
+            .current_dir(&repo_path)
+            .output()
+            .expect("git init");
+        assert!(
+            init.status.success(),
+            "git init failed: {}",
+            String::from_utf8_lossy(&init.stderr)
+        );
+        std::process::Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(&repo_path)
+            .output()
+            .expect("git config email");
+        std::process::Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(&repo_path)
+            .output()
+            .expect("git config name");
+        std::fs::write(repo_path.join("README.md"), "test\n").expect("write readme");
+        std::process::Command::new("git")
+            .args(["add", "README.md"])
+            .current_dir(&repo_path)
+            .output()
+            .expect("git add");
+        let commit = std::process::Command::new("git")
+            .args(["commit", "-m", "init"])
+            .current_dir(&repo_path)
+            .output()
+            .expect("git commit");
+        assert!(
+            commit.status.success(),
+            "git commit failed: {}",
+            String::from_utf8_lossy(&commit.stderr)
+        );
+        std::process::Command::new("git")
+            .args(["branch", "u/cleanup"])
+            .current_dir(&repo_path)
+            .output()
+            .expect("git branch");
+
+        let worktree_path = temp.path().join("stack-worktree");
+        let worktree = std::process::Command::new("git")
+            .args([
+                "worktree",
+                "add",
+                worktree_path.to_str().unwrap(),
+                "u/cleanup",
+            ])
+            .current_dir(&repo_path)
+            .output()
+            .expect("git worktree add");
+        assert!(
+            worktree.status.success(),
+            "git worktree add failed: {}",
+            String::from_utf8_lossy(&worktree.stderr)
+        );
+        let lock = std::process::Command::new("git")
+            .args(["worktree", "lock", worktree_path.to_str().unwrap()])
+            .current_dir(&repo_path)
+            .output()
+            .expect("git worktree lock");
+        assert!(
+            lock.status.success(),
+            "git worktree lock failed: {}",
+            String::from_utf8_lossy(&lock.stderr)
+        );
+
+        let gg_dir = repo_path.join(".git/gg");
+        std::fs::create_dir_all(&gg_dir).expect("create gg dir");
+        std::fs::write(
+            gg_dir.join("config.json"),
+            serde_json::json!({
+                "defaults": {"branch_username": "u", "base": "main"},
+                "stacks": {"cleanup": {}}
+            })
+            .to_string(),
+        )
+        .expect("write config");
+
+        let repo = Repository::open(&repo_path).expect("open repo");
+        let result =
+            run_for_stack_with_repo_after_verified_land(&repo, "cleanup", true, true, &mut |_| {});
+
+        assert!(!result.expect("cleanup should not error"));
+        assert!(
+            Config::load_with_global(repo.commondir())
+                .expect("reload config")
+                .get_stack("cleanup")
+                .is_some(),
+            "incomplete cleanup must not remove stack config"
         );
     }
 }

--- a/crates/gg-core/src/commands/clean.rs
+++ b/crates/gg-core/src/commands/clean.rs
@@ -269,6 +269,7 @@ pub fn run(clean_all: bool, json: bool) -> Result<()> {
     let mut cleaned: Vec<String> = Vec::new();
     let mut skipped: Vec<String> = Vec::new();
     let mut remote_effects = Vec::new();
+    let mut cleanup_error: Option<String> = None;
 
     if stacks.is_empty() {
         if json {
@@ -298,7 +299,7 @@ pub fn run(clean_all: bool, json: bool) -> Result<()> {
             // Branch doesn't exist: clean LOCAL orphan entry branches and config.
             // Be conservative: do NOT delete remote branches here because we can't
             // reliably verify merge status without the main stack branch.
-            delete_entry_branches(
+            if let Err(error) = delete_entry_branches(
                 &repo,
                 &config,
                 stack_name,
@@ -306,7 +307,11 @@ pub fn run(clean_all: bool, json: bool) -> Result<()> {
                 /*delete_remote=*/ false,
                 /*silent=*/ json,
                 &mut |_| {},
-            )?;
+            ) {
+                cleanup_error.get_or_insert_with(|| error.to_string());
+                skipped.push(format!("{stack_name} ({error})"));
+                continue;
+            }
             config.remove_stack(stack_name);
             cleaned.push(stack_name.clone());
             continue;
@@ -423,7 +428,7 @@ pub fn run(clean_all: bool, json: bool) -> Result<()> {
             }
 
             // Delete entry branches (local and remote when verified)
-            delete_entry_branches(
+            if let Err(error) = delete_entry_branches(
                 &repo,
                 &config,
                 stack_name,
@@ -434,7 +439,19 @@ pub fn run(clean_all: bool, json: bool) -> Result<()> {
                     guard.record_remote_effect(effect.clone());
                     remote_effects.push(effect);
                 },
-            )?;
+            ) {
+                if !json {
+                    println!(
+                        "{} Could not delete entry branches for '{}': {}",
+                        style("Warning:").yellow(),
+                        stack_name,
+                        error
+                    );
+                }
+                cleanup_error.get_or_insert_with(|| error.to_string());
+                skipped.push(format!("{stack_name} ({error})"));
+                continue;
+            }
 
             // Remove from config
             config.remove_stack(stack_name);
@@ -487,7 +504,11 @@ pub fn run(clean_all: bool, json: bool) -> Result<()> {
         touched_remote,
     )?;
 
-    Ok(())
+    if let Some(error) = cleanup_error {
+        Err(GgError::Other(error))
+    } else {
+        Ok(())
+    }
 }
 
 fn maybe_remove_configured_worktree(

--- a/crates/gg-core/src/commands/clean.rs
+++ b/crates/gg-core/src/commands/clean.rs
@@ -942,6 +942,13 @@ fn delete_entry_branches(
                 }
             };
             let entry_branch = git::format_entry_branch(username, stack_name, &entry_id);
+            // Delete remote entry branch first so a remote failure leaves the local ref
+            // discoverable for a retry.
+            if delete_remote {
+                if let Some(effect) = delete_remote_branch(repo, &entry_branch)? {
+                    record_remote_effect(effect);
+                }
+            }
             // Delete local entry branch
             if let Ok(mut branch) = repo.find_branch(&entry_branch, BranchType::Local) {
                 // Check if branch is HEAD of a worktree
@@ -954,12 +961,6 @@ fn delete_entry_branches(
                 }
                 // Try to delete, ignore errors (best effort for entry branches)
                 let _ = branch.delete();
-            }
-            // Delete remote entry branch
-            if delete_remote {
-                if let Some(effect) = delete_remote_branch(repo, &entry_branch)? {
-                    record_remote_effect(effect);
-                }
             }
         }
     }
@@ -986,6 +987,13 @@ fn delete_entry_branches(
         .unwrap_or_default();
 
     for branch_name in branches {
+        // Delete remote first so a remote failure leaves the local orphan ref
+        // discoverable for a retry.
+        if delete_remote {
+            if let Some(effect) = delete_remote_branch(repo, &branch_name)? {
+                record_remote_effect(effect);
+            }
+        }
         if let Ok(mut branch) = repo.find_branch(&branch_name, BranchType::Local) {
             // Check if branch is HEAD of a worktree
             if let Some(wt_name) = git::is_branch_checked_out_in_worktree(repo, &branch_name) {
@@ -997,12 +1005,6 @@ fn delete_entry_branches(
             }
             // Try to delete, ignore errors (best effort for entry branches)
             let _ = branch.delete();
-        }
-        // Also try to delete from remote
-        if delete_remote {
-            if let Some(effect) = delete_remote_branch(repo, &branch_name)? {
-                record_remote_effect(effect);
-            }
         }
     }
     Ok(())
@@ -1151,6 +1153,83 @@ mod tests {
                 .get_stack("cleanup")
                 .is_some(),
             "stack config must remain retryable"
+        );
+    }
+
+    #[test]
+    fn verified_land_keeps_orphan_entry_retryable_when_remote_cleanup_fails() {
+        let temp = tempfile::tempdir().expect("create temp dir");
+        let repo_path = temp.path().join("repo");
+        std::fs::create_dir(&repo_path).expect("create repo dir");
+
+        let init = std::process::Command::new("git")
+            .args(["init", "-b", "main"])
+            .current_dir(&repo_path)
+            .output()
+            .expect("git init");
+        assert!(
+            init.status.success(),
+            "git init failed: {}",
+            String::from_utf8_lossy(&init.stderr)
+        );
+        std::process::Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(&repo_path)
+            .output()
+            .expect("git config email");
+        std::process::Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(&repo_path)
+            .output()
+            .expect("git config name");
+        std::fs::write(repo_path.join("README.md"), "test\n").expect("write readme");
+        std::process::Command::new("git")
+            .args(["add", "README.md"])
+            .current_dir(&repo_path)
+            .output()
+            .expect("git add");
+        let commit = std::process::Command::new("git")
+            .args(["commit", "-m", "init"])
+            .current_dir(&repo_path)
+            .output()
+            .expect("git commit");
+        assert!(
+            commit.status.success(),
+            "git commit failed: {}",
+            String::from_utf8_lossy(&commit.stderr)
+        );
+        std::process::Command::new("git")
+            .args(["branch", "u/cleanup"])
+            .current_dir(&repo_path)
+            .output()
+            .expect("git branch");
+        std::process::Command::new("git")
+            .args(["branch", "u/cleanup--c-1111111"])
+            .current_dir(&repo_path)
+            .output()
+            .expect("git branch");
+
+        let gg_dir = repo_path.join(".git/gg");
+        std::fs::create_dir_all(&gg_dir).expect("create gg dir");
+        std::fs::write(
+            gg_dir.join("config.json"),
+            serde_json::json!({
+                "defaults": {"branch_username": "u", "base": "main"},
+                "stacks": {"cleanup": {}}
+            })
+            .to_string(),
+        )
+        .expect("write config");
+
+        let repo = Repository::open(&repo_path).expect("open repo");
+        let result =
+            run_for_stack_with_repo_after_verified_land(&repo, "cleanup", true, true, &mut |_| {});
+
+        assert!(result.is_err(), "missing origin should fail remote cleanup");
+        assert!(
+            repo.find_branch("u/cleanup--c-1111111", BranchType::Local)
+                .is_ok(),
+            "orphan entry branch must remain retryable"
         );
     }
 

--- a/crates/gg-core/src/commands/clean.rs
+++ b/crates/gg-core/src/commands/clean.rs
@@ -30,7 +30,7 @@ pub fn run_for_stack(stack_name: &str, force: bool) -> Result<()> {
     )?;
 
     let mut remote_effects = Vec::new();
-    run_for_stack_with_repo_options(&repo, stack_name, force, false, &mut |effect| {
+    run_for_stack_with_repo_options(&repo, stack_name, force, false, false, &mut |effect| {
         guard.record_remote_effect(effect.clone());
         remote_effects.push(effect);
     })?;
@@ -47,7 +47,7 @@ pub fn run_for_stack(stack_name: &str, force: bool) -> Result<()> {
 
 /// Run clean for a stack with an already-open repository (no lock acquisition)
 pub fn run_for_stack_with_repo(repo: &Repository, stack_name: &str, force: bool) -> Result<()> {
-    run_for_stack_with_repo_options(repo, stack_name, force, false, &mut |_| {})
+    run_for_stack_with_repo_options(repo, stack_name, force, false, false, &mut |_| {})
 }
 
 /// Run clean after `gg land` has already verified that every PR/MR in the stack
@@ -61,9 +61,10 @@ pub(crate) fn run_for_stack_with_repo_after_verified_land(
     repo: &Repository,
     stack_name: &str,
     force: bool,
+    silent: bool,
     record_remote_effect: &mut dyn FnMut(RemoteEffect),
 ) -> Result<()> {
-    run_for_stack_with_repo_options(repo, stack_name, force, true, record_remote_effect)
+    run_for_stack_with_repo_options(repo, stack_name, force, true, silent, record_remote_effect)
 }
 
 fn run_for_stack_with_repo_options(
@@ -71,6 +72,7 @@ fn run_for_stack_with_repo_options(
     stack_name: &str,
     force: bool,
     merge_verified_by_land: bool,
+    silent: bool,
     record_remote_effect: &mut dyn FnMut(RemoteEffect),
 ) -> Result<()> {
     let git_dir = repo.commondir();
@@ -102,7 +104,7 @@ fn run_for_stack_with_repo_options(
         )));
     }
 
-    let _ = maybe_remove_configured_worktree(repo, &mut config, stack_name, false)?;
+    let _ = maybe_remove_configured_worktree(repo, &mut config, stack_name, silent)?;
 
     // Delete local branch
     if let Ok(mut branch) = repo.find_branch(&branch_name, BranchType::Local) {
@@ -123,11 +125,13 @@ fn run_for_stack_with_repo_options(
             if let Err(e) = git::checkout_branch(repo, &base) {
                 let msg = e.to_string();
                 if msg.contains("current HEAD of a linked") {
-                    println!(
-                        "{} '{}' is checked out in another worktree; detaching HEAD before branch deletion.",
-                        style("Note:").cyan(),
-                        base
-                    );
+                    if !silent {
+                        println!(
+                            "{} '{}' is checked out in another worktree; detaching HEAD before branch deletion.",
+                            style("Note:").cyan(),
+                            base
+                        );
+                    }
                     if let Ok(head) = repo.head() {
                         if let Some(oid) = head.target() {
                             repo.set_head_detached(oid)?;
@@ -144,32 +148,36 @@ fn run_for_stack_with_repo_options(
             // Try to prune if stale
             if !git::try_prune_worktree(repo, &wt_name) {
                 // Worktree still exists - warn and try to remove it
-                println!(
-                    "{} Branch '{}' is checked out in worktree '{}'. Removing worktree.",
-                    style("Note:").cyan(),
-                    branch_name,
-                    wt_name
-                );
+                if !silent {
+                    println!(
+                        "{} Branch '{}' is checked out in worktree '{}'. Removing worktree.",
+                        style("Note:").cyan(),
+                        branch_name,
+                        wt_name
+                    );
+                }
                 let _ = git::remove_worktree(&wt_name);
             }
         }
 
         // Try to delete the branch, handle errors gracefully
         if let Err(e) = branch.delete() {
-            println!(
-                "{} Could not delete local branch '{}': {}",
-                style("Warning:").yellow(),
-                branch_name,
-                e
-            );
-            println!(
-                "  You may need to manually remove the worktree first: git worktree remove <path>"
-            );
+            if !silent {
+                println!(
+                    "{} Could not delete local branch '{}': {}",
+                    style("Warning:").yellow(),
+                    branch_name,
+                    e
+                );
+                println!(
+                    "  You may need to manually remove the worktree first: git worktree remove <path>"
+                );
+            }
         }
     }
 
     let allow_remote_delete = should_delete_remote_branches(merge_status, merge_verified_by_land);
-    if !allow_remote_delete {
+    if !allow_remote_delete && !silent {
         println!(
             "{} Skipping remote branch deletion for '{}' because merge verification is unavailable.",
             style("Warning:").yellow(),
@@ -184,7 +192,7 @@ fn run_for_stack_with_repo_options(
         stack_name,
         &username,
         /*delete_remote=*/ allow_remote_delete,
-        /*silent=*/ false,
+        /*silent=*/ silent,
         record_remote_effect,
     );
 

--- a/crates/gg-core/src/commands/clean.rs
+++ b/crates/gg-core/src/commands/clean.rs
@@ -63,8 +63,15 @@ pub(crate) fn run_for_stack_with_repo_after_verified_land(
     force: bool,
     silent: bool,
     record_remote_effect: &mut dyn FnMut(RemoteEffect),
-) -> Result<()> {
-    run_for_stack_with_repo_options(repo, stack_name, force, true, silent, record_remote_effect)
+) -> Result<bool> {
+    let git_dir = repo.commondir();
+    let mut config = Config::load_with_global(git_dir)?;
+    if !maybe_remove_configured_worktree(repo, &mut config, stack_name, silent)? {
+        return Ok(false);
+    }
+    config.save(git_dir)?;
+    run_for_stack_with_repo_options(repo, stack_name, force, true, silent, record_remote_effect)?;
+    Ok(true)
 }
 
 fn run_for_stack_with_repo_options(

--- a/crates/gg-core/src/commands/clean.rs
+++ b/crates/gg-core/src/commands/clean.rs
@@ -67,6 +67,88 @@ pub(crate) fn run_for_stack_with_repo_after_verified_land(
     run_for_stack_with_repo_options(repo, stack_name, force, true, silent, record_remote_effect)
 }
 
+fn delete_stack_branch(
+    repo: &Repository,
+    config: &Config,
+    stack_name: &str,
+    branch_name: &str,
+    silent: bool,
+) -> Result<bool> {
+    let Ok(mut branch) = repo.find_branch(branch_name, BranchType::Local) else {
+        return Ok(true);
+    };
+
+    let current = git::current_branch_name(repo);
+    if current.as_deref() == Some(branch_name) {
+        let base = config
+            .get_base_for_stack(stack_name)
+            .map(|s| s.to_string())
+            .or_else(|| git::find_base_branch(repo).ok())
+            .unwrap_or_else(|| "main".to_string());
+
+        if let Err(e) = git::checkout_branch(repo, &base) {
+            let msg = e.to_string();
+            if msg.contains("current HEAD of a linked") {
+                if !silent {
+                    println!(
+                        "{} '{}' is checked out in another worktree; detaching HEAD before branch deletion.",
+                        style("Note:").cyan(),
+                        base
+                    );
+                }
+                if let Ok(head) = repo.head() {
+                    if let Some(oid) = head.target() {
+                        repo.set_head_detached(oid)?;
+                    }
+                }
+            } else {
+                return Err(e);
+            }
+        }
+    }
+
+    if let Some(wt_name) = git::is_branch_checked_out_in_worktree(repo, branch_name) {
+        if !git::try_prune_worktree(repo, &wt_name) {
+            if !silent {
+                println!(
+                    "{} Branch '{}' is checked out in worktree '{}'. Removing worktree.",
+                    style("Note:").cyan(),
+                    branch_name,
+                    wt_name
+                );
+            }
+            if let Err(e) = git::remove_worktree(&wt_name) {
+                if !silent {
+                    println!(
+                        "{} Could not remove worktree '{}': {}",
+                        style("Warning:").yellow(),
+                        wt_name,
+                        e
+                    );
+                }
+                return Ok(false);
+            }
+        }
+    }
+
+    if let Err(e) = branch.delete() {
+        if !silent {
+            println!(
+                "{} Could not delete local branch '{}': {}",
+                style("Warning:").yellow(),
+                branch_name,
+                e
+            );
+            println!(
+                "  You may need to manually remove the worktree first: git worktree remove <path>"
+            );
+        }
+        return Ok(false);
+    }
+
+    Ok(true)
+}
+
 fn run_for_stack_with_repo_options(
     repo: &Repository,
     stack_name: &str,
@@ -115,87 +197,6 @@ fn run_for_stack_with_repo_options(
         return Ok(false);
     }
 
-    // Delete local branch
-    if let Ok(mut branch) = repo.find_branch(&branch_name, BranchType::Local) {
-        // Make sure we're not on this branch
-        let current = git::current_branch_name(repo);
-        if current.as_deref() == Some(&branch_name) {
-            // Switch to base branch first
-            let base = config
-                .get_base_for_stack(stack_name)
-                .map(|s| s.to_string())
-                .or_else(|| git::find_base_branch(repo).ok())
-                .unwrap_or_else(|| "main".to_string());
-
-            // The pre-detection above can miss worktrees if
-            // Repository::open_from_worktree fails on them. Add a
-            // defensive fallback: if checkout fails because the branch is
-            // in a linked worktree, detach HEAD instead.
-            if let Err(e) = git::checkout_branch(repo, &base) {
-                let msg = e.to_string();
-                if msg.contains("current HEAD of a linked") {
-                    if !silent {
-                        println!(
-                            "{} '{}' is checked out in another worktree; detaching HEAD before branch deletion.",
-                            style("Note:").cyan(),
-                            base
-                        );
-                    }
-                    if let Ok(head) = repo.head() {
-                        if let Some(oid) = head.target() {
-                            repo.set_head_detached(oid)?;
-                        }
-                    }
-                } else {
-                    return Err(e);
-                }
-            }
-        }
-
-        // Check if branch is HEAD of a worktree
-        if let Some(wt_name) = git::is_branch_checked_out_in_worktree(repo, &branch_name) {
-            // Try to prune if stale
-            if !git::try_prune_worktree(repo, &wt_name) {
-                // Worktree still exists - warn and try to remove it
-                if !silent {
-                    println!(
-                        "{} Branch '{}' is checked out in worktree '{}'. Removing worktree.",
-                        style("Note:").cyan(),
-                        branch_name,
-                        wt_name
-                    );
-                }
-                if let Err(e) = git::remove_worktree(&wt_name) {
-                    if !silent {
-                        println!(
-                            "{} Could not remove worktree '{}': {}",
-                            style("Warning:").yellow(),
-                            wt_name,
-                            e
-                        );
-                    }
-                    return Ok(false);
-                }
-            }
-        }
-
-        // Try to delete the branch, handle errors gracefully
-        if let Err(e) = branch.delete() {
-            if !silent {
-                println!(
-                    "{} Could not delete local branch '{}': {}",
-                    style("Warning:").yellow(),
-                    branch_name,
-                    e
-                );
-                println!(
-                    "  You may need to manually remove the worktree first: git worktree remove <path>"
-                );
-            }
-            return Ok(false);
-        }
-    }
-
     let allow_remote_delete = should_delete_remote_branches(merge_status, merge_verified_by_land);
     if !allow_remote_delete && !silent {
         println!(
@@ -215,6 +216,10 @@ fn run_for_stack_with_repo_options(
         /*silent=*/ silent,
         record_remote_effect,
     )?;
+
+    if !delete_stack_branch(repo, &config, stack_name, &branch_name, silent)? {
+        return Ok(false);
+    }
 
     // Remove from config
     config.remove_stack(stack_name);
@@ -351,73 +356,6 @@ pub fn run(clean_all: bool, json: bool) -> Result<()> {
                 continue;
             }
 
-            // Delete local branch
-            if let Ok(mut branch) = repo.find_branch(&branch_name, BranchType::Local) {
-                // Make sure we're not on this branch
-                let current = git::current_branch_name(&repo);
-                if current.as_deref() == Some(&branch_name) {
-                    // Switch to base branch first
-                    let base = config
-                        .get_base_for_stack(stack_name)
-                        .map(|s| s.to_string())
-                        .or_else(|| git::find_base_branch(&repo).ok())
-                        .unwrap_or_else(|| "main".to_string());
-
-                    // Defensive fallback for the same linked-worktree case.
-                    if let Err(e) = git::checkout_branch(&repo, &base) {
-                        let msg = e.to_string();
-                        if msg.contains("current HEAD of a linked") {
-                            if !json {
-                                println!(
-                                    "{} '{}' is checked out in another worktree; detaching HEAD before branch deletion.",
-                                    style("Note:").cyan(),
-                                    base
-                                );
-                            }
-                            if let Ok(head) = repo.head() {
-                                if let Some(oid) = head.target() {
-                                    repo.set_head_detached(oid)?;
-                                }
-                            }
-                        } else {
-                            return Err(e);
-                        }
-                    }
-                }
-
-                // Check if branch is HEAD of a worktree
-                if let Some(wt_name) = git::is_branch_checked_out_in_worktree(&repo, &branch_name) {
-                    // Try to prune if stale
-                    if !git::try_prune_worktree(&repo, &wt_name) {
-                        // Worktree still exists - warn and try to remove it
-                        if !json {
-                            println!(
-                                "{} Branch '{}' is checked out in worktree '{}'. Removing worktree.",
-                                style("Note:").cyan(),
-                                branch_name,
-                                wt_name
-                            );
-                        }
-                        let _ = git::remove_worktree(&wt_name);
-                    }
-                }
-
-                // Try to delete the branch, handle errors gracefully
-                if let Err(e) = branch.delete() {
-                    if !json {
-                        println!(
-                            "{} Could not delete local branch '{}': {}",
-                            style("Warning:").yellow(),
-                            branch_name,
-                            e
-                        );
-                        println!(
-                            "  You may need to manually remove the worktree first: git worktree remove <path>"
-                        );
-                    }
-                }
-            }
-
             let allow_remote_delete = merge_status.verified;
             if !allow_remote_delete && !json {
                 println!(
@@ -450,6 +388,11 @@ pub fn run(clean_all: bool, json: bool) -> Result<()> {
                 }
                 cleanup_error.get_or_insert_with(|| error.to_string());
                 skipped.push(format!("{stack_name} ({error})"));
+                continue;
+            }
+
+            if !delete_stack_branch(&repo, &config, stack_name, &branch_name, json)? {
+                skipped.push(format!("{stack_name} (branch cleanup could not complete)"));
                 continue;
             }
 
@@ -504,7 +447,9 @@ pub fn run(clean_all: bool, json: bool) -> Result<()> {
         touched_remote,
     )?;
 
-    if let Some(error) = cleanup_error {
+    if json {
+        Ok(())
+    } else if let Some(error) = cleanup_error {
         Err(GgError::Other(error))
     } else {
         Ok(())
@@ -1128,6 +1073,84 @@ mod tests {
         assert!(
             error.to_string().contains("git ls-remote failed"),
             "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn verified_land_keeps_stack_retryable_when_remote_entry_cleanup_fails() {
+        let temp = tempfile::tempdir().expect("create temp dir");
+        let repo_path = temp.path().join("repo");
+        std::fs::create_dir(&repo_path).expect("create repo dir");
+
+        let init = std::process::Command::new("git")
+            .args(["init", "-b", "main"])
+            .current_dir(&repo_path)
+            .output()
+            .expect("git init");
+        assert!(
+            init.status.success(),
+            "git init failed: {}",
+            String::from_utf8_lossy(&init.stderr)
+        );
+        std::process::Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(&repo_path)
+            .output()
+            .expect("git config email");
+        std::process::Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(&repo_path)
+            .output()
+            .expect("git config name");
+        std::fs::write(repo_path.join("README.md"), "test\n").expect("write readme");
+        std::process::Command::new("git")
+            .args(["add", "README.md"])
+            .current_dir(&repo_path)
+            .output()
+            .expect("git add");
+        let commit = std::process::Command::new("git")
+            .args(["commit", "-m", "init"])
+            .current_dir(&repo_path)
+            .output()
+            .expect("git commit");
+        assert!(
+            commit.status.success(),
+            "git commit failed: {}",
+            String::from_utf8_lossy(&commit.stderr)
+        );
+        std::process::Command::new("git")
+            .args(["branch", "u/cleanup"])
+            .current_dir(&repo_path)
+            .output()
+            .expect("git branch");
+
+        let gg_dir = repo_path.join(".git/gg");
+        std::fs::create_dir_all(&gg_dir).expect("create gg dir");
+        std::fs::write(
+            gg_dir.join("config.json"),
+            serde_json::json!({
+                "defaults": {"branch_username": "u", "base": "main"},
+                "stacks": {"cleanup": {"mrs": {"c-1111111": 1}}}
+            })
+            .to_string(),
+        )
+        .expect("write config");
+
+        let repo = Repository::open(&repo_path).expect("open repo");
+        let result =
+            run_for_stack_with_repo_after_verified_land(&repo, "cleanup", true, true, &mut |_| {});
+
+        assert!(result.is_err(), "missing origin should fail remote cleanup");
+        assert!(
+            repo.find_branch("u/cleanup", BranchType::Local).is_ok(),
+            "stack branch must remain retryable"
+        );
+        assert!(
+            Config::load_with_global(repo.commondir())
+                .expect("reload config")
+                .get_stack("cleanup")
+                .is_some(),
+            "stack config must remain retryable"
         );
     }
 

--- a/crates/gg-core/src/commands/land.rs
+++ b/crates/gg-core/src/commands/land.rs
@@ -1182,7 +1182,8 @@ pub fn run(opts: LandOptions) -> Result<()> {
             if admin && !structured {
                 eprintln!("⚠ Merging with admin override — bypassing approval requirements");
             }
-            match provider.merge_pr(pr_num, squash, false, admin) {
+            let merge_admin = admin && !(structured && provider == Provider::GitLab);
+            match provider.merge_pr(pr_num, squash, false, merge_admin) {
                 Ok(()) => {
                     // Record the merge as a remote effect. Fetch the URL if we
                     // can; fall back to empty string if the info call fails.

--- a/crates/gg-core/src/commands/land.rs
+++ b/crates/gg-core/src/commands/land.rs
@@ -242,7 +242,9 @@ fn cleanup_after_merge(
     pr_num: u64,
     land_all: bool,
     json: bool,
-) {
+) -> Vec<String> {
+    let mut warnings = Vec::new();
+
     // Remove PR/MR mapping from config
     config.remove_mr_for_entry(&stack.name, gg_id);
 
@@ -272,6 +274,13 @@ fn cleanup_after_merge(
                 );
             }
             if let Err(e) = provider.update_pr_base(remaining_pr, &stack.base) {
+                let warning = format!(
+                    "Failed to update {} {}{} base: {}",
+                    provider.pr_label(),
+                    provider.pr_number_prefix(),
+                    remaining_pr,
+                    e
+                );
                 if !json {
                     println!(
                         "{} Warning: Failed to update {} {}{} base: {}",
@@ -282,9 +291,11 @@ fn cleanup_after_merge(
                         e
                     );
                 }
+                warnings.push(warning);
             }
         }
     }
+    warnings
 }
 
 /// Rebase remaining PR branches onto the base branch after a merge
@@ -1070,7 +1081,7 @@ pub fn run(opts: LandOptions) -> Result<()> {
                             .expect("land segment guard")
                             .mark_touched_remote();
                         landed_count += 1;
-                        cleanup_after_merge(
+                        warnings.extend(cleanup_after_merge(
                             &mut config,
                             &stack,
                             &provider,
@@ -1078,7 +1089,7 @@ pub fn run(opts: LandOptions) -> Result<()> {
                             pr_num,
                             land_multiple,
                             structured,
-                        );
+                        ));
                         if land_multiple {
                             let current_index = stack
                                 .entries
@@ -1219,7 +1230,7 @@ pub fn run(opts: LandOptions) -> Result<()> {
                         },
                     );
                     landed_count += 1;
-                    cleanup_after_merge(
+                    warnings.extend(cleanup_after_merge(
                         &mut config,
                         &stack,
                         &provider,
@@ -1227,7 +1238,7 @@ pub fn run(opts: LandOptions) -> Result<()> {
                         pr_num,
                         land_multiple,
                         structured,
-                    );
+                    ));
                     if land_multiple {
                         let current_index = stack
                             .entries
@@ -2383,7 +2394,7 @@ mod tests {
         // - land_all: bool (whether to update remaining PR bases)
 
         // Type-level assertion that cleanup_after_merge exists with the correct signature
-        let _fn_ptr: fn(&mut Config, &Stack, &Provider, &str, u64, bool, bool) =
+        let _fn_ptr: fn(&mut Config, &Stack, &Provider, &str, u64, bool, bool) -> Vec<String> =
             cleanup_after_merge;
     }
 

--- a/crates/gg-core/src/commands/land.rs
+++ b/crates/gg-core/src/commands/land.rs
@@ -679,6 +679,11 @@ pub fn run(opts: LandOptions) -> Result<()> {
         None if land_all => stack.entries.len(),
         None => default_land_total_entries(&stack),
     };
+    let summary_total_entries = if land_multiple {
+        total_entries
+    } else {
+        stack.entries.len()
+    };
     emit_land_event(
         streamer.as_mut(),
         LandStreamingEvent::Start {
@@ -1406,7 +1411,7 @@ pub fn run(opts: LandOptions) -> Result<()> {
 
     let mut jsonl_summary = None;
     if structured {
-        let remaining = total_entries.saturating_sub(
+        let remaining = summary_total_entries.saturating_sub(
             landed_entries
                 .iter()
                 .filter(|e| matches!(e.action.as_str(), "merged" | "already_merged"))

--- a/crates/gg-core/src/commands/land.rs
+++ b/crates/gg-core/src/commands/land.rs
@@ -738,69 +738,81 @@ pub fn run(opts: LandOptions) -> Result<()> {
         let mut next_entry_idx = None;
         for (idx, entry) in entries_to_land.iter().enumerate() {
             if let Some(num) = entry.mr_number {
-                if let Ok(info) = provider.get_pr_info(num) {
-                    if info.state == PrState::Open || info.state == PrState::Draft {
-                        next_entry_idx = Some(idx);
-                        break;
-                    } else if info.state == PrState::Merged {
-                        if let Some(gg_id) = &entry.gg_id {
-                            if seen_already_merged.insert(gg_id.clone()) {
-                                if !structured {
-                                    println!(
-                                        "{} {} {}{} ({}) — already merged",
-                                        style("→").cyan(),
-                                        provider.pr_label(),
-                                        provider.pr_number_prefix(),
-                                        num,
-                                        entry.title
+                match provider.get_pr_info(num) {
+                    Ok(info) => {
+                        if info.state == PrState::Open || info.state == PrState::Draft {
+                            next_entry_idx = Some(idx);
+                            break;
+                        } else if info.state == PrState::Merged {
+                            if let Some(gg_id) = &entry.gg_id {
+                                if seen_already_merged.insert(gg_id.clone()) {
+                                    if !structured {
+                                        println!(
+                                            "{} {} {}{} ({}) — already merged",
+                                            style("→").cyan(),
+                                            provider.pr_label(),
+                                            provider.pr_number_prefix(),
+                                            num,
+                                            entry.title
+                                        );
+                                    }
+                                    record_landed_entry(
+                                        &mut landed_entries,
+                                        &mut streamer,
+                                        LandedEntryJson {
+                                            position: entry.position,
+                                            sha: entry.short_sha.clone(),
+                                            title: entry.title.clone(),
+                                            gg_id: gg_id.clone(),
+                                            pr_number: num,
+                                            action: "already_merged".to_string(),
+                                            error: None,
+                                        },
+                                    );
+                                    landed_count += 1;
+                                }
+                            }
+                            continue;
+                        } else if info.state == PrState::Closed {
+                            if let Some(gg_id) = &entry.gg_id {
+                                if seen_closed.insert(gg_id.clone()) {
+                                    if !structured {
+                                        println!(
+                                            "{} {} {}{} ({}) — closed, skipping",
+                                            style("⚠").yellow(),
+                                            provider.pr_label(),
+                                            provider.pr_number_prefix(),
+                                            num,
+                                            entry.title
+                                        );
+                                    }
+                                    record_landed_entry(
+                                        &mut landed_entries,
+                                        &mut streamer,
+                                        LandedEntryJson {
+                                            position: entry.position,
+                                            sha: entry.short_sha.clone(),
+                                            title: entry.title.clone(),
+                                            gg_id: gg_id.clone(),
+                                            pr_number: num,
+                                            action: "skipped_closed".to_string(),
+                                            error: None,
+                                        },
                                     );
                                 }
-                                record_landed_entry(
-                                    &mut landed_entries,
-                                    &mut streamer,
-                                    LandedEntryJson {
-                                        position: entry.position,
-                                        sha: entry.short_sha.clone(),
-                                        title: entry.title.clone(),
-                                        gg_id: gg_id.clone(),
-                                        pr_number: num,
-                                        action: "already_merged".to_string(),
-                                        error: None,
-                                    },
-                                );
-                                landed_count += 1;
                             }
+                            continue;
                         }
-                        continue;
-                    } else if info.state == PrState::Closed {
-                        if let Some(gg_id) = &entry.gg_id {
-                            if seen_closed.insert(gg_id.clone()) {
-                                if !structured {
-                                    println!(
-                                        "{} {} {}{} ({}) — closed, skipping",
-                                        style("⚠").yellow(),
-                                        provider.pr_label(),
-                                        provider.pr_number_prefix(),
-                                        num,
-                                        entry.title
-                                    );
-                                }
-                                record_landed_entry(
-                                    &mut landed_entries,
-                                    &mut streamer,
-                                    LandedEntryJson {
-                                        position: entry.position,
-                                        sha: entry.short_sha.clone(),
-                                        title: entry.title.clone(),
-                                        gg_id: gg_id.clone(),
-                                        pr_number: num,
-                                        action: "skipped_closed".to_string(),
-                                        error: None,
-                                    },
-                                );
-                            }
-                        }
-                        continue;
+                    }
+                    Err(e) => {
+                        land_error = Some(format!(
+                            "Failed to fetch {} {}{}: {}",
+                            provider.pr_label(),
+                            provider.pr_number_prefix(),
+                            num,
+                            e
+                        ));
+                        break 'landing_loop;
                     }
                 }
             }

--- a/crates/gg-core/src/commands/land.rs
+++ b/crates/gg-core/src/commands/land.rs
@@ -1083,6 +1083,14 @@ pub fn run(opts: LandOptions) -> Result<()> {
                             structured,
                             streamer.as_mut(),
                         );
+                        if wait_result.is_ok() {
+                            mark_landed_entry_merged(
+                                &mut landed_entries,
+                                streamer.as_mut(),
+                                entry.position,
+                                pr_num,
+                            );
+                        }
                         lock = Some(git::acquire_operation_lock_silent(
                             &repo, "land", structured,
                         )?);
@@ -1092,12 +1100,6 @@ pub fn run(opts: LandOptions) -> Result<()> {
                             land_error = Some(e.to_string());
                             break 'landing_loop;
                         }
-                        mark_landed_entry_merged(
-                            &mut landed_entries,
-                            streamer.as_mut(),
-                            entry.position,
-                            pr_num,
-                        );
                         if let Some(error) = stack_changed_while_waiting(&expected_stack, &stack) {
                             land_error = Some(error);
                             break 'landing_loop;
@@ -1405,7 +1407,8 @@ pub fn run(opts: LandOptions) -> Result<()> {
             ) {
                 Ok(true) => cleaned = true,
                 Ok(false) => warnings.push(
-                    "Cleanup skipped because the configured worktree was retained".to_string(),
+                    "Cleanup skipped because worktree or branch cleanup could not complete"
+                        .to_string(),
                 ),
                 Err(error) => warnings.push(format!("Cleanup skipped: {error}")),
             }

--- a/crates/gg-core/src/commands/land.rs
+++ b/crates/gg-core/src/commands/land.rs
@@ -19,7 +19,7 @@ use crate::output::{
     LandedEntryJson, StreamingJson, OUTPUT_VERSION,
 };
 use crate::provider::{CiStatus, PrState, Provider};
-use crate::stack::{resolve_target, Stack};
+use crate::stack::{resolve_target, Stack, StackEntry};
 
 /// Format elapsed duration as human-readable string (e.g., "2m15s", "45s")
 fn format_duration(elapsed: Duration) -> String {
@@ -566,6 +566,13 @@ fn default_land_total_entries(stack: &Stack) -> usize {
     total
 }
 
+fn mapped_land_total_entries(entries: &[StackEntry]) -> usize {
+    entries
+        .iter()
+        .filter(|entry| entry.mr_number.is_some())
+        .count()
+}
+
 /// Run the land command
 pub fn run(opts: LandOptions) -> Result<()> {
     let LandOptions {
@@ -678,8 +685,10 @@ pub fn run(opts: LandOptions) -> Result<()> {
     };
     let land_multiple = land_all || land_until.is_some();
     let total_entries = match land_until {
-        Some(end_pos) => end_pos.min(stack.entries.len()),
-        None if land_all => stack.entries.len(),
+        Some(end_pos) => {
+            mapped_land_total_entries(&stack.entries[..end_pos.min(stack.entries.len())])
+        }
+        None if land_all => mapped_land_total_entries(&stack.entries),
         None => default_land_total_entries(&stack),
     };
     let summary_total_entries = if land_multiple {
@@ -2328,6 +2337,48 @@ mod tests {
         };
 
         assert_eq!(default_land_total_entries(&stack), 2);
+    }
+
+    #[test]
+    fn mapped_land_total_entries_skips_unmapped_entries() {
+        use crate::stack::StackEntry;
+
+        let entries = vec![
+            StackEntry {
+                oid: git2::Oid::ZERO_SHA1,
+                short_sha: "sha1".to_string(),
+                title: "Entry 1".to_string(),
+                gg_id: Some("c-1111111".to_string()),
+                gg_parent: None,
+                mr_number: None,
+                mr_state: None,
+                approved: false,
+                changes_requested: false,
+                mergeable: false,
+                ci_status: None,
+                position: 1,
+                in_merge_train: false,
+                merge_train_position: None,
+            },
+            StackEntry {
+                oid: git2::Oid::ZERO_SHA1,
+                short_sha: "sha2".to_string(),
+                title: "Entry 2".to_string(),
+                gg_id: Some("c-2222222".to_string()),
+                gg_parent: None,
+                mr_number: Some(2),
+                mr_state: Some(PrState::Open),
+                approved: false,
+                changes_requested: false,
+                mergeable: false,
+                ci_status: None,
+                position: 2,
+                in_merge_train: false,
+                merge_train_position: None,
+            },
+        ];
+
+        assert_eq!(mapped_land_total_entries(&entries), 1);
     }
 
     #[test]

--- a/crates/gg-core/src/commands/land.rs
+++ b/crates/gg-core/src/commands/land.rs
@@ -701,7 +701,15 @@ pub fn run(opts: LandOptions) -> Result<()> {
         None if land_all => mapped_land_total_entries(&stack.entries),
         None => default_land_total_entries(&stack),
     };
-    let summary_total_entries = if land_multiple {
+    let summary_total_entries = if auto_merge_on_land && !merge_trains_enabled {
+        match land_until {
+            Some(end_pos) => {
+                mapped_land_total_entries(&stack.entries[..end_pos.min(stack.entries.len())])
+            }
+            None if land_all => mapped_land_total_entries(&stack.entries),
+            None => stack.entries.len(),
+        }
+    } else if land_multiple {
         total_entries
     } else {
         stack.entries.len()

--- a/crates/gg-core/src/commands/land.rs
+++ b/crates/gg-core/src/commands/land.rs
@@ -564,7 +564,9 @@ pub fn run(opts: LandOptions) -> Result<()> {
     let repo = git::open_repo()?;
     let git_dir = repo.commondir();
     let args: Vec<String> = std::env::args().skip(1).collect();
-    let mut lock = Some(git::acquire_operation_lock(&repo, "land")?);
+    let mut lock = Some(git::acquire_operation_lock_silent(
+        &repo, "land", structured,
+    )?);
     let mut config = Config::load_with_global(git_dir)?;
     let mut guard = if wait {
         None
@@ -927,7 +929,9 @@ pub fn run(opts: LandOptions) -> Result<()> {
                             streamer.as_mut(),
                             &mut readiness_poll,
                         );
-                        lock = Some(git::acquire_operation_lock(&repo, "land")?);
+                        lock = Some(git::acquire_operation_lock_silent(
+                            &repo, "land", structured,
+                        )?);
                         config = Config::load_with_global(git_dir)?;
                         stack = Stack::load(&repo, &config)?;
                         if let Err(e) = wait_result {
@@ -1055,7 +1059,9 @@ pub fn run(opts: LandOptions) -> Result<()> {
                             structured,
                             streamer.as_mut(),
                         );
-                        lock = Some(git::acquire_operation_lock(&repo, "land")?);
+                        lock = Some(git::acquire_operation_lock_silent(
+                            &repo, "land", structured,
+                        )?);
                         config = Config::load_with_global(git_dir)?;
                         stack = Stack::load(&repo, &config)?;
                         if let Err(e) = wait_result {
@@ -1298,7 +1304,9 @@ pub fn run(opts: LandOptions) -> Result<()> {
             drop(lock.take());
             let sleep_result =
                 interruptible_sleep(Duration::from_secs(2), interrupted.as_ref(), None);
-            lock = Some(git::acquire_operation_lock(&repo, "land")?);
+            lock = Some(git::acquire_operation_lock_silent(
+                &repo, "land", structured,
+            )?);
             config = Config::load_with_global(git_dir)?;
             stack = Stack::load(&repo, &config)?;
             if let Err(error) = sleep_result {

--- a/crates/gg-core/src/commands/land.rs
+++ b/crates/gg-core/src/commands/land.rs
@@ -551,6 +551,18 @@ fn finish_land_segment(
     )
 }
 
+fn default_land_total_entries(stack: &Stack) -> usize {
+    let mut total = 0;
+    for entry in &stack.entries {
+        total += 1;
+        match entry.mr_state {
+            Some(PrState::Merged | PrState::Closed) => {}
+            _ => break,
+        }
+    }
+    total
+}
+
 /// Run the land command
 pub fn run(opts: LandOptions) -> Result<()> {
     let LandOptions {
@@ -665,7 +677,7 @@ pub fn run(opts: LandOptions) -> Result<()> {
     let total_entries = match land_until {
         Some(end_pos) => end_pos.min(stack.entries.len()),
         None if land_all => stack.entries.len(),
-        None => 1,
+        None => default_land_total_entries(&stack),
     };
     emit_land_event(
         streamer.as_mut(),

--- a/crates/gg-core/src/commands/land.rs
+++ b/crates/gg-core/src/commands/land.rs
@@ -883,6 +883,7 @@ pub fn run(opts: LandOptions) -> Result<()> {
         let pr_info = provider.get_pr_info(pr_num)?;
         match pr_info.state {
             PrState::Merged => {
+                stack.entries[entry_idx].mr_state = Some(PrState::Merged);
                 if seen_already_merged.insert(gg_id.clone()) {
                     if !structured {
                         println!(
@@ -912,6 +913,7 @@ pub fn run(opts: LandOptions) -> Result<()> {
                 continue 'landing_loop;
             }
             PrState::Closed => {
+                stack.entries[entry_idx].mr_state = Some(PrState::Closed);
                 if seen_closed.insert(gg_id.clone()) {
                     if !structured {
                         println!(

--- a/crates/gg-core/src/commands/land.rs
+++ b/crates/gg-core/src/commands/land.rs
@@ -804,6 +804,12 @@ pub fn run(opts: LandOptions) -> Result<()> {
                     Some(PrState::Closed) => {
                         if let Some(gg_id) = &entry.gg_id {
                             if seen_closed.insert(gg_id.clone()) {
+                                warnings.push(format!(
+                                    "{} {}{} is closed; skipping",
+                                    provider.pr_label(),
+                                    provider.pr_number_prefix(),
+                                    num
+                                ));
                                 if !structured {
                                     println!(
                                         "{} {} {}{} ({}) — closed, skipping",
@@ -912,6 +918,12 @@ pub fn run(opts: LandOptions) -> Result<()> {
             }
             Some(PrState::Closed) => {
                 if seen_closed.insert(gg_id.clone()) {
+                    warnings.push(format!(
+                        "{} {}{} is closed; skipping",
+                        provider.pr_label(),
+                        provider.pr_number_prefix(),
+                        pr_num
+                    ));
                     if !structured {
                         println!(
                             "{} {} {}{} ({}) — closed, skipping",
@@ -1038,12 +1050,26 @@ pub fn run(opts: LandOptions) -> Result<()> {
                 } else if !land_all && (!admin || provider != Provider::GitHub) {
                     let approved = provider.check_pr_approved(pr_num)?;
                     if !approved {
-                        land_error = Some(format!(
+                        let error = format!(
                             "{} {}{} is not approved",
                             provider.pr_label(),
                             provider.pr_number_prefix(),
                             pr_num
-                        ));
+                        );
+                        record_landed_entry(
+                            &mut landed_entries,
+                            &mut streamer,
+                            LandedEntryJson {
+                                position: entry.position,
+                                sha: entry.short_sha.clone(),
+                                title: entry.title.clone(),
+                                gg_id: gg_id.clone(),
+                                pr_number: pr_num,
+                                action: "error".to_string(),
+                                error: Some(error.clone()),
+                            },
+                        );
+                        land_error = Some(error);
                         break 'landing_loop;
                     }
                 }

--- a/crates/gg-core/src/commands/land.rs
+++ b/crates/gg-core/src/commands/land.rs
@@ -14,7 +14,10 @@ use crate::error::{GgError, Result};
 use crate::git;
 use crate::glab::AutoMergeResult;
 use crate::operations::{OperationKind, RemoteEffect, SnapshotScope};
-use crate::output::{print_json, LandResponse, LandResultJson, LandedEntryJson, OUTPUT_VERSION};
+use crate::output::{
+    print_json, LandResponse, LandResultJson, LandStreamingEvent, LandStreamingResponse,
+    LandedEntryJson, StreamingJson, OUTPUT_VERSION,
+};
 use crate::provider::{CiStatus, PrState, Provider};
 use crate::stack::{resolve_target, Stack};
 
@@ -97,6 +100,56 @@ const MAX_CONSECUTIVE_API_ERRORS: u32 = 5;
 /// train is being recalculated). Treating Idle as a hard error is too
 /// aggressive and can fail healthy `gg land --wait --all` flows.
 const IDLE_STILL_WAITING_POLLS: u32 = 6;
+
+fn emit_land_event(streamer: Option<&mut StreamingJson>, event: LandStreamingEvent) {
+    if let Some(streamer) = streamer {
+        streamer.emit(&LandStreamingResponse {
+            version: OUTPUT_VERSION,
+            command: "land".to_string(),
+            event,
+        });
+    }
+}
+
+fn record_landed_entry(
+    landed_entries: &mut Vec<LandedEntryJson>,
+    streamer: &mut Option<StreamingJson>,
+    entry: LandedEntryJson,
+) {
+    emit_land_event(
+        streamer.as_mut(),
+        LandStreamingEvent::Entry {
+            entry: entry.clone(),
+        },
+    );
+    landed_entries.push(entry);
+}
+
+fn ci_status_name(status: &CiStatus) -> String {
+    match status {
+        CiStatus::Pending => "pending",
+        CiStatus::Running => "running",
+        CiStatus::Success => "success",
+        CiStatus::Failed => "failed",
+        CiStatus::Canceled => "canceled",
+        CiStatus::Unknown => "unknown",
+    }
+    .to_string()
+}
+
+fn merge_train_status_name(status: &crate::glab::MergeTrainStatus) -> String {
+    use crate::glab::MergeTrainStatus;
+    match status {
+        MergeTrainStatus::Idle => "idle",
+        MergeTrainStatus::Stale => "stale",
+        MergeTrainStatus::Fresh => "fresh",
+        MergeTrainStatus::Merging => "merging",
+        MergeTrainStatus::Merged => "merged",
+        MergeTrainStatus::SkipMerged => "skip_merged",
+        MergeTrainStatus::Unknown => "unknown",
+    }
+    .to_string()
+}
 
 fn merge_train_idle_state_message(idle_count: u32, seen_in_train: bool) -> &'static str {
     if seen_in_train {
@@ -377,6 +430,7 @@ fn rebase_remaining_branches(
 pub struct LandOptions {
     pub land_all: bool,
     pub json: bool,
+    pub jsonl: bool,
     pub squash: bool,
     pub wait: bool,
     pub auto_clean: bool,
@@ -464,6 +518,7 @@ pub fn run(opts: LandOptions) -> Result<()> {
     let LandOptions {
         land_all,
         json,
+        jsonl,
         squash,
         wait,
         auto_clean,
@@ -471,6 +526,7 @@ pub fn run(opts: LandOptions) -> Result<()> {
         until,
         admin,
     } = opts;
+    let structured = json || jsonl;
     let repo = git::open_repo()?;
     let git_dir = repo.commondir();
     let args: Vec<String> = std::env::args().skip(1).collect();
@@ -496,7 +552,7 @@ pub fn run(opts: LandOptions) -> Result<()> {
         provider == Provider::GitLab && (auto_merge_flag || config.get_gitlab_auto_merge_on_land());
 
     let merge_trains_enabled = provider.check_merge_trains_enabled().unwrap_or(false);
-    if merge_trains_enabled && !json {
+    if merge_trains_enabled && !structured {
         println!(
             "{}",
             style(format!(
@@ -508,13 +564,14 @@ pub fn run(opts: LandOptions) -> Result<()> {
     }
 
     let mut stack = Stack::load(&repo, &config)?;
+    let mut streamer = jsonl.then(StreamingJson::new);
     if stack.is_empty() {
         if json {
             print_json(&LandResponse {
                 version: OUTPUT_VERSION,
                 land: LandResultJson {
-                    stack: stack.name,
-                    base: stack.base,
+                    stack: stack.name.clone(),
+                    base: stack.base.clone(),
                     landed: vec![],
                     remaining: 0,
                     cleaned: false,
@@ -522,7 +579,7 @@ pub fn run(opts: LandOptions) -> Result<()> {
                     error: None,
                 },
             });
-        } else {
+        } else if !jsonl {
             println!("{}", style("Stack is empty. Nothing to land.").dim());
         }
         finish_land_segment(
@@ -532,10 +589,26 @@ pub fn run(opts: LandOptions) -> Result<()> {
             &mut remote_effects,
             &mut touched_remote,
         )?;
+        if jsonl {
+            emit_land_event(
+                streamer.as_mut(),
+                LandStreamingEvent::Summary {
+                    result: LandResultJson {
+                        stack: stack.name,
+                        base: stack.base,
+                        landed: vec![],
+                        remaining: 0,
+                        cleaned: false,
+                        warnings: vec![],
+                        error: None,
+                    },
+                },
+            );
+        }
         return Ok(());
     }
 
-    if !json {
+    if !structured {
         println!(
             "{}",
             style(format!("Checking {} status...", provider.pr_label())).dim()
@@ -549,11 +622,21 @@ pub fn run(opts: LandOptions) -> Result<()> {
         None
     };
     let land_multiple = land_all || land_until.is_some();
+    emit_land_event(
+        streamer.as_mut(),
+        LandStreamingEvent::Start {
+            stack: stack.name.clone(),
+            base: stack.base.clone(),
+            total_entries: land_until
+                .map(|end_pos| end_pos.min(stack.entries.len()))
+                .unwrap_or_else(|| stack.entries.len()),
+        },
+    );
 
     let interrupted = if wait {
         let flag = Arc::new(AtomicBool::new(false));
         let flag_clone = Arc::clone(&flag);
-        let json_mode = json;
+        let json_mode = structured;
         ctrlc::set_handler(move || {
             if flag_clone.load(Ordering::SeqCst) {
                 // Use abort() instead of process::exit(130) to avoid potential
@@ -599,7 +682,7 @@ pub fn run(opts: LandOptions) -> Result<()> {
                     } else if info.state == PrState::Merged {
                         if let Some(gg_id) = &entry.gg_id {
                             if seen_already_merged.insert(gg_id.clone()) {
-                                if !json {
+                                if !structured {
                                     println!(
                                         "{} {} {}{} ({}) — already merged",
                                         style("→").cyan(),
@@ -609,15 +692,19 @@ pub fn run(opts: LandOptions) -> Result<()> {
                                         entry.title
                                     );
                                 }
-                                landed_entries.push(LandedEntryJson {
-                                    position: entry.position,
-                                    sha: entry.short_sha.clone(),
-                                    title: entry.title.clone(),
-                                    gg_id: gg_id.clone(),
-                                    pr_number: num,
-                                    action: "already_merged".to_string(),
-                                    error: None,
-                                });
+                                record_landed_entry(
+                                    &mut landed_entries,
+                                    &mut streamer,
+                                    LandedEntryJson {
+                                        position: entry.position,
+                                        sha: entry.short_sha.clone(),
+                                        title: entry.title.clone(),
+                                        gg_id: gg_id.clone(),
+                                        pr_number: num,
+                                        action: "already_merged".to_string(),
+                                        error: None,
+                                    },
+                                );
                                 landed_count += 1;
                             }
                         }
@@ -625,7 +712,7 @@ pub fn run(opts: LandOptions) -> Result<()> {
                     } else if info.state == PrState::Closed {
                         if let Some(gg_id) = &entry.gg_id {
                             if seen_closed.insert(gg_id.clone()) {
-                                if !json {
+                                if !structured {
                                     println!(
                                         "{} {} {}{} ({}) — closed, skipping",
                                         style("⚠").yellow(),
@@ -635,15 +722,19 @@ pub fn run(opts: LandOptions) -> Result<()> {
                                         entry.title
                                     );
                                 }
-                                landed_entries.push(LandedEntryJson {
-                                    position: entry.position,
-                                    sha: entry.short_sha.clone(),
-                                    title: entry.title.clone(),
-                                    gg_id: gg_id.clone(),
-                                    pr_number: num,
-                                    action: "skipped_closed".to_string(),
-                                    error: None,
-                                });
+                                record_landed_entry(
+                                    &mut landed_entries,
+                                    &mut streamer,
+                                    LandedEntryJson {
+                                        position: entry.position,
+                                        sha: entry.short_sha.clone(),
+                                        title: entry.title.clone(),
+                                        gg_id: gg_id.clone(),
+                                        pr_number: num,
+                                        action: "skipped_closed".to_string(),
+                                        error: None,
+                                    },
+                                );
                             }
                         }
                         continue;
@@ -692,7 +783,7 @@ pub fn run(opts: LandOptions) -> Result<()> {
         match pr_info.state {
             PrState::Merged => {
                 if seen_already_merged.insert(gg_id.clone()) {
-                    if !json {
+                    if !structured {
                         println!(
                             "{} {} {}{} ({}) — already merged",
                             style("→").cyan(),
@@ -702,22 +793,26 @@ pub fn run(opts: LandOptions) -> Result<()> {
                             entry.title
                         );
                     }
-                    landed_entries.push(LandedEntryJson {
-                        position: entry.position,
-                        sha: entry.short_sha.clone(),
-                        title: entry.title.clone(),
-                        gg_id: gg_id.clone(),
-                        pr_number: pr_num,
-                        action: "already_merged".to_string(),
-                        error: None,
-                    });
+                    record_landed_entry(
+                        &mut landed_entries,
+                        &mut streamer,
+                        LandedEntryJson {
+                            position: entry.position,
+                            sha: entry.short_sha.clone(),
+                            title: entry.title.clone(),
+                            gg_id: gg_id.clone(),
+                            pr_number: pr_num,
+                            action: "already_merged".to_string(),
+                            error: None,
+                        },
+                    );
                     landed_count += 1;
                 }
                 continue 'landing_loop;
             }
             PrState::Closed => {
                 if seen_closed.insert(gg_id.clone()) {
-                    if !json {
+                    if !structured {
                         println!(
                             "{} {} {}{} ({}) — closed, skipping",
                             style("⚠").yellow(),
@@ -727,28 +822,36 @@ pub fn run(opts: LandOptions) -> Result<()> {
                             entry.title
                         );
                     }
-                    landed_entries.push(LandedEntryJson {
+                    record_landed_entry(
+                        &mut landed_entries,
+                        &mut streamer,
+                        LandedEntryJson {
+                            position: entry.position,
+                            sha: entry.short_sha.clone(),
+                            title: entry.title.clone(),
+                            gg_id: gg_id.clone(),
+                            pr_number: pr_num,
+                            action: "skipped_closed".to_string(),
+                            error: None,
+                        },
+                    );
+                }
+                continue 'landing_loop;
+            }
+            PrState::Draft => {
+                record_landed_entry(
+                    &mut landed_entries,
+                    &mut streamer,
+                    LandedEntryJson {
                         position: entry.position,
                         sha: entry.short_sha.clone(),
                         title: entry.title.clone(),
                         gg_id: gg_id.clone(),
                         pr_number: pr_num,
-                        action: "skipped_closed".to_string(),
+                        action: "skipped_draft".to_string(),
                         error: None,
-                    });
-                }
-                continue 'landing_loop;
-            }
-            PrState::Draft => {
-                landed_entries.push(LandedEntryJson {
-                    position: entry.position,
-                    sha: entry.short_sha.clone(),
-                    title: entry.title.clone(),
-                    gg_id: gg_id.clone(),
-                    pr_number: pr_num,
-                    action: "skipped_draft".to_string(),
-                    error: None,
-                });
+                    },
+                );
                 land_error = Some(format!(
                     "{} {}{} is a draft",
                     provider.pr_label(),
@@ -761,6 +864,7 @@ pub fn run(opts: LandOptions) -> Result<()> {
                 if wait {
                     let skip_approval = land_all || (admin && provider == Provider::GitHub);
                     let wait_started = Instant::now();
+                    let mut readiness_poll = 0;
                     loop {
                         let expected_stack = LandStackFingerprint::from(&stack);
                         finish_land_segment(
@@ -775,40 +879,51 @@ pub fn run(opts: LandOptions) -> Result<()> {
                         let timeout_minutes = config.get_land_wait_timeout_minutes();
                         let wait_result = wait_for_pr_ready(
                             &provider,
+                            entry.position,
                             pr_num,
                             skip_approval,
                             wait_started,
                             timeout_minutes,
                             interrupted.as_ref(),
                             &stack.base,
-                            json,
+                            structured,
+                            streamer.as_mut(),
+                            &mut readiness_poll,
                         );
                         lock = Some(git::acquire_operation_lock(&repo, "land")?);
                         config = Config::load_with_global(git_dir)?;
                         stack = Stack::load(&repo, &config)?;
                         if let Err(e) = wait_result {
-                            landed_entries.push(LandedEntryJson {
-                                position: entry.position,
-                                sha: entry.short_sha.clone(),
-                                title: entry.title.clone(),
-                                gg_id: gg_id.clone(),
-                                pr_number: pr_num,
-                                action: "error".to_string(),
-                                error: Some(e.to_string()),
-                            });
+                            record_landed_entry(
+                                &mut landed_entries,
+                                &mut streamer,
+                                LandedEntryJson {
+                                    position: entry.position,
+                                    sha: entry.short_sha.clone(),
+                                    title: entry.title.clone(),
+                                    gg_id: gg_id.clone(),
+                                    pr_number: pr_num,
+                                    action: "error".to_string(),
+                                    error: Some(e.to_string()),
+                                },
+                            );
                             land_error = Some(e.to_string());
                             break 'landing_loop;
                         }
                         if let Some(error) = stack_changed_while_waiting(&expected_stack, &stack) {
-                            landed_entries.push(LandedEntryJson {
-                                position: entry.position,
-                                sha: entry.short_sha.clone(),
-                                title: entry.title.clone(),
-                                gg_id: gg_id.clone(),
-                                pr_number: pr_num,
-                                action: "error".to_string(),
-                                error: Some(error.clone()),
-                            });
+                            record_landed_entry(
+                                &mut landed_entries,
+                                &mut streamer,
+                                LandedEntryJson {
+                                    position: entry.position,
+                                    sha: entry.short_sha.clone(),
+                                    title: entry.title.clone(),
+                                    gg_id: gg_id.clone(),
+                                    pr_number: pr_num,
+                                    action: "error".to_string(),
+                                    error: Some(error.clone()),
+                                },
+                            );
                             land_error = Some(error);
                             break 'landing_loop;
                         }
@@ -833,7 +948,7 @@ pub fn run(opts: LandOptions) -> Result<()> {
             }
         }
 
-        if !land_multiple && !wait && !json {
+        if !land_multiple && !wait && !structured {
             let confirm = Confirm::new()
                 .with_prompt(format!(
                     "Merge {} {}{} ({})? ",
@@ -868,15 +983,19 @@ pub fn run(opts: LandOptions) -> Result<()> {
                         AutoMergeResult::Queued => "queued",
                         AutoMergeResult::AlreadyQueued => "already_queued",
                     };
-                    landed_entries.push(LandedEntryJson {
-                        position: entry.position,
-                        sha: entry.short_sha.clone(),
-                        title: entry.title.clone(),
-                        gg_id: gg_id.clone(),
-                        pr_number: pr_num,
-                        action: action.to_string(),
-                        error: None,
-                    });
+                    record_landed_entry(
+                        &mut landed_entries,
+                        &mut streamer,
+                        LandedEntryJson {
+                            position: entry.position,
+                            sha: entry.short_sha.clone(),
+                            title: entry.title.clone(),
+                            gg_id: gg_id.clone(),
+                            pr_number: pr_num,
+                            action: action.to_string(),
+                            error: None,
+                        },
+                    );
                     if wait {
                         let expected_stack = LandStackFingerprint::from(&stack);
                         finish_land_segment(
@@ -891,11 +1010,13 @@ pub fn run(opts: LandOptions) -> Result<()> {
                         let timeout_minutes = config.get_land_wait_timeout_minutes();
                         let wait_result = wait_for_merge_train_completion(
                             &provider,
+                            entry.position,
                             pr_num,
                             timeout_minutes,
                             interrupted.as_ref(),
                             &stack.base,
-                            json,
+                            structured,
+                            streamer.as_mut(),
                         );
                         lock = Some(git::acquire_operation_lock(&repo, "land")?);
                         config = Config::load_with_global(git_dir)?;
@@ -924,7 +1045,7 @@ pub fn run(opts: LandOptions) -> Result<()> {
                             &gg_id,
                             pr_num,
                             land_multiple,
-                            json,
+                            structured,
                         );
                         if land_multiple {
                             let current_index = stack
@@ -937,7 +1058,7 @@ pub fn run(opts: LandOptions) -> Result<()> {
                                 &stack,
                                 &provider,
                                 current_index,
-                                json,
+                                structured,
                             ) {
                                 warnings
                                     .push(format!("Failed to rebase remaining branches: {}", e));
@@ -954,15 +1075,19 @@ pub fn run(opts: LandOptions) -> Result<()> {
                     }
                 }
                 Err(e) => {
-                    landed_entries.push(LandedEntryJson {
-                        position: entry.position,
-                        sha: entry.short_sha.clone(),
-                        title: entry.title.clone(),
-                        gg_id: gg_id.clone(),
-                        pr_number: pr_num,
-                        action: "error".to_string(),
-                        error: Some(e.to_string()),
-                    });
+                    record_landed_entry(
+                        &mut landed_entries,
+                        &mut streamer,
+                        LandedEntryJson {
+                            position: entry.position,
+                            sha: entry.short_sha.clone(),
+                            title: entry.title.clone(),
+                            gg_id: gg_id.clone(),
+                            pr_number: pr_num,
+                            action: "error".to_string(),
+                            error: Some(e.to_string()),
+                        },
+                    );
                     land_error = Some(e.to_string());
                     break 'landing_loop;
                 }
@@ -979,35 +1104,47 @@ pub fn run(opts: LandOptions) -> Result<()> {
                         .as_mut()
                         .expect("land segment guard")
                         .mark_touched_remote();
-                    landed_entries.push(LandedEntryJson {
-                        position: entry.position,
-                        sha: entry.short_sha.clone(),
-                        title: entry.title.clone(),
-                        gg_id: gg_id.clone(),
-                        pr_number: pr_num,
-                        action: "queued".to_string(),
-                        error: None,
-                    });
+                    record_landed_entry(
+                        &mut landed_entries,
+                        &mut streamer,
+                        LandedEntryJson {
+                            position: entry.position,
+                            sha: entry.short_sha.clone(),
+                            title: entry.title.clone(),
+                            gg_id: gg_id.clone(),
+                            pr_number: pr_num,
+                            action: "queued".to_string(),
+                            error: None,
+                        },
+                    );
                 }
-                Ok(AutoMergeResult::AlreadyQueued) => landed_entries.push(LandedEntryJson {
-                    position: entry.position,
-                    sha: entry.short_sha.clone(),
-                    title: entry.title.clone(),
-                    gg_id: gg_id.clone(),
-                    pr_number: pr_num,
-                    action: "already_queued".to_string(),
-                    error: None,
-                }),
-                Err(e) => {
-                    landed_entries.push(LandedEntryJson {
+                Ok(AutoMergeResult::AlreadyQueued) => record_landed_entry(
+                    &mut landed_entries,
+                    &mut streamer,
+                    LandedEntryJson {
                         position: entry.position,
                         sha: entry.short_sha.clone(),
                         title: entry.title.clone(),
                         gg_id: gg_id.clone(),
                         pr_number: pr_num,
-                        action: "error".to_string(),
-                        error: Some(e.to_string()),
-                    });
+                        action: "already_queued".to_string(),
+                        error: None,
+                    },
+                ),
+                Err(e) => {
+                    record_landed_entry(
+                        &mut landed_entries,
+                        &mut streamer,
+                        LandedEntryJson {
+                            position: entry.position,
+                            sha: entry.short_sha.clone(),
+                            title: entry.title.clone(),
+                            gg_id: gg_id.clone(),
+                            pr_number: pr_num,
+                            action: "error".to_string(),
+                            error: Some(e.to_string()),
+                        },
+                    );
                     land_error = Some(e.to_string());
                 }
             }
@@ -1035,15 +1172,19 @@ pub fn run(opts: LandOptions) -> Result<()> {
                         .expect("land segment guard")
                         .record_remote_effect(effect);
 
-                    landed_entries.push(LandedEntryJson {
-                        position: entry.position,
-                        sha: entry.short_sha.clone(),
-                        title: entry.title.clone(),
-                        gg_id: gg_id.clone(),
-                        pr_number: pr_num,
-                        action: "merged".to_string(),
-                        error: None,
-                    });
+                    record_landed_entry(
+                        &mut landed_entries,
+                        &mut streamer,
+                        LandedEntryJson {
+                            position: entry.position,
+                            sha: entry.short_sha.clone(),
+                            title: entry.title.clone(),
+                            gg_id: gg_id.clone(),
+                            pr_number: pr_num,
+                            action: "merged".to_string(),
+                            error: None,
+                        },
+                    );
                     landed_count += 1;
                     cleanup_after_merge(
                         &mut config,
@@ -1052,7 +1193,7 @@ pub fn run(opts: LandOptions) -> Result<()> {
                         &gg_id,
                         pr_num,
                         land_multiple,
-                        json,
+                        structured,
                     );
                     if land_multiple {
                         let current_index = stack
@@ -1060,9 +1201,13 @@ pub fn run(opts: LandOptions) -> Result<()> {
                             .iter()
                             .position(|e| e.mr_number == Some(pr_num))
                             .unwrap_or(0);
-                        if let Err(e) =
-                            rebase_remaining_branches(&repo, &stack, &provider, current_index, json)
-                        {
+                        if let Err(e) = rebase_remaining_branches(
+                            &repo,
+                            &stack,
+                            &provider,
+                            current_index,
+                            structured,
+                        ) {
                             warnings.push(format!("Failed to rebase remaining branches: {}", e));
                             land_error = Some(e.to_string());
                             break 'landing_loop;
@@ -1074,15 +1219,19 @@ pub fn run(opts: LandOptions) -> Result<()> {
                     }
                 }
                 Err(e) => {
-                    landed_entries.push(LandedEntryJson {
-                        position: entry.position,
-                        sha: entry.short_sha.clone(),
-                        title: entry.title.clone(),
-                        gg_id: gg_id.clone(),
-                        pr_number: pr_num,
-                        action: "error".to_string(),
-                        error: Some(e.to_string()),
-                    });
+                    record_landed_entry(
+                        &mut landed_entries,
+                        &mut streamer,
+                        LandedEntryJson {
+                            position: entry.position,
+                            sha: entry.short_sha.clone(),
+                            title: entry.title.clone(),
+                            gg_id: gg_id.clone(),
+                            pr_number: pr_num,
+                            action: "error".to_string(),
+                            error: Some(e.to_string()),
+                        },
+                    );
                     land_error = Some(e.to_string());
                     break 'landing_loop;
                 }
@@ -1125,7 +1274,7 @@ pub fn run(opts: LandOptions) -> Result<()> {
 
     let mut cleaned = false;
     if landed_count > 0 && landed_count >= stack.len() {
-        let should_clean = if json {
+        let should_clean = if structured {
             auto_clean
         } else if auto_clean {
             true
@@ -1149,8 +1298,12 @@ pub fn run(opts: LandOptions) -> Result<()> {
             // After landing, the stack contains merged commits by definition.
             // Bypass the immutability guard since the rebase here is a
             // sanctioned cleanup step, not a user-driven history rewrite.
-            let _ =
-                crate::commands::rebase::run_with_repo(&repo, Some(stack.base.clone()), json, true);
+            let _ = crate::commands::rebase::run_with_repo(
+                &repo,
+                Some(stack.base.clone()),
+                structured,
+                true,
+            );
             if crate::commands::clean::run_for_stack_with_repo_after_verified_land(
                 &repo,
                 &stack.name,
@@ -1171,7 +1324,8 @@ pub fn run(opts: LandOptions) -> Result<()> {
         }
     }
 
-    if json {
+    let mut jsonl_summary = None;
+    if structured {
         let target_len = if let Some(end_pos) = land_until {
             end_pos.min(stack.entries.len())
         } else {
@@ -1183,18 +1337,23 @@ pub fn run(opts: LandOptions) -> Result<()> {
                 .filter(|e| matches!(e.action.as_str(), "merged" | "already_merged"))
                 .count(),
         );
-        print_json(&LandResponse {
-            version: OUTPUT_VERSION,
-            land: LandResultJson {
-                stack: stack.name,
-                base: stack.base,
-                landed: landed_entries,
-                remaining,
-                cleaned,
-                warnings,
-                error: land_error.clone(),
-            },
-        });
+        let result = LandResultJson {
+            stack: stack.name,
+            base: stack.base,
+            landed: landed_entries,
+            remaining,
+            cleaned,
+            warnings,
+            error: land_error.clone(),
+        };
+        if json {
+            print_json(&LandResponse {
+                version: OUTPUT_VERSION,
+                land: result,
+            });
+        } else {
+            jsonl_summary = Some(result);
+        }
     } else if let Some(ref error) = land_error {
         // Report error in non-JSON mode
         if landed_count > 0 {
@@ -1235,11 +1394,13 @@ pub fn run(opts: LandOptions) -> Result<()> {
         &mut touched_remote,
     )?;
     drop(lock);
+    if let Some(result) = jsonl_summary {
+        emit_land_event(streamer.as_mut(), LandStreamingEvent::Summary { result });
+    }
 
-    // In JSON mode, the error is already included in the LandResponse payload.
-    // Returning Err would cause gg-cli to emit a second JSON error object,
-    // breaking machine consumers that expect a single JSON document.
-    if json {
+    // In structured modes, the error is already included in the final payload.
+    // Returning Err would cause gg-cli to emit a second error object.
+    if structured {
         Ok(())
     } else if let Some(_error) = land_error {
         Err(GgError::Silenced)
@@ -1253,6 +1414,7 @@ pub fn run(opts: LandOptions) -> Result<()> {
 #[allow(clippy::too_many_arguments)]
 fn wait_for_pr_ready(
     provider: &Provider,
+    position: usize,
     pr_num: u64,
     skip_approval: bool,
     start_time: Instant,
@@ -1260,6 +1422,8 @@ fn wait_for_pr_ready(
     interrupted: Option<&Arc<AtomicBool>>,
     target_branch: &str,
     json: bool,
+    mut streamer: Option<&mut StreamingJson>,
+    poll: &mut u64,
 ) -> Result<()> {
     let timeout = Duration::from_secs(timeout_minutes * 60);
     let poll_interval = Duration::from_secs(POLL_INTERVAL_SECS);
@@ -1310,50 +1474,79 @@ fn wait_for_pr_ready(
             }
         }
 
+        *poll += 1;
+
         let mut new_state = String::new();
         let mut ci_ready = false;
+        let mut merge_train_status = None;
+        let mut merge_train_position = None;
+        let mut pipeline_running = None;
+        let mut heartbeat_error = None;
 
         // Check merge train status if enabled
         if merge_trains_enabled {
-            if let Ok(Some(train_info)) = provider.get_merge_train_status(pr_num, target_branch) {
-                use crate::glab::MergeTrainStatus;
-                match train_info.status {
-                    MergeTrainStatus::Merged => {
-                        if let Some(ref spinner) = current_spinner {
-                            finish_spinner(
-                                spinner,
-                                &format!(
-                                    "{} {}{} merged via merge train",
-                                    provider.pr_label(),
-                                    provider.pr_number_prefix(),
-                                    pr_num
-                                ),
-                                state_start_time,
+            match provider.get_merge_train_status(pr_num, target_branch) {
+                Ok(Some(train_info)) => {
+                    use crate::glab::MergeTrainStatus;
+                    merge_train_status = Some(merge_train_status_name(&train_info.status));
+                    merge_train_position = train_info.position;
+                    pipeline_running = Some(train_info.pipeline_running);
+                    match train_info.status {
+                        MergeTrainStatus::Merged => {
+                            emit_land_event(
+                                streamer.as_deref_mut(),
+                                LandStreamingEvent::Wait {
+                                    position,
+                                    pr_number: pr_num,
+                                    phase: "readiness".to_string(),
+                                    poll: *poll,
+                                    elapsed_seconds: start_time.elapsed().as_secs(),
+                                    ci_status: None,
+                                    approved: None,
+                                    merge_train_status,
+                                    merge_train_position,
+                                    pipeline_running,
+                                    error: None,
+                                },
                             );
+                            if let Some(ref spinner) = current_spinner {
+                                finish_spinner(
+                                    spinner,
+                                    &format!(
+                                        "{} {}{} merged via merge train",
+                                        provider.pr_label(),
+                                        provider.pr_number_prefix(),
+                                        pr_num
+                                    ),
+                                    state_start_time,
+                                );
+                            }
+                            return Ok(());
                         }
-                        return Ok(());
-                    }
-                    MergeTrainStatus::Merging => {
-                        new_state = "Merge train: merging now...".to_string();
-                    }
-                    MergeTrainStatus::Fresh => {
-                        if let Some(pos) = train_info.position {
-                            new_state = format!("Merge train: position {} (fresh, ready)", pos);
+                        MergeTrainStatus::Merging => {
+                            new_state = "Merge train: merging now...".to_string();
+                        }
+                        MergeTrainStatus::Fresh => {
+                            if let Some(pos) = train_info.position {
+                                new_state = format!("Merge train: position {} (fresh, ready)", pos);
+                            }
+                        }
+                        MergeTrainStatus::Stale => {
+                            new_state = "Merge train: stale (needs rebase)".to_string();
+                        }
+                        _ => {
+                            if let Some(pos) = train_info.position {
+                                new_state = format!("Merge train: position {}", pos);
+                            }
                         }
                     }
-                    MergeTrainStatus::Stale => {
-                        new_state = "Merge train: stale (needs rebase)".to_string();
-                    }
-                    _ => {
-                        if let Some(pos) = train_info.position {
-                            new_state = format!("Merge train: position {}", pos);
-                        }
-                    }
-                }
 
-                if train_info.pipeline_running {
-                    new_state = format!("{} (pipeline running)", new_state);
+                    if train_info.pipeline_running {
+                        new_state = format!("{} (pipeline running)", new_state);
+                    }
                 }
+                Ok(None) => {}
+                Err(e) => heartbeat_error = Some(e.to_string()),
             }
         }
 
@@ -1362,6 +1555,27 @@ fn wait_for_pr_ready(
             Ok(status) => status,
             Err(e) => {
                 consecutive_errors += 1;
+                // Transient error — update spinner and retry on next poll
+                let error_state = format!(
+                    "API error (attempt {}/{}): {}",
+                    consecutive_errors, MAX_CONSECUTIVE_API_ERRORS, e
+                );
+                emit_land_event(
+                    streamer.as_deref_mut(),
+                    LandStreamingEvent::Wait {
+                        position,
+                        pr_number: pr_num,
+                        phase: "readiness".to_string(),
+                        poll: *poll,
+                        elapsed_seconds: start_time.elapsed().as_secs(),
+                        ci_status: None,
+                        approved: None,
+                        merge_train_status,
+                        merge_train_position,
+                        pipeline_running,
+                        error: Some(e.to_string()),
+                    },
+                );
                 if consecutive_errors >= MAX_CONSECUTIVE_API_ERRORS {
                     if let Some(ref spinner) = current_spinner {
                         spinner.finish_and_clear();
@@ -1371,11 +1585,6 @@ fn wait_for_pr_ready(
                         consecutive_errors, e
                     )));
                 }
-                // Transient error — update spinner and retry on next poll
-                let error_state = format!(
-                    "API error (attempt {}/{}): {}",
-                    consecutive_errors, MAX_CONSECUTIVE_API_ERRORS, e
-                );
                 if !json && current_state.as_ref() != Some(&error_state) {
                     if let Some(ref spinner) = current_spinner {
                         finish_spinner(
@@ -1392,6 +1601,7 @@ fn wait_for_pr_ready(
                 continue;
             }
         };
+        let ci_status_json = ci_status_name(&ci_status);
         match ci_status {
             CiStatus::Success => {
                 ci_ready = true;
@@ -1424,18 +1634,51 @@ fn wait_for_pr_ready(
                         ));
                     }
                 }
+                emit_land_event(
+                    streamer.as_deref_mut(),
+                    LandStreamingEvent::Wait {
+                        position,
+                        pr_number: pr_num,
+                        phase: "readiness".to_string(),
+                        poll: *poll,
+                        elapsed_seconds: start_time.elapsed().as_secs(),
+                        ci_status: Some(ci_status_json),
+                        approved: None,
+                        merge_train_status,
+                        merge_train_position,
+                        pipeline_running,
+                        error: Some(msg.clone()),
+                    },
+                );
                 return Err(GgError::Other(msg));
             }
             CiStatus::Canceled => {
                 if let Some(ref spinner) = current_spinner {
                     spinner.finish_and_clear();
                 }
-                return Err(GgError::Other(format!(
+                let msg = format!(
                     "{} {}{} CI was canceled",
                     provider.pr_label(),
                     provider.pr_number_prefix(),
                     pr_num
-                )));
+                );
+                emit_land_event(
+                    streamer.as_deref_mut(),
+                    LandStreamingEvent::Wait {
+                        position,
+                        pr_number: pr_num,
+                        phase: "readiness".to_string(),
+                        poll: *poll,
+                        elapsed_seconds: start_time.elapsed().as_secs(),
+                        ci_status: Some(ci_status_json),
+                        approved: None,
+                        merge_train_status,
+                        merge_train_position,
+                        pipeline_running,
+                        error: Some(msg.clone()),
+                    },
+                );
+                return Err(GgError::Other(msg));
             }
             CiStatus::Unknown => {
                 if new_state.is_empty() {
@@ -1446,13 +1689,34 @@ fn wait_for_pr_ready(
 
         // Check approval status (unless --all flag is used AND merge trains are off).
         // With merge trains, approval is always required to enter the queue.
-        let approval_ready = if skip_approval && !merge_trains_enabled {
-            true
+        let approved = if skip_approval && !merge_trains_enabled {
+            None
         } else {
             let approved = match provider.check_pr_approved(pr_num) {
                 Ok(approved) => approved,
                 Err(e) => {
                     consecutive_errors += 1;
+                    // Transient error — update spinner and retry on next poll
+                    let error_state = format!(
+                        "API error (attempt {}/{}): {}",
+                        consecutive_errors, MAX_CONSECUTIVE_API_ERRORS, e
+                    );
+                    emit_land_event(
+                        streamer.as_deref_mut(),
+                        LandStreamingEvent::Wait {
+                            position,
+                            pr_number: pr_num,
+                            phase: "readiness".to_string(),
+                            poll: *poll,
+                            elapsed_seconds: start_time.elapsed().as_secs(),
+                            ci_status: Some(ci_status_json),
+                            approved: None,
+                            merge_train_status,
+                            merge_train_position,
+                            pipeline_running,
+                            error: Some(e.to_string()),
+                        },
+                    );
                     if consecutive_errors >= MAX_CONSECUTIVE_API_ERRORS {
                         if let Some(ref spinner) = current_spinner {
                             spinner.finish_and_clear();
@@ -1462,11 +1726,6 @@ fn wait_for_pr_ready(
                             consecutive_errors, e
                         )));
                     }
-                    // Transient error — update spinner and retry on next poll
-                    let error_state = format!(
-                        "API error (attempt {}/{}): {}",
-                        consecutive_errors, MAX_CONSECUTIVE_API_ERRORS, e
-                    );
                     if !json && current_state.as_ref() != Some(&error_state) {
                         if let Some(ref spinner) = current_spinner {
                             finish_spinner(
@@ -1486,11 +1745,29 @@ fn wait_for_pr_ready(
             if !approved && ci_ready && new_state.is_empty() {
                 new_state = "Waiting for approval...".to_string();
             }
-            approved
+            Some(approved)
         };
+        let approval_ready = approved.unwrap_or(true);
 
         // All API calls succeeded this iteration — reset retry counter
         consecutive_errors = 0;
+
+        emit_land_event(
+            streamer.as_deref_mut(),
+            LandStreamingEvent::Wait {
+                position,
+                pr_number: pr_num,
+                phase: "readiness".to_string(),
+                poll: *poll,
+                elapsed_seconds: start_time.elapsed().as_secs(),
+                ci_status: Some(ci_status_json),
+                approved,
+                merge_train_status,
+                merge_train_position,
+                pipeline_running,
+                error: heartbeat_error,
+            },
+        );
 
         // If both CI and approval are ready, we're done
         if ci_ready && approval_ready {
@@ -1534,18 +1811,22 @@ fn wait_for_pr_ready(
 
 /// Wait for an MR to complete merging through the merge train
 /// Polls the merge train status until the MR is fully merged
+#[allow(clippy::too_many_arguments)]
 fn wait_for_merge_train_completion(
     provider: &Provider,
+    position: usize,
     pr_num: u64,
     timeout_minutes: u64,
     interrupted: Option<&Arc<AtomicBool>>,
     target_branch: &str,
     json: bool,
+    mut streamer: Option<&mut StreamingJson>,
 ) -> Result<()> {
     let start_time = Instant::now();
     let timeout = Duration::from_secs(timeout_minutes * 60);
     let poll_interval = Duration::from_secs(POLL_INTERVAL_SECS);
     let mut consecutive_errors: u32 = 0;
+    let mut poll = 0;
 
     // After adding to merge train, the MR may not appear in the train list
     // immediately. Idle/not-found is a polling state; the overall timeout is
@@ -1595,11 +1876,34 @@ fn wait_for_merge_train_completion(
             }
         }
 
+        poll += 1;
+
         // Check if MR is actually merged by checking its state first
         let pr_info = match provider.get_pr_info(pr_num) {
             Ok(info) => info,
             Err(e) => {
                 consecutive_errors += 1;
+                // Transient error — update spinner and retry on next poll
+                let error_state = format!(
+                    "API error (attempt {}/{}): {}",
+                    consecutive_errors, MAX_CONSECUTIVE_API_ERRORS, e
+                );
+                emit_land_event(
+                    streamer.as_deref_mut(),
+                    LandStreamingEvent::Wait {
+                        position,
+                        pr_number: pr_num,
+                        phase: "merge_train".to_string(),
+                        poll,
+                        elapsed_seconds: start_time.elapsed().as_secs(),
+                        ci_status: None,
+                        approved: None,
+                        merge_train_status: None,
+                        merge_train_position: None,
+                        pipeline_running: None,
+                        error: Some(e.to_string()),
+                    },
+                );
                 if consecutive_errors >= MAX_CONSECUTIVE_API_ERRORS {
                     if let Some(ref spinner) = current_spinner {
                         spinner.finish_and_clear();
@@ -1609,11 +1913,6 @@ fn wait_for_merge_train_completion(
                         consecutive_errors, e
                     )));
                 }
-                // Transient error — update spinner and retry on next poll
-                let error_state = format!(
-                    "API error (attempt {}/{}): {}",
-                    consecutive_errors, MAX_CONSECUTIVE_API_ERRORS, e
-                );
                 if !json && current_state.as_ref() != Some(&error_state) {
                     if let Some(ref spinner) = current_spinner {
                         finish_spinner(
@@ -1631,6 +1930,22 @@ fn wait_for_merge_train_completion(
             }
         };
         if pr_info.state == PrState::Merged {
+            emit_land_event(
+                streamer.as_deref_mut(),
+                LandStreamingEvent::Wait {
+                    position,
+                    pr_number: pr_num,
+                    phase: "merge_train".to_string(),
+                    poll,
+                    elapsed_seconds: start_time.elapsed().as_secs(),
+                    ci_status: None,
+                    approved: None,
+                    merge_train_status: None,
+                    merge_train_position: None,
+                    pipeline_running: None,
+                    error: None,
+                },
+            );
             if let Some(ref spinner) = current_spinner {
                 finish_spinner(
                     spinner,
@@ -1648,39 +1963,52 @@ fn wait_for_merge_train_completion(
 
         // Check if MR was closed (removed from train or rejected)
         if pr_info.state == PrState::Closed {
-            if let Some(ref spinner) = current_spinner {
-                spinner.finish_and_clear();
-            }
-            return Err(GgError::Other(format!(
+            let msg = format!(
                 "{} {}{} was closed (may have been removed from merge train)",
                 provider.pr_label(),
                 provider.pr_number_prefix(),
                 pr_num
-            )));
+            );
+            emit_land_event(
+                streamer.as_deref_mut(),
+                LandStreamingEvent::Wait {
+                    position,
+                    pr_number: pr_num,
+                    phase: "merge_train".to_string(),
+                    poll,
+                    elapsed_seconds: start_time.elapsed().as_secs(),
+                    ci_status: None,
+                    approved: None,
+                    merge_train_status: None,
+                    merge_train_position: None,
+                    pipeline_running: None,
+                    error: Some(msg.clone()),
+                },
+            );
+            if let Some(ref spinner) = current_spinner {
+                spinner.finish_and_clear();
+            }
+            return Err(GgError::Other(msg));
         }
 
         let mut new_state = String::new();
+        let mut merge_train_status = None;
+        let mut merge_train_position = None;
+        let mut pipeline_running = None;
+        let mut heartbeat_error = None;
+        let mut terminal_result = None;
 
         // Check merge train status
         let mut api_calls_succeeded = true;
         match provider.get_merge_train_status(pr_num, target_branch) {
             Ok(Some(train_info)) => {
                 use crate::glab::MergeTrainStatus;
+                merge_train_status = Some(merge_train_status_name(&train_info.status));
+                merge_train_position = train_info.position;
+                pipeline_running = Some(train_info.pipeline_running);
                 match train_info.status {
                     MergeTrainStatus::Merged => {
-                        if let Some(ref spinner) = current_spinner {
-                            finish_spinner(
-                                spinner,
-                                &format!(
-                                    "{} {}{} merged via merge train",
-                                    provider.pr_label(),
-                                    provider.pr_number_prefix(),
-                                    pr_num
-                                ),
-                                state_start_time,
-                            );
-                        }
-                        return Ok(());
+                        terminal_result = Some(Ok(()));
                     }
                     MergeTrainStatus::Merging => {
                         seen_in_train = true;
@@ -1700,31 +2028,29 @@ fn wait_for_merge_train_completion(
                         new_state = "Merge train: stale (waiting for rebase/pipeline)".to_string();
                     }
                     MergeTrainStatus::SkipMerged => {
-                        if let Some(ref spinner) = current_spinner {
-                            spinner.finish_and_clear();
-                        }
-                        return Err(GgError::Other(format!(
+                        let msg = format!(
                             "{} {}{} was skipped from the merge train",
                             provider.pr_label(),
                             provider.pr_number_prefix(),
                             pr_num
-                        )));
+                        );
+                        heartbeat_error = Some(msg.clone());
+                        terminal_result = Some(Err(GgError::Other(msg)));
                     }
                     MergeTrainStatus::Idle => {
                         idle_count += 1;
                         if let Some(message) = terminal_detailed_merge_status_message(
                             pr_info.detailed_merge_status.as_deref(),
                         ) {
-                            if let Some(ref spinner) = current_spinner {
-                                spinner.finish_and_clear();
-                            }
-                            return Err(GgError::Other(format!(
+                            let msg = format!(
                                 "{} {}{} cannot continue in the merge train: {}",
                                 provider.pr_label(),
                                 provider.pr_number_prefix(),
                                 pr_num,
                                 message
-                            )));
+                            );
+                            heartbeat_error = Some(msg.clone());
+                            terminal_result = Some(Err(GgError::Other(msg)));
                         }
                         new_state =
                             merge_train_idle_state_message(idle_count, seen_in_train).to_string();
@@ -1734,18 +2060,19 @@ fn wait_for_merge_train_completion(
                             api_calls_succeeded = false;
                             consecutive_errors += 1;
                             if consecutive_errors >= MAX_CONSECUTIVE_API_ERRORS {
-                                if let Some(ref spinner) = current_spinner {
-                                    spinner.finish_and_clear();
-                                }
-                                return Err(GgError::Other(format!(
+                                let msg = format!(
                                     "Too many consecutive API errors ({}) while checking merge train status",
                                     consecutive_errors
-                                )));
+                                );
+                                heartbeat_error = Some(msg.clone());
+                                terminal_result = Some(Err(GgError::Other(msg)));
+                            } else {
+                                new_state = format!(
+                                    "Merge train status unavailable (attempt {}/{}), retrying...",
+                                    consecutive_errors, MAX_CONSECUTIVE_API_ERRORS
+                                );
+                                heartbeat_error = Some(new_state.clone());
                             }
-                            new_state = format!(
-                                "Merge train status unavailable (attempt {}/{}), retrying...",
-                                consecutive_errors, MAX_CONSECUTIVE_API_ERRORS
-                            );
                         } else {
                             new_state = "Merge train returned an unrecognized status; waiting conservatively...".to_string();
                         }
@@ -1768,24 +2095,68 @@ fn wait_for_merge_train_completion(
                 api_calls_succeeded = false;
                 consecutive_errors += 1;
                 if consecutive_errors >= MAX_CONSECUTIVE_API_ERRORS {
-                    if let Some(ref spinner) = current_spinner {
-                        spinner.finish_and_clear();
-                    }
-                    return Err(GgError::Other(format!(
+                    let msg = format!(
                         "Too many consecutive API errors ({}) while checking merge train status: {}",
                         consecutive_errors, e
-                    )));
+                    );
+                    heartbeat_error = Some(msg.clone());
+                    terminal_result = Some(Err(GgError::Other(msg)));
+                } else {
+                    new_state = format!(
+                        "Merge train API error (attempt {}/{}): {}",
+                        consecutive_errors, MAX_CONSECUTIVE_API_ERRORS, e
+                    );
+                    heartbeat_error = Some(e.to_string());
                 }
-                new_state = format!(
-                    "Merge train API error (attempt {}/{}): {}",
-                    consecutive_errors, MAX_CONSECUTIVE_API_ERRORS, e
-                );
             }
         }
 
         // All API calls succeeded this iteration — reset retry counter
         if api_calls_succeeded {
             consecutive_errors = 0;
+        }
+
+        emit_land_event(
+            streamer.as_deref_mut(),
+            LandStreamingEvent::Wait {
+                position,
+                pr_number: pr_num,
+                phase: "merge_train".to_string(),
+                poll,
+                elapsed_seconds: start_time.elapsed().as_secs(),
+                ci_status: None,
+                approved: None,
+                merge_train_status,
+                merge_train_position,
+                pipeline_running,
+                error: heartbeat_error,
+            },
+        );
+
+        if let Some(result) = terminal_result {
+            match result {
+                Ok(()) => {
+                    if let Some(ref spinner) = current_spinner {
+                        finish_spinner(
+                            spinner,
+                            &format!(
+                                "{} {}{} merged via merge train",
+                                provider.pr_label(),
+                                provider.pr_number_prefix(),
+                                pr_num
+                            ),
+                            state_start_time,
+                        );
+                    }
+                    return Ok(());
+                }
+                Err(error) => {
+                    if let Some(ref spinner) = current_spinner {
+                        spinner.finish_and_clear();
+                    }
+                    return Err(error);
+                }
+            }
         }
 
         // Update spinner if state changed
@@ -2103,6 +2474,7 @@ mod tests {
         // Type assertion that the function signature includes target_branch: &str
         let _fn_ptr: fn(
             &Provider,
+            usize,
             u64,
             bool,
             Instant,
@@ -2110,6 +2482,8 @@ mod tests {
             Option<&Arc<AtomicBool>>,
             &str,
             bool,
+            Option<&mut StreamingJson>,
+            &mut u64,
         ) -> Result<()> = wait_for_pr_ready;
     }
 

--- a/crates/gg-core/src/commands/land.rs
+++ b/crates/gg-core/src/commands/land.rs
@@ -551,9 +551,9 @@ fn finish_land_segment(
     )
 }
 
-fn default_land_total_entries(stack: &Stack) -> usize {
+fn single_land_total_entries(entries: &[StackEntry]) -> usize {
     let mut total = 0;
-    for entry in &stack.entries {
+    for entry in entries {
         if entry.mr_number.is_none() {
             continue;
         }
@@ -564,6 +564,10 @@ fn default_land_total_entries(stack: &Stack) -> usize {
         }
     }
     total
+}
+
+fn default_land_total_entries(stack: &Stack) -> usize {
+    single_land_total_entries(&stack.entries)
 }
 
 fn mapped_land_total_entries(entries: &[StackEntry]) -> usize {
@@ -685,8 +689,14 @@ pub fn run(opts: LandOptions) -> Result<()> {
     };
     let land_multiple = land_all || land_until.is_some();
     let total_entries = match land_until {
+        Some(end_pos) if auto_merge_on_land && !merge_trains_enabled => {
+            single_land_total_entries(&stack.entries[..end_pos.min(stack.entries.len())])
+        }
         Some(end_pos) => {
             mapped_land_total_entries(&stack.entries[..end_pos.min(stack.entries.len())])
+        }
+        None if land_all && auto_merge_on_land && !merge_trains_enabled => {
+            default_land_total_entries(&stack)
         }
         None if land_all => mapped_land_total_entries(&stack.entries),
         None => default_land_total_entries(&stack),
@@ -2379,6 +2389,7 @@ mod tests {
         ];
 
         assert_eq!(mapped_land_total_entries(&entries), 1);
+        assert_eq!(single_land_total_entries(&entries), 1);
     }
 
     #[test]

--- a/crates/gg-core/src/commands/land.rs
+++ b/crates/gg-core/src/commands/land.rs
@@ -569,7 +569,7 @@ pub fn run(opts: LandOptions) -> Result<()> {
 
     let provider = Provider::detect(&repo)?;
     provider.check_installed()?;
-    provider.check_auth()?;
+    provider.check_auth_with_silent(structured)?;
 
     let auto_merge_on_land =
         provider == Provider::GitLab && (auto_merge_flag || config.get_gitlab_auto_merge_on_land());
@@ -1051,6 +1051,12 @@ pub fn run(opts: LandOptions) -> Result<()> {
                             land_error = Some(e.to_string());
                             break 'landing_loop;
                         }
+                        mark_landed_entry_merged(
+                            &mut landed_entries,
+                            streamer.as_mut(),
+                            entry.position,
+                            pr_num,
+                        );
                         if let Some(error) = stack_changed_while_waiting(&expected_stack, &stack) {
                             land_error = Some(error);
                             break 'landing_loop;
@@ -1064,12 +1070,6 @@ pub fn run(opts: LandOptions) -> Result<()> {
                             .expect("land segment guard")
                             .mark_touched_remote();
                         landed_count += 1;
-                        mark_landed_entry_merged(
-                            &mut landed_entries,
-                            streamer.as_mut(),
-                            entry.position,
-                            pr_num,
-                        );
                         cleanup_after_merge(
                             &mut config,
                             &stack,
@@ -1362,12 +1362,7 @@ pub fn run(opts: LandOptions) -> Result<()> {
 
     let mut jsonl_summary = None;
     if structured {
-        let target_len = if let Some(end_pos) = land_until {
-            end_pos.min(stack.entries.len())
-        } else {
-            stack.entries.len()
-        };
-        let remaining = target_len.saturating_sub(
+        let remaining = total_entries.saturating_sub(
             landed_entries
                 .iter()
                 .filter(|e| matches!(e.action.as_str(), "merged" | "already_merged"))

--- a/crates/gg-core/src/commands/land.rs
+++ b/crates/gg-core/src/commands/land.rs
@@ -577,6 +577,22 @@ fn mapped_land_total_entries(entries: &[StackEntry]) -> usize {
         .count()
 }
 
+fn unsynced_land_total_entries(entries: &[StackEntry]) -> usize {
+    let has_mapped_entry = entries.iter().any(|entry| entry.mr_number.is_some());
+    let mut seen_mapped_entry = false;
+    entries
+        .iter()
+        .filter(|entry| {
+            if entry.mr_number.is_some() {
+                seen_mapped_entry = true;
+                false
+            } else {
+                !has_mapped_entry || seen_mapped_entry
+            }
+        })
+        .count()
+}
+
 /// Run the land command
 pub fn run(opts: LandOptions) -> Result<()> {
     let LandOptions {
@@ -701,6 +717,7 @@ pub fn run(opts: LandOptions) -> Result<()> {
         None if land_all => mapped_land_total_entries(&stack.entries),
         None => default_land_total_entries(&stack),
     };
+    let unsynced_total_entries = unsynced_land_total_entries(&stack.entries);
     let summary_total_entries = if queues_one_entry {
         match land_until {
             Some(end_pos) => {
@@ -713,7 +730,7 @@ pub fn run(opts: LandOptions) -> Result<()> {
         total_entries
     } else {
         mapped_land_total_entries(&stack.entries)
-    };
+    } + unsynced_total_entries;
     emit_land_event(
         streamer.as_mut(),
         LandStreamingEvent::Start {
@@ -754,6 +771,17 @@ pub fn run(opts: LandOptions) -> Result<()> {
     let mut seen_closed: HashSet<String> = HashSet::new();
     let mut warnings: Vec<String> = vec![];
     let mut land_error: Option<String> = None;
+    if unsynced_total_entries > 0 {
+        warnings.push(format!(
+            "{} unsynced stack entr{} remaining. Run `gg sync` before landing them.",
+            unsynced_total_entries,
+            if unsynced_total_entries == 1 {
+                "y is"
+            } else {
+                "ies are"
+            }
+        ));
+    }
 
     'landing_loop: loop {
         let entries_to_land = if let Some(end_pos) = land_until {
@@ -2474,6 +2502,40 @@ mod tests {
 
         assert_eq!(mapped_land_total_entries(&entries), 1);
         assert_eq!(single_land_total_entries(&entries), 1);
+    }
+
+    #[test]
+    fn unsynced_land_total_entries_ignores_unmapped_prefix() {
+        use crate::stack::StackEntry;
+
+        fn entry(position: usize, mr_number: Option<u64>) -> StackEntry {
+            StackEntry {
+                oid: git2::Oid::ZERO_SHA1,
+                short_sha: format!("sha{position}"),
+                title: format!("Entry {position}"),
+                gg_id: Some(format!("c-{position:07}")),
+                gg_parent: None,
+                mr_number,
+                mr_state: mr_number.map(|_| PrState::Open),
+                approved: false,
+                changes_requested: false,
+                mergeable: false,
+                ci_status: None,
+                position,
+                in_merge_train: false,
+                merge_train_position: None,
+            }
+        }
+
+        assert_eq!(
+            unsynced_land_total_entries(&[entry(1, None), entry(2, Some(2)), entry(3, None)]),
+            1
+        );
+        assert_eq!(
+            unsynced_land_total_entries(&[entry(1, None), entry(2, Some(2))]),
+            0
+        );
+        assert_eq!(unsynced_land_total_entries(&[entry(1, None)]), 1);
     }
 
     #[test]

--- a/crates/gg-core/src/commands/land.rs
+++ b/crates/gg-core/src/commands/land.rs
@@ -554,6 +554,9 @@ fn finish_land_segment(
 fn default_land_total_entries(stack: &Stack) -> usize {
     let mut total = 0;
     for entry in &stack.entries {
+        if entry.mr_number.is_none() {
+            continue;
+        }
         total += 1;
         match entry.mr_state {
             Some(PrState::Merged | PrState::Closed) => {}
@@ -2271,6 +2274,45 @@ mod tests {
     #[test]
     fn test_constants() {
         assert_eq!(POLL_INTERVAL_SECS, 10);
+    }
+
+    #[test]
+    fn default_land_total_entries_skips_unmapped_entries() {
+        use crate::stack::StackEntry;
+
+        fn entry(position: usize, mr_number: Option<u64>, mr_state: Option<PrState>) -> StackEntry {
+            StackEntry {
+                oid: git2::Oid::ZERO_SHA1,
+                short_sha: format!("sha{position}"),
+                title: format!("Entry {position}"),
+                gg_id: Some(format!("c-{position:07}")),
+                gg_parent: None,
+                mr_number,
+                mr_state,
+                approved: false,
+                changes_requested: false,
+                mergeable: false,
+                ci_status: None,
+                position,
+                in_merge_train: false,
+                merge_train_position: None,
+            }
+        }
+
+        let stack = Stack {
+            name: "s".to_string(),
+            username: "u".to_string(),
+            base: "main".to_string(),
+            entries: vec![
+                entry(1, None, None),
+                entry(2, Some(2), Some(PrState::Merged)),
+                entry(3, Some(3), Some(PrState::Open)),
+                entry(4, Some(4), Some(PrState::Open)),
+            ],
+            current_position: Some(0),
+        };
+
+        assert_eq!(default_land_total_entries(&stack), 2);
     }
 
     #[test]

--- a/crates/gg-core/src/commands/land.rs
+++ b/crates/gg-core/src/commands/land.rs
@@ -125,6 +125,29 @@ fn record_landed_entry(
     landed_entries.push(entry);
 }
 
+fn mark_landed_entry_merged(
+    landed_entries: &mut [LandedEntryJson],
+    streamer: Option<&mut StreamingJson>,
+    position: usize,
+    pr_number: u64,
+) {
+    let Some(entry) = landed_entries.iter_mut().rev().find(|entry| {
+        entry.position == position
+            && entry.pr_number == pr_number
+            && matches!(entry.action.as_str(), "queued" | "already_queued")
+    }) else {
+        return;
+    };
+
+    entry.action = "merged".to_string();
+    emit_land_event(
+        streamer,
+        LandStreamingEvent::Entry {
+            entry: entry.clone(),
+        },
+    );
+}
+
 fn ci_status_name(status: &CiStatus) -> String {
     match status {
         CiStatus::Pending => "pending",
@@ -1038,6 +1061,12 @@ pub fn run(opts: LandOptions) -> Result<()> {
                             .expect("land segment guard")
                             .mark_touched_remote();
                         landed_count += 1;
+                        mark_landed_entry_merged(
+                            &mut landed_entries,
+                            streamer.as_mut(),
+                            entry.position,
+                            pr_num,
+                        );
                         cleanup_after_merge(
                             &mut config,
                             &stack,
@@ -1304,7 +1333,7 @@ pub fn run(opts: LandOptions) -> Result<()> {
                 structured,
                 true,
             );
-            if crate::commands::clean::run_for_stack_with_repo_after_verified_land(
+            match crate::commands::clean::run_for_stack_with_repo_after_verified_land(
                 &repo,
                 &stack.name,
                 true,
@@ -1317,10 +1346,12 @@ pub fn run(opts: LandOptions) -> Result<()> {
                     remote_effects.push(effect);
                     touched_remote = true;
                 },
-            )
-            .is_ok()
-            {
-                cleaned = true;
+            ) {
+                Ok(true) => cleaned = true,
+                Ok(false) => warnings.push(
+                    "Cleanup skipped because the configured worktree was retained".to_string(),
+                ),
+                Err(error) => warnings.push(format!("Cleanup skipped: {error}")),
             }
         }
     }
@@ -2583,6 +2614,23 @@ mod tests {
                 result
             );
         }
+    }
+
+    #[test]
+    fn merge_train_completion_replaces_queued_entry_with_merged() {
+        let mut entries = vec![LandedEntryJson {
+            position: 1,
+            sha: "abc1234".to_string(),
+            title: "queued entry".to_string(),
+            gg_id: "c-1234567".to_string(),
+            pr_number: 42,
+            action: "queued".to_string(),
+            error: None,
+        }];
+
+        mark_landed_entry_merged(&mut entries, None, 1, 42);
+
+        assert_eq!(entries[0].action, "merged");
     }
 
     // ==========================================================================

--- a/crates/gg-core/src/commands/land.rs
+++ b/crates/gg-core/src/commands/land.rs
@@ -310,7 +310,9 @@ fn rebase_remaining_branches(
     provider: &Provider,
     start_index: usize,
     json: bool,
-) -> Result<()> {
+) -> Result<Vec<String>> {
+    let mut warnings = Vec::new();
+
     // Fetch the latest base branch
     if !json {
         println!(
@@ -435,6 +437,7 @@ fn rebase_remaining_branches(
 
         if !push_result.status.success() {
             let stderr = String::from_utf8_lossy(&push_result.stderr);
+            let warning = format!("Failed to push {}: {}", branch_name, stderr.trim());
             if !json {
                 println!(
                     "{} Warning: Failed to push {}: {}",
@@ -443,6 +446,7 @@ fn rebase_remaining_branches(
                     stderr
                 );
             }
+            warnings.push(warning);
             // Continue with other branches even if one push fails
         }
     }
@@ -456,7 +460,7 @@ fn rebase_remaining_branches(
             .output();
     }
 
-    Ok(())
+    Ok(warnings)
 }
 
 /// Options for the land command
@@ -1102,17 +1106,22 @@ pub fn run(opts: LandOptions) -> Result<()> {
                                 .iter()
                                 .position(|e| e.mr_number == Some(pr_num))
                                 .unwrap_or(0);
-                            if let Err(e) = rebase_remaining_branches(
+                            match rebase_remaining_branches(
                                 &repo,
                                 &stack,
                                 &provider,
                                 current_index,
                                 structured,
                             ) {
-                                warnings
-                                    .push(format!("Failed to rebase remaining branches: {}", e));
-                                land_error = Some(e.to_string());
-                                break 'landing_loop;
+                                Ok(rebase_warnings) => warnings.extend(rebase_warnings),
+                                Err(e) => {
+                                    warnings.push(format!(
+                                        "Failed to rebase remaining branches: {}",
+                                        e
+                                    ));
+                                    land_error = Some(e.to_string());
+                                    break 'landing_loop;
+                                }
                             }
                             stack = Stack::load(&repo, &config)?;
                             if !stack.is_empty() {
@@ -1251,16 +1260,20 @@ pub fn run(opts: LandOptions) -> Result<()> {
                             .iter()
                             .position(|e| e.mr_number == Some(pr_num))
                             .unwrap_or(0);
-                        if let Err(e) = rebase_remaining_branches(
+                        match rebase_remaining_branches(
                             &repo,
                             &stack,
                             &provider,
                             current_index,
                             structured,
                         ) {
-                            warnings.push(format!("Failed to rebase remaining branches: {}", e));
-                            land_error = Some(e.to_string());
-                            break 'landing_loop;
+                            Ok(rebase_warnings) => warnings.extend(rebase_warnings),
+                            Err(e) => {
+                                warnings
+                                    .push(format!("Failed to rebase remaining branches: {}", e));
+                                land_error = Some(e.to_string());
+                                break 'landing_loop;
+                            }
                         }
                         stack = Stack::load(&repo, &config)?;
                         if !stack.is_empty() {
@@ -2417,7 +2430,7 @@ mod tests {
         // - start_index: usize (current merge position in stack)
 
         // Type-level assertion that rebase_remaining_branches exists with the correct signature
-        let _fn_ptr: fn(&git2::Repository, &Stack, &Provider, usize, bool) -> Result<()> =
+        let _fn_ptr: fn(&git2::Repository, &Stack, &Provider, usize, bool) -> Result<Vec<String>> =
             rebase_remaining_branches;
     }
 

--- a/crates/gg-core/src/commands/land.rs
+++ b/crates/gg-core/src/commands/land.rs
@@ -838,12 +838,28 @@ pub fn run(opts: LandOptions) -> Result<()> {
                         continue;
                     }
                     None => {
-                        land_error = Some(format!(
+                        let error = format!(
                             "Failed to fetch {} {}{}",
                             provider.pr_label(),
                             provider.pr_number_prefix(),
                             num
-                        ));
+                        );
+                        if let Some(gg_id) = &entry.gg_id {
+                            record_landed_entry(
+                                &mut landed_entries,
+                                &mut streamer,
+                                LandedEntryJson {
+                                    position: entry.position,
+                                    sha: entry.short_sha.clone(),
+                                    title: entry.title.clone(),
+                                    gg_id: gg_id.clone(),
+                                    pr_number: num,
+                                    action: "error".to_string(),
+                                    error: Some(error.clone()),
+                                },
+                            );
+                        }
+                        land_error = Some(error);
                         break 'landing_loop;
                     }
                 }
@@ -951,6 +967,12 @@ pub fn run(opts: LandOptions) -> Result<()> {
                 continue 'landing_loop;
             }
             Some(PrState::Draft) => {
+                let error = format!(
+                    "{} {}{} is a draft",
+                    provider.pr_label(),
+                    provider.pr_number_prefix(),
+                    pr_num
+                );
                 record_landed_entry(
                     &mut landed_entries,
                     &mut streamer,
@@ -961,15 +983,10 @@ pub fn run(opts: LandOptions) -> Result<()> {
                         gg_id: gg_id.clone(),
                         pr_number: pr_num,
                         action: "skipped_draft".to_string(),
-                        error: None,
+                        error: Some(error.clone()),
                     },
                 );
-                land_error = Some(format!(
-                    "{} {}{} is a draft",
-                    provider.pr_label(),
-                    provider.pr_number_prefix(),
-                    pr_num
-                ));
+                land_error = Some(error);
                 break 'landing_loop;
             }
             Some(PrState::Open) => {

--- a/crates/gg-core/src/commands/land.rs
+++ b/crates/gg-core/src/commands/land.rs
@@ -688,20 +688,20 @@ pub fn run(opts: LandOptions) -> Result<()> {
         None
     };
     let land_multiple = land_all || land_until.is_some();
+    let queues_one_entry =
+        (auto_merge_on_land && !merge_trains_enabled) || (merge_trains_enabled && !wait);
     let total_entries = match land_until {
-        Some(end_pos) if auto_merge_on_land && !merge_trains_enabled => {
+        Some(end_pos) if queues_one_entry => {
             single_land_total_entries(&stack.entries[..end_pos.min(stack.entries.len())])
         }
         Some(end_pos) => {
             mapped_land_total_entries(&stack.entries[..end_pos.min(stack.entries.len())])
         }
-        None if land_all && auto_merge_on_land && !merge_trains_enabled => {
-            default_land_total_entries(&stack)
-        }
+        None if land_all && queues_one_entry => default_land_total_entries(&stack),
         None if land_all => mapped_land_total_entries(&stack.entries),
         None => default_land_total_entries(&stack),
     };
-    let summary_total_entries = if auto_merge_on_land && !merge_trains_enabled {
+    let summary_total_entries = if queues_one_entry {
         match land_until {
             Some(end_pos) => {
                 mapped_land_total_entries(&stack.entries[..end_pos.min(stack.entries.len())])
@@ -880,10 +880,8 @@ pub fn run(opts: LandOptions) -> Result<()> {
             }
         };
 
-        let pr_info = provider.get_pr_info(pr_num)?;
-        match pr_info.state {
-            PrState::Merged => {
-                stack.entries[entry_idx].mr_state = Some(PrState::Merged);
+        match entry.mr_state {
+            Some(PrState::Merged) => {
                 if seen_already_merged.insert(gg_id.clone()) {
                     if !structured {
                         println!(
@@ -912,8 +910,7 @@ pub fn run(opts: LandOptions) -> Result<()> {
                 }
                 continue 'landing_loop;
             }
-            PrState::Closed => {
-                stack.entries[entry_idx].mr_state = Some(PrState::Closed);
+            Some(PrState::Closed) => {
                 if seen_closed.insert(gg_id.clone()) {
                     if !structured {
                         println!(
@@ -941,7 +938,7 @@ pub fn run(opts: LandOptions) -> Result<()> {
                 }
                 continue 'landing_loop;
             }
-            PrState::Draft => {
+            Some(PrState::Draft) => {
                 record_landed_entry(
                     &mut landed_entries,
                     &mut streamer,
@@ -963,7 +960,7 @@ pub fn run(opts: LandOptions) -> Result<()> {
                 ));
                 break 'landing_loop;
             }
-            PrState::Open => {
+            Some(PrState::Open) => {
                 if wait {
                     let skip_approval = land_all || (admin && provider == Provider::GitHub);
                     let wait_started = Instant::now();
@@ -1050,6 +1047,15 @@ pub fn run(opts: LandOptions) -> Result<()> {
                         break 'landing_loop;
                     }
                 }
+            }
+            None => {
+                land_error = Some(format!(
+                    "Failed to fetch {} {}{}",
+                    provider.pr_label(),
+                    provider.pr_number_prefix(),
+                    pr_num
+                ));
+                break 'landing_loop;
             }
         }
 

--- a/crates/gg-core/src/commands/land.rs
+++ b/crates/gg-core/src/commands/land.rs
@@ -707,12 +707,12 @@ pub fn run(opts: LandOptions) -> Result<()> {
                 mapped_land_total_entries(&stack.entries[..end_pos.min(stack.entries.len())])
             }
             None if land_all => mapped_land_total_entries(&stack.entries),
-            None => stack.entries.len(),
+            None => mapped_land_total_entries(&stack.entries),
         }
     } else if land_multiple {
         total_entries
     } else {
-        stack.entries.len()
+        mapped_land_total_entries(&stack.entries)
     };
     emit_land_event(
         streamer.as_mut(),
@@ -765,79 +765,78 @@ pub fn run(opts: LandOptions) -> Result<()> {
         let mut next_entry_idx = None;
         for (idx, entry) in entries_to_land.iter().enumerate() {
             if let Some(num) = entry.mr_number {
-                match provider.get_pr_info(num) {
-                    Ok(info) => {
-                        if info.state == PrState::Open || info.state == PrState::Draft {
-                            next_entry_idx = Some(idx);
-                            break;
-                        } else if info.state == PrState::Merged {
-                            if let Some(gg_id) = &entry.gg_id {
-                                if seen_already_merged.insert(gg_id.clone()) {
-                                    if !structured {
-                                        println!(
-                                            "{} {} {}{} ({}) — already merged",
-                                            style("→").cyan(),
-                                            provider.pr_label(),
-                                            provider.pr_number_prefix(),
-                                            num,
-                                            entry.title
-                                        );
-                                    }
-                                    record_landed_entry(
-                                        &mut landed_entries,
-                                        &mut streamer,
-                                        LandedEntryJson {
-                                            position: entry.position,
-                                            sha: entry.short_sha.clone(),
-                                            title: entry.title.clone(),
-                                            gg_id: gg_id.clone(),
-                                            pr_number: num,
-                                            action: "already_merged".to_string(),
-                                            error: None,
-                                        },
-                                    );
-                                    landed_count += 1;
-                                }
-                            }
-                            continue;
-                        } else if info.state == PrState::Closed {
-                            if let Some(gg_id) = &entry.gg_id {
-                                if seen_closed.insert(gg_id.clone()) {
-                                    if !structured {
-                                        println!(
-                                            "{} {} {}{} ({}) — closed, skipping",
-                                            style("⚠").yellow(),
-                                            provider.pr_label(),
-                                            provider.pr_number_prefix(),
-                                            num,
-                                            entry.title
-                                        );
-                                    }
-                                    record_landed_entry(
-                                        &mut landed_entries,
-                                        &mut streamer,
-                                        LandedEntryJson {
-                                            position: entry.position,
-                                            sha: entry.short_sha.clone(),
-                                            title: entry.title.clone(),
-                                            gg_id: gg_id.clone(),
-                                            pr_number: num,
-                                            action: "skipped_closed".to_string(),
-                                            error: None,
-                                        },
-                                    );
-                                }
-                            }
-                            continue;
-                        }
+                match entry.mr_state {
+                    Some(PrState::Open | PrState::Draft) => {
+                        next_entry_idx = Some(idx);
+                        break;
                     }
-                    Err(e) => {
+                    Some(PrState::Merged) => {
+                        if let Some(gg_id) = &entry.gg_id {
+                            if seen_already_merged.insert(gg_id.clone()) {
+                                if !structured {
+                                    println!(
+                                        "{} {} {}{} ({}) — already merged",
+                                        style("→").cyan(),
+                                        provider.pr_label(),
+                                        provider.pr_number_prefix(),
+                                        num,
+                                        entry.title
+                                    );
+                                }
+                                record_landed_entry(
+                                    &mut landed_entries,
+                                    &mut streamer,
+                                    LandedEntryJson {
+                                        position: entry.position,
+                                        sha: entry.short_sha.clone(),
+                                        title: entry.title.clone(),
+                                        gg_id: gg_id.clone(),
+                                        pr_number: num,
+                                        action: "already_merged".to_string(),
+                                        error: None,
+                                    },
+                                );
+                                landed_count += 1;
+                            }
+                        }
+                        continue;
+                    }
+                    Some(PrState::Closed) => {
+                        if let Some(gg_id) = &entry.gg_id {
+                            if seen_closed.insert(gg_id.clone()) {
+                                if !structured {
+                                    println!(
+                                        "{} {} {}{} ({}) — closed, skipping",
+                                        style("⚠").yellow(),
+                                        provider.pr_label(),
+                                        provider.pr_number_prefix(),
+                                        num,
+                                        entry.title
+                                    );
+                                }
+                                record_landed_entry(
+                                    &mut landed_entries,
+                                    &mut streamer,
+                                    LandedEntryJson {
+                                        position: entry.position,
+                                        sha: entry.short_sha.clone(),
+                                        title: entry.title.clone(),
+                                        gg_id: gg_id.clone(),
+                                        pr_number: num,
+                                        action: "skipped_closed".to_string(),
+                                        error: None,
+                                    },
+                                );
+                            }
+                        }
+                        continue;
+                    }
+                    None => {
                         land_error = Some(format!(
-                            "Failed to fetch {} {}{}: {}",
+                            "Failed to fetch {} {}{}",
                             provider.pr_label(),
                             provider.pr_number_prefix(),
-                            num,
-                            e
+                            num
                         ));
                         break 'landing_loop;
                     }

--- a/crates/gg-core/src/commands/land.rs
+++ b/crates/gg-core/src/commands/land.rs
@@ -1150,7 +1150,7 @@ pub fn run(opts: LandOptions) -> Result<()> {
             }
             break 'landing_loop;
         } else {
-            if admin {
+            if admin && !structured {
                 eprintln!("⚠ Merging with admin override — bypassing approval requirements");
             }
             match provider.merge_pr(pr_num, squash, false, admin) {
@@ -1308,6 +1308,7 @@ pub fn run(opts: LandOptions) -> Result<()> {
                 &repo,
                 &stack.name,
                 true,
+                structured,
                 &mut |effect| {
                     guard
                         .as_mut()

--- a/crates/gg-core/src/commands/land.rs
+++ b/crates/gg-core/src/commands/land.rs
@@ -1065,7 +1065,33 @@ pub fn run(opts: LandOptions) -> Result<()> {
                         }
                     }
                 } else if !land_all && (!admin || provider != Provider::GitHub) {
-                    let approved = provider.check_pr_approved(pr_num)?;
+                    let approved = match provider.check_pr_approved(pr_num) {
+                        Ok(approved) => approved,
+                        Err(error) => {
+                            let error = format!(
+                                "Failed to check approval for {} {}{}: {}",
+                                provider.pr_label(),
+                                provider.pr_number_prefix(),
+                                pr_num,
+                                error
+                            );
+                            record_landed_entry(
+                                &mut landed_entries,
+                                &mut streamer,
+                                LandedEntryJson {
+                                    position: entry.position,
+                                    sha: entry.short_sha.clone(),
+                                    title: entry.title.clone(),
+                                    gg_id: gg_id.clone(),
+                                    pr_number: pr_num,
+                                    action: "error".to_string(),
+                                    error: Some(error.clone()),
+                                },
+                            );
+                            land_error = Some(error);
+                            break 'landing_loop;
+                        }
+                    };
                     if !approved {
                         let error = format!(
                             "{} {}{} is not approved",

--- a/crates/gg-core/src/commands/land.rs
+++ b/crates/gg-core/src/commands/land.rs
@@ -645,14 +645,17 @@ pub fn run(opts: LandOptions) -> Result<()> {
         None
     };
     let land_multiple = land_all || land_until.is_some();
+    let total_entries = match land_until {
+        Some(end_pos) => end_pos.min(stack.entries.len()),
+        None if land_all => stack.entries.len(),
+        None => 1,
+    };
     emit_land_event(
         streamer.as_mut(),
         LandStreamingEvent::Start {
             stack: stack.name.clone(),
             base: stack.base.clone(),
-            total_entries: land_until
-                .map(|end_pos| end_pos.min(stack.entries.len()))
-                .unwrap_or_else(|| stack.entries.len()),
+            total_entries,
         },
     );
 

--- a/crates/gg-core/src/git.rs
+++ b/crates/gg-core/src/git.rs
@@ -68,14 +68,32 @@ impl Drop for OperationLock {
 ///
 /// Returns a lock handle that will automatically release when dropped.
 pub fn acquire_operation_lock(repo: &Repository, operation: &str) -> Result<OperationLock> {
-    acquire_operation_lock_with_timeout(repo, operation, INDEX_LOCK_TIMEOUT_SECS)
+    acquire_operation_lock_with_timeout_and_silent(repo, operation, INDEX_LOCK_TIMEOUT_SECS, false)
+}
+
+pub fn acquire_operation_lock_silent(
+    repo: &Repository,
+    operation: &str,
+    silent: bool,
+) -> Result<OperationLock> {
+    acquire_operation_lock_with_timeout_and_silent(repo, operation, INDEX_LOCK_TIMEOUT_SECS, silent)
 }
 
 /// Internal version with configurable timeout (for testing)
+#[cfg(test)]
 pub(crate) fn acquire_operation_lock_with_timeout(
     repo: &Repository,
     operation: &str,
     timeout_secs: u64,
+) -> Result<OperationLock> {
+    acquire_operation_lock_with_timeout_and_silent(repo, operation, timeout_secs, false)
+}
+
+pub(crate) fn acquire_operation_lock_with_timeout_and_silent(
+    repo: &Repository,
+    operation: &str,
+    timeout_secs: u64,
+    silent: bool,
 ) -> Result<OperationLock> {
     // --- Step 1: Check for index.lock (detect if git is running) ---
     // Use repo.path() for per-worktree index.lock
@@ -87,7 +105,7 @@ pub(crate) fn acquire_operation_lock_with_timeout(
     // Wait for any existing index.lock to be released
     let mut warned = false;
     while index_lock_path.exists() {
-        if !warned {
+        if !silent && !warned {
             eprintln!(
                 "{} Waiting for git operation to complete (index.lock exists)...",
                 console::style("Note:").cyan().bold()

--- a/crates/gg-core/src/output.rs
+++ b/crates/gg-core/src/output.rs
@@ -399,6 +399,7 @@ impl Serialize for LandStreamingResponse {
             LandStreamingEvent::Wait { error: Some(_), .. } => "warning",
             LandStreamingEvent::Entry { entry } if entry.error.is_some() => "error",
             LandStreamingEvent::Summary { result } if result.error.is_some() => "error",
+            LandStreamingEvent::Summary { result } if !result.warnings.is_empty() => "warning",
             _ => "ok",
         };
         let mut value = serde_json::to_value(&self.event).map_err(serde::ser::Error::custom)?;
@@ -679,6 +680,29 @@ mod tests {
         assert_eq!(json["event"], "summary");
         assert_eq!(json["stack"], "feat-stack");
         assert_eq!(json["landed"][0]["action"], "merged");
+    }
+
+    #[test]
+    fn land_summary_with_warnings_has_warning_status() {
+        let response = LandStreamingResponse {
+            version: OUTPUT_VERSION,
+            command: "land".to_string(),
+            event: LandStreamingEvent::Summary {
+                result: LandResultJson {
+                    stack: "feat-stack".to_string(),
+                    base: "main".to_string(),
+                    landed: vec![],
+                    remaining: 0,
+                    cleaned: false,
+                    warnings: vec!["cleanup skipped".to_string()],
+                    error: None,
+                },
+            },
+        };
+
+        let json = serde_json::to_value(&response).expect("should serialize");
+
+        assert_eq!(json["status"], "warning");
     }
 
     #[test]

--- a/crates/gg-core/src/output.rs
+++ b/crates/gg-core/src/output.rs
@@ -384,7 +384,66 @@ pub struct LandResponse {
     pub land: LandResultJson,
 }
 
+pub struct LandStreamingResponse {
+    pub version: u32,
+    pub command: String,
+    pub event: LandStreamingEvent,
+}
+
+impl Serialize for LandStreamingResponse {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let status = match &self.event {
+            LandStreamingEvent::Wait { error: Some(_), .. } => "warning",
+            LandStreamingEvent::Entry { entry } if entry.error.is_some() => "error",
+            LandStreamingEvent::Summary { result } if result.error.is_some() => "error",
+            _ => "ok",
+        };
+        let mut value = serde_json::to_value(&self.event).map_err(serde::ser::Error::custom)?;
+        let object = value
+            .as_object_mut()
+            .ok_or_else(|| serde::ser::Error::custom("streaming event serialized non-object"))?;
+        object.insert("version".to_string(), serde_json::json!(self.version));
+        object.insert("command".to_string(), serde_json::json!(self.command));
+        object.insert("status".to_string(), serde_json::json!(status));
+        value.serialize(serializer)
+    }
+}
+
 #[derive(Serialize)]
+#[serde(rename_all = "snake_case", tag = "event")]
+pub enum LandStreamingEvent {
+    Start {
+        stack: String,
+        base: String,
+        total_entries: usize,
+    },
+    Wait {
+        position: usize,
+        pr_number: u64,
+        phase: String,
+        poll: u64,
+        elapsed_seconds: u64,
+        ci_status: Option<String>,
+        approved: Option<bool>,
+        merge_train_status: Option<String>,
+        merge_train_position: Option<usize>,
+        pipeline_running: Option<bool>,
+        error: Option<String>,
+    },
+    Entry {
+        #[serde(flatten)]
+        entry: LandedEntryJson,
+    },
+    Summary {
+        #[serde(flatten)]
+        result: LandResultJson,
+    },
+}
+
+#[derive(Clone, Serialize)]
 pub struct LandResultJson {
     pub stack: String,
     pub base: String,
@@ -395,7 +454,7 @@ pub struct LandResultJson {
     pub error: Option<String>,
 }
 
-#[derive(Serialize)]
+#[derive(Clone, Serialize)]
 pub struct LandedEntryJson {
     pub position: usize,
     pub sha: String,
@@ -550,6 +609,76 @@ mod tests {
             self.flushed = true;
             Ok(())
         }
+    }
+
+    #[test]
+    fn land_wait_event_serializes_structured_heartbeat() {
+        let response = LandStreamingResponse {
+            version: OUTPUT_VERSION,
+            command: "land".to_string(),
+            event: LandStreamingEvent::Wait {
+                position: 2,
+                pr_number: 42,
+                phase: "readiness".to_string(),
+                poll: 3,
+                elapsed_seconds: 20,
+                ci_status: Some("running".to_string()),
+                approved: Some(false),
+                merge_train_status: None,
+                merge_train_position: None,
+                pipeline_running: None,
+                error: None,
+            },
+        };
+
+        let json = serde_json::to_value(&response).expect("should serialize");
+
+        assert_eq!(json["version"], 1);
+        assert_eq!(json["command"], "land");
+        assert_eq!(json["status"], "ok");
+        assert_eq!(json["event"], "wait");
+        assert_eq!(json["position"], 2);
+        assert_eq!(json["pr_number"], 42);
+        assert_eq!(json["phase"], "readiness");
+        assert_eq!(json["poll"], 3);
+        assert_eq!(json["elapsed_seconds"], 20);
+        assert_eq!(json["ci_status"], "running");
+        assert_eq!(json["approved"], false);
+        assert!(json["merge_train_status"].is_null());
+    }
+
+    #[test]
+    fn land_summary_event_reuses_atomic_result() {
+        let response = LandStreamingResponse {
+            version: OUTPUT_VERSION,
+            command: "land".to_string(),
+            event: LandStreamingEvent::Summary {
+                result: LandResultJson {
+                    stack: "feat-stack".to_string(),
+                    base: "main".to_string(),
+                    landed: vec![LandedEntryJson {
+                        position: 1,
+                        sha: "abc1234".to_string(),
+                        title: "First".to_string(),
+                        gg_id: "c-abc1234".to_string(),
+                        pr_number: 42,
+                        action: "merged".to_string(),
+                        error: None,
+                    }],
+                    remaining: 0,
+                    cleaned: false,
+                    warnings: vec![],
+                    error: None,
+                },
+            },
+        };
+
+        let json = serde_json::to_value(&response).expect("should serialize");
+
+        assert_eq!(json["status"], "ok");
+        assert_eq!(json["event"], "summary");
+        assert_eq!(json["stack"], "feat-stack");
+        assert_eq!(json["landed"][0]["action"], "merged");
     }
 
     #[test]

--- a/crates/gg-core/src/output.rs
+++ b/crates/gg-core/src/output.rs
@@ -398,6 +398,7 @@ impl Serialize for LandStreamingResponse {
         let status = match &self.event {
             LandStreamingEvent::Wait { error: Some(_), .. } => "warning",
             LandStreamingEvent::Entry { entry } if entry.error.is_some() => "error",
+            LandStreamingEvent::Entry { entry } if entry.action == "skipped_closed" => "warning",
             LandStreamingEvent::Summary { result } if result.error.is_some() => "error",
             LandStreamingEvent::Summary { result } if !result.warnings.is_empty() => "warning",
             _ => "ok",

--- a/crates/gg-core/src/provider.rs
+++ b/crates/gg-core/src/provider.rs
@@ -17,11 +17,13 @@ pub use crate::glab::FailedJob;
 ///
 /// On network errors, prints a warning and returns Ok(()) to allow
 /// the operation to continue (auth may still be valid, we just can't verify).
-fn check_auth_with_network_fallback(result: Result<()>) -> Result<()> {
+fn check_auth_with_network_fallback(result: Result<()>, silent: bool) -> Result<()> {
     match result {
         Ok(()) => Ok(()),
         Err(GgError::NetworkError(msg)) => {
-            eprintln!("{} {}", console::style("Warning:").yellow().bold(), msg);
+            if !silent {
+                eprintln!("{} {}", console::style("Warning:").yellow().bold(), msg);
+            }
             Ok(())
         }
         Err(e) => Err(e),
@@ -153,9 +155,15 @@ impl Provider {
     /// On network errors, prints a warning and returns Ok(()) to allow
     /// the operation to continue (auth may still be valid, we just can't verify).
     pub fn check_auth(&self) -> Result<()> {
+        self.check_auth_with_silent(false)
+    }
+
+    /// Check if authenticated with provider, optionally suppressing the
+    /// recoverable network warning for structured output modes.
+    pub fn check_auth_with_silent(&self, silent: bool) -> Result<()> {
         match self {
-            Provider::GitHub => check_auth_with_network_fallback(gh::check_gh_auth()),
-            Provider::GitLab => check_auth_with_network_fallback(glab::check_glab_auth()),
+            Provider::GitHub => check_auth_with_network_fallback(gh::check_gh_auth(), silent),
+            Provider::GitLab => check_auth_with_network_fallback(glab::check_glab_auth(), silent),
         }
     }
 
@@ -769,22 +777,41 @@ mod tests {
 
     #[test]
     fn test_check_auth_with_network_fallback_returns_ok_on_network_error() {
-        let result = check_auth_with_network_fallback(Err(GgError::NetworkError(
-            "Could not verify authentication (network error)".to_string(),
-        )));
+        let result = check_auth_with_network_fallback(
+            Err(GgError::NetworkError(
+                "Could not verify authentication (network error)".to_string(),
+            )),
+            false,
+        );
         assert!(result.is_ok(), "NetworkError should be converted to Ok(())");
     }
 
     #[test]
+    fn test_check_auth_with_network_fallback_silent_returns_ok_on_network_error() {
+        let result = check_auth_with_network_fallback(
+            Err(GgError::NetworkError(
+                "Could not verify authentication (network error)".to_string(),
+            )),
+            true,
+        );
+        assert!(
+            result.is_ok(),
+            "silent NetworkError should be converted to Ok(())"
+        );
+    }
+
+    #[test]
     fn test_check_auth_with_network_fallback_propagates_other_errors() {
-        let result =
-            check_auth_with_network_fallback(Err(GgError::Other("Not authenticated".to_string())));
+        let result = check_auth_with_network_fallback(
+            Err(GgError::Other("Not authenticated".to_string())),
+            false,
+        );
         assert!(result.is_err(), "Non-network errors should propagate");
     }
 
     #[test]
     fn test_check_auth_with_network_fallback_passes_through_ok() {
-        let result = check_auth_with_network_fallback(Ok(()));
+        let result = check_auth_with_network_fallback(Ok(()), false);
         assert!(result.is_ok());
     }
 

--- a/docs/src/commands/land.md
+++ b/docs/src/commands/land.md
@@ -17,6 +17,7 @@ gg land [OPTIONS]
 - `--no-clean`: Disable auto-clean for this run
 - `--admin`: *(GitHub only)* Use admin privileges to bypass branch protection requirements (see [Admin Override](#admin-override) below)
 - `--json`: Emit machine-readable JSON output (no human logs)
+- `--jsonl`: Emit flushed NDJSON events as landing and polling progress; conflicts with `--json`
 
 ## Examples
 
@@ -35,6 +36,9 @@ gg land --all --auto-merge
 
 # JSON output for automation
 gg land --all --json
+
+# Stream landing progress and wait heartbeats
+gg land --all --wait --jsonl
 
 # Bypass approval requirements (GitHub admin)
 gg land --admin
@@ -123,4 +127,38 @@ Example JSON response:
     "error": null
   }
 }
+```
+
+## Streaming NDJSON (`--jsonl`)
+
+`gg land --jsonl` emits one compact JSON object per line and flushes each line.
+Every event has `version`, `command`, `status`, and `event`. Human output is
+suppressed. Use this mode to monitor a long-running `--wait` invocation.
+
+Event kinds:
+
+| Event | Fields | Emitted when |
+|---|---|---|
+| `start` | `stack`, `base`, `total_entries` | A non-empty landing run begins |
+| `wait` | `position`, `pr_number`, `phase`, `poll`, `elapsed_seconds`, `ci_status`, `approved`, `merge_train_status`, `merge_train_position`, `pipeline_running`, `error` | Each readiness or merge-train provider poll completes |
+| `entry` | Same fields as an item in `landed` | An entry reaches an outcome |
+| `summary` | Same fields as the `land` object from `--json` | Landing finishes, including partial failures |
+| `error` | `message` | A fatal error prevents a summary |
+
+`phase` is `readiness` while checking CI and approval, or `merge_train` after
+queueing an MR. Fields that the current phase did not check are `null`.
+Transient provider errors appear in a `wait` event with `status: "warning"` and
+the command keeps polling. Unchanged states still emit a heartbeat on the
+existing 10-second polling cadence.
+
+The final event is `summary` when landing reaches its normal result path.
+Consumers should inspect its `error` field because partial landing failures keep
+the existing `--json` exit behavior. Fatal setup failures emit `error` and exit
+nonzero.
+
+```ndjson
+{"version":1,"command":"land","status":"ok","event":"start","stack":"my-stack","base":"main","total_entries":1}
+{"version":1,"command":"land","status":"ok","event":"wait","position":1,"pr_number":42,"phase":"readiness","poll":1,"elapsed_seconds":0,"ci_status":"running","approved":true,"merge_train_status":null,"merge_train_position":null,"pipeline_running":null,"error":null}
+{"version":1,"command":"land","status":"ok","event":"entry","position":1,"sha":"abc1234","title":"feat: add parser","gg_id":"c-abc1234","pr_number":42,"action":"merged","error":null}
+{"version":1,"command":"land","status":"ok","event":"summary","stack":"my-stack","base":"main","landed":[{"position":1,"sha":"abc1234","title":"feat: add parser","gg_id":"c-abc1234","pr_number":42,"action":"merged","error":null}],"remaining":0,"cleaned":false,"warnings":[],"error":null}
 ```

--- a/skills/gg/references/landing-and-cleanup.md
+++ b/skills/gg/references/landing-and-cleanup.md
@@ -80,8 +80,11 @@ stop before invoking global cleanup.
    confirmation immediately before execution. If cleanup may follow, record the
    exact stack name, local and remote branch names, configured worktree path, and
    PR/MR mappings before landing.
-2. Run the user-approved `gg land` scope with `--json` and explicitly without
-   cleanup. For multi-entry stacks, do not use a non-wait `gg land -a` snapshot
+2. Run the user-approved `gg land` scope explicitly without cleanup. Use
+   `--jsonl` for a monitored run and consume its final `summary`; use `--json`
+   when only the final result is needed. Treat each `wait` event as a heartbeat,
+   and inspect its typed CI, approval, and merge-train fields. For multi-entry
+   stacks, do not use a non-wait `gg land -a` snapshot
    to merge every entry after downstream PR retargeting and branch rebases.
    In squash-merge stacks with downstream entries, land the current entry with a
    one-entry multi-land command such as


### PR DESCRIPTION
## Summary

Add machine-readable streaming output to `gg land` so automation can observe long-running landing operations.

- Emit `start`, ten-second `wait` heartbeat, `entry`, and final `summary` JSONL events.
- Preserve structured fatal errors and existing `--json` behavior.
- Document the JSONL contract and add coverage for event shape, polling, and immediate flush behavior.

## Verification

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `mdbook build docs`